### PR TITLE
fix(skills): quote argument-hint YAML values for Copilot CLI 1.0.65

### DIFF
--- a/.claude/skills/amp-copilot/SKILL.md
+++ b/.claude/skills/amp-copilot/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: amp-copilot
 description: Amplifier design copilot — topology selection, sizing via gm/Id lookup tables, PVT corner validation, and process-portable design. Use when designing amplifiers (OTA, opamp, comparator), selecting topology from specs, sizing transistors, or characterizing a new process node. Also triggers on keywords like amplifier, OTA, opamp, gain-bandwidth, CMRR, PSRR, slew rate.
-argument-hint: [circuit type and specs, e.g. "two-stage OTA GBW=50MHz CL=10pF"]
+argument-hint: '[circuit type and specs, e.g. "two-stage OTA GBW=50MHz CL=10pF"]'
 allowed-tools: Bash(virtuoso *) Read Write
 ---
 

--- a/.claude/skills/cell-explore/SKILL.md
+++ b/.claude/skills/cell-explore/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cell-explore
 description: Explore Virtuoso cellviews - list libraries, cells, instances, nets, layers, and hierarchy. Use when browsing a design, understanding circuit topology, or inspecting layout/schematic contents.
-argument-hint: [library or cell path, e.g. "myLib" or "myLib/myCell"]
+argument-hint: '[library or cell path, e.g. "myLib" or "myLib/myCell"]'
 allowed-tools: Bash(virtuoso *)
 ---
 

--- a/.claude/skills/circuit-optimizer/SKILL.md
+++ b/.claude/skills/circuit-optimizer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: circuit-optimizer
 description: Bayesian optimization for circuit auto-tuning — closed-loop optimizer where Claude acts as the BO engine. Sweeps gm/Id + L parameters, runs Spectre, scores against specs, and iterates. Supports progressive PVT corners. Use when optimizing circuit sizing, auto-tuning amplifier parameters, or running design-space exploration. Triggers on "optimize", "auto-tune", "bayesian", "find best sizing".
-argument-hint: [optimization goal, e.g. "maximize GBW subject to PM>60deg"]
+argument-hint: '[optimization goal, e.g. "maximize GBW subject to PM>60deg"]'
 allowed-tools: Bash(virtuoso *) Read Write
 ---
 

--- a/.claude/skills/gm-over-id/SKILL.md
+++ b/.claude/skills/gm-over-id/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gm-over-id
 description: gm/Id methodology for analog IC design — transistor sizing via lookup table approach. Use when designing amplifiers, current mirrors, OTAs, or any analog circuit where you need to determine W/L from specs (GBW, gain, noise). Also use when the user mentions gm/id, transistor sizing, Vov, current density, or design space exploration.
-argument-hint: [transistor and target, e.g. "NMOS gm/Id=15 Ids=100uA"]
+argument-hint: '[transistor and target, e.g. "NMOS gm/Id=15 Ids=100uA"]'
 allowed-tools: Bash(virtuoso *) Read Write
 ---
 

--- a/.claude/skills/history-evolve/SKILL.md
+++ b/.claude/skills/history-evolve/SKILL.md
@@ -10,7 +10,7 @@ description: |
 author: Claude Code
 version: 1.0.0
 date: 2026-05-02
-argument-hint: [optional: session ID or date range, e.g. "meowu-meow-38371" or "last 7 days"]
+argument-hint: '[optional: session ID or date range, e.g. "meowu-meow-38371" or "last 7 days"]'
 allowed-tools: Bash(cat *) Bash(ls *) Bash(jq *) Bash(grep *) Bash(find *) Read Write Edit
 ---
 

--- a/.claude/skills/maestro/SKILL.md
+++ b/.claude/skills/maestro/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: maestro
 description: Maestro (ADE Assembler) session management and simulation. Use when: running simulations via Maestro, configuring tests/analyses/outputs, updating design variables, reading results.
-argument-hint: [action, e.g. "run AC on fnxSession0" or "list sessions"]
+argument-hint: '[action, e.g. "run AC on fnxSession0" or "list sessions"]'
 allowed-tools: Bash(vcli *)
 ---
 

--- a/.claude/skills/maestro/SKILL.md
+++ b/.claude/skills/maestro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maestro
-description: Maestro (ADE Assembler) session management and simulation. Use when: running simulations via Maestro, configuring tests/analyses/outputs, updating design variables, reading results.
+description: "Maestro (ADE Assembler) session management and simulation. Use when: running simulations via Maestro, configuring tests/analyses/outputs, updating design variables, reading results."
 argument-hint: '[action, e.g. "run AC on fnxSession0" or "list sessions"]'
 allowed-tools: Bash(vcli *)
 ---

--- a/.claude/skills/ocean-netlist-regen/SKILL.md
+++ b/.claude/skills/ocean-netlist-regen/SKILL.md
@@ -13,7 +13,7 @@ description: |
 author: Claude Code
 version: 2.3.0
 date: 2026-04-20
-argument-hint: [symptom, e.g. "run() returns nil" or "OSSHNL-109"]
+argument-hint: '[symptom, e.g. "run() returns nil" or "OSSHNL-109"]'
 allowed-tools: Bash(virtuoso *) Bash(vcli *) Bash(spectre *) Read Write
 ---
 

--- a/.claude/skills/porting-skill/SKILL.md
+++ b/.claude/skills/porting-skill/SKILL.md
@@ -11,7 +11,7 @@ description: |
   voltage", "our .sdb corners don't match new PDK", or any mention of PDK/process
   transition. Invoke this skill proactively when you detect PDK-specific paths or
   corner names in netlists that don't match the target environment.
-argument-hint: [source → target, e.g. "SMIC 28nm to TSMC 40nm" or "IC23 to IC25"]
+argument-hint: '[source → target, e.g. "SMIC 28nm to TSMC 40nm" or "IC23 to IC25"]'
 allowed-tools: Bash(vcli *) Bash(virtuoso *) Bash(spectre *) Read Write Edit Grep
 ---
 

--- a/.claude/skills/schematic-gen/SKILL.md
+++ b/.claude/skills/schematic-gen/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Use when: (1) user wants to draw/create a schematic in Virtuoso, (2) user says
   "draw the OTA" or "create the schematic", (3) after sizing is complete and ready
   to build the circuit, (4) user provides a topology and wants it instantiated.
-argument-hint: [topology, e.g. "5T OTA" or "cascode current mirror"]
+argument-hint: '[topology, e.g. "5T OTA" or "cascode current mirror"]'
 allowed-tools: Bash(vcli *) Read Write Edit
 ---
 

--- a/.claude/skills/sim-measure/SKILL.md
+++ b/.claude/skills/sim-measure/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sim-measure
 description: Extract waveform measurements from Virtuoso simulation results. Use when measuring voltage, current, gm, gm/Id, bandwidth, settling time, or any simulation metric.
-argument-hint: [measurement target, e.g. "GBW and phase margin from AC"]
+argument-hint: '[measurement target, e.g. "GBW and phase margin from AC"]'
 allowed-tools: Bash(virtuoso *)
 ---
 

--- a/.claude/skills/sim-plot/SKILL.md
+++ b/.claude/skills/sim-plot/SKILL.md
@@ -11,7 +11,7 @@ description: |
 author: Claude Code
 version: 1.0.0
 date: 2026-04-06
-argument-hint: [chart type, e.g. "AC Bode plot" or "sweep line chart"]
+argument-hint: '[chart type, e.g. "AC Bode plot" or "sweep line chart"]'
 allowed-tools: Bash(python *) Read Write
 ---
 

--- a/.claude/skills/sim-run/SKILL.md
+++ b/.claude/skills/sim-run/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sim-run
 description: Run circuit simulation (DC, tran, AC) on Virtuoso. Use when executing Spectre simulation, running analysis, or checking simulation results.
-argument-hint: [analysis, e.g. "tran 10us" or "ac 1Hz-1GHz" or "dc"]
+argument-hint: '[analysis, e.g. "tran 10us" or "ac 1Hz-1GHz" or "dc"]'
 allowed-tools: Bash(virtuoso *)
 ---
 

--- a/.claude/skills/sim-setup/SKILL.md
+++ b/.claude/skills/sim-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: sim-setup
 description: Set up Virtuoso simulation with Ocean SKILL. Use when configuring simulator, design target, model files, or design variables before running simulation.
-argument-hint: [design target, e.g. "myLib/myOTA schematic for tran"]
+argument-hint: '[design target, e.g. "myLib/myOTA schematic for tran"]'
 allowed-tools: Bash(virtuoso *)
 ---
 

--- a/.claude/skills/sim-sweep/SKILL.md
+++ b/.claude/skills/sim-sweep/SKILL.md
@@ -2,7 +2,7 @@
 name: sim-sweep
 description: Run parameter sweeps and PVT corner simulations on Virtuoso. Use when sweeping design variables, running corner analysis, or characterizing circuits across operating conditions.
 disable-model-invocation: true
-argument-hint: [parameter and range, e.g. "W from 1u to 10u, measure GBW"]
+argument-hint: '[parameter and range, e.g. "W from 1u to 10u, measure GBW"]'
 allowed-tools: Bash(virtuoso *) Read Write
 ---
 

--- a/.claude/skills/skill-exec/SKILL.md
+++ b/.claude/skills/skill-exec/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-exec
 description: Execute SKILL code on Virtuoso. Use when running SKILL expressions, querying cellview data, listing libraries/cells, or interacting with Virtuoso programmatically.
-argument-hint: [SKILL expression to run]
+argument-hint: "[SKILL expression to run]"
 allowed-tools: Bash(vcli *) Bash(virtuoso *)
 ---
 

--- a/.claude/skills/skill-review/SKILL.md
+++ b/.claude/skills/skill-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: skill-review
 description: Audit a Claude Code skill file against the official skills specification. Use when the user asks to review, audit, or check a skill for spec compliance, or when a skill file may be too long, have wrong frontmatter, or needs structural improvement.
-argument-hint: [skill name or path, e.g. "veriloga" or ".claude/skills/veriloga/SKILL.md"]
+argument-hint: '[skill name or path, e.g. "veriloga" or ".claude/skills/veriloga/SKILL.md"]'
 allowed-tools: Read Bash(wc *) Bash(find *) Bash(ls *)
 ---
 

--- a/.claude/skills/skill-shell-gotchas/SKILL.md
+++ b/.claude/skills/skill-shell-gotchas/SKILL.md
@@ -9,7 +9,7 @@ description: |
 author: Claude Code
 version: 1.0.0
 date: 2026-04-06
-argument-hint: [symptom, e.g. "sh() returns t" or "ipcBeginProcess 127"]
+argument-hint: '[symptom, e.g. "sh() returns t" or "ipcBeginProcess 127"]'
 allowed-tools: Read
 ---
 

--- a/.claude/skills/spec-driven-circuit-design/SKILL.md
+++ b/.claude/skills/spec-driven-circuit-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec-driven-circuit-design
 description: Spec-driven analog circuit design — decompose system specs into block/transistor-level requirements, validate feasibility via simulation, and iterate. Use when defining amplifier specs, checking if specs are achievable, decomposing system requirements to circuit blocks, or when the user says "design spec", "spec review", "is this spec feasible", or "spec breakdown".
-argument-hint: [circuit type and specs, e.g. "LDO 3.3V→1.2V 100mA"]
+argument-hint: '[circuit type and specs, e.g. "LDO 3.3V→1.2V 100mA"]'
 allowed-tools: Bash(virtuoso *) Read Write Edit
 ---
 

--- a/.claude/skills/spectre-netlist-gotchas/SKILL.md
+++ b/.claude/skills/spectre-netlist-gotchas/SKILL.md
@@ -14,7 +14,7 @@ description: |
 author: Claude Code
 version: 1.0.0
 date: 2026-04-07
-argument-hint: [error or symptom, e.g. "SFE-30" or "noise in megavolts"]
+argument-hint: '[error or symptom, e.g. "SFE-30" or "noise in megavolts"]'
 allowed-tools: Bash(spectre *) Read Write
 ---
 

--- a/.claude/skills/spectre-netlist-template/SKILL.md
+++ b/.claude/skills/spectre-netlist-template/SKILL.md
@@ -13,7 +13,7 @@ version: 1.0.0
 date: 2026-04-19
 source: /opt/cadence/IC231/doc/spectremod/Chap1.html (vsource/isource/port syntax)
         /opt/cadence/IC231/doc/spectreref/chap3.html (analysis statements)
-argument-hint: [circuit type, e.g. "OTA" or "LDO" or "bandgap" or "VCO"]
+argument-hint: '[circuit type, e.g. "OTA" or "LDO" or "bandgap" or "VCO"]'
 allowed-tools: Bash(python *) Bash(spectre *) Read Write
 ---
 

--- a/.claude/skills/tunnel-connect/SKILL.md
+++ b/.claude/skills/tunnel-connect/SKILL.md
@@ -2,7 +2,7 @@
 name: tunnel-connect
 description: Connect to Virtuoso via SSH tunnel or local bridge. Use when setting up Virtuoso connection, starting the bridge, or troubleshooting connectivity issues.
 disable-model-invocation: true
-argument-hint: [host or issue, e.g. "server1.company.com"]
+argument-hint: '[host or issue, e.g. "server1.company.com"]'
 allowed-tools: Bash(virtuoso *) Read
 ---
 

--- a/.claude/skills/veriloga/SKILL.md
+++ b/.claude/skills/veriloga/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: veriloga
 description: Design, write, and debug Verilog-A behavioral models for Cadence Virtuoso/Spectre simulation. Use when creating Verilog-A modules (voltage sources, behavioral models, testbench stimuli, ideal components), debugging Spectre simulation errors with Verilog-A, or when the user mentions veriloga, behavioral model, or ideal component.
-argument-hint: [module type to build or error to debug, e.g. "LDO model", "comparator", "convergence error"]
+argument-hint: '[module type to build or error to debug, e.g. "LDO model", "comparator", "convergence error"]'
 allowed-tools: Bash(virtuoso *) Bash(vcli *) Bash(spectre *) Read Write Edit
 ---
 


### PR DESCRIPTION
## Summary

Copilot CLI 1.0.65 enforces stricter YAML frontmatter parsing for skill files: the `argument-hint` field must be a **string**. Values like

```yaml
argument-hint: [circuit type, e.g. "OTA" or "LDO"]
```

are parsed as YAML **flow sequences** (arrays), not strings, and the loader rejects the skill.

This PR wraps each `argument-hint:` value in quotes so it always parses as a single string. Behavior in Claude Code / older Copilot CLI is unchanged — the displayed hint text is identical.

## YAML rule

- `argument-hint: [X]` → `argument-hint: "[X]"`
- If `X` contains double quotes, use single-quoted YAML: `argument-hint: '[X with "quotes"]'`

Most skills here fall into the second category (their examples use `"..."`), so single-quoted YAML strings are used across the board for consistency.

## Files fixed (22)

All under `.claude/skills/*/SKILL.md`:

amp-copilot, cell-explore, circuit-optimizer, gm-over-id, history-evolve, maestro, ocean-netlist-regen, porting-skill, schematic-gen, sim-measure, sim-plot, sim-run, sim-setup, sim-sweep, skill-exec, skill-review, skill-shell-gotchas, spec-driven-circuit-design, spectre-netlist-gotchas, spectre-netlist-template, tunnel-connect, veriloga.

The two already-quoted skills (`digital-import`, `maestro-read-results`) were left untouched.

## Related

Same underlying YAML-frontmatter pitfall as [anthropics/claude-code#22161](https://github.com/anthropics/claude-code/issues/22161) — latent in Claude Code, surfaced by Copilot CLI 1.0.65's stricter loader.

## Test plan

- [x] Grep confirms zero remaining unquoted `argument-hint: [` lines
- [x] `yaml.safe_load` on each `argument-hint:` line parses to `str` (validated across all 24 skills)
- [x] Load a fixed skill (e.g. `veriloga`) in Copilot CLI 1.0.65 — hint renders, skill loads without error
- [x] Load same skill in Claude Code — no regression in display or invocation