### PR TITLE
feat(tunnel): 新增 attach/detach + 端口探测改用 bash /dev/tcp

### DIFF
--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -1,8 +1,9 @@
 use crate::client::bridge::VirtuosoClient;
 use crate::config::Config;
 use crate::error::{Result, VirtuosoError};
-use crate::models::{SessionInfo, TunnelState};
+use crate::models::{SessionInfo, TunnelState, TUNNEL_MODE_ATTACHED, TUNNEL_MODE_DEPLOYED};
 use crate::output::OutputFormat;
+use crate::transport::session_discovery::pick_live_session;
 use crate::transport::tunnel::SSHClient;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -43,6 +44,129 @@ pub fn start(timeout: Option<u64>, dry_run: bool) -> Result<Value> {
     }))
 }
 
+/// Connect to a Virtuoso daemon that already exists on the remote host.
+///
+/// This is the non-destructive counterpart to [`start`]: instead of deploying
+/// a fresh daemon + bridge.il via `tunnel start`, `tunnel attach` discovers
+/// an existing daemon (written by `bridge.il` to
+/// `~/.cache/virtuoso_bridge/sessions/*.json`), verifies its TCP listener,
+/// and opens a single-port SSH tunnel to it.
+///
+/// The remote daemon is **not** touched — it belongs to Virtuoso and must
+/// outlive this command. To drop the local side of the connection, run
+/// `tunnel detach` (which kills the tunnel SSH process and clears state).
+///
+/// Returns `Err(NotFound)` if no live daemon can be discovered.
+pub fn attach(dry_run: bool) -> Result<Value> {
+    let cfg = Config::from_env()?;
+
+    // Refuse if a tunnel of any mode is already up. The user can pick the
+    // matching verb to clean up (`detach` for attached, `stop` for deployed).
+    if let Some(existing) = TunnelState::load()? {
+        let mode = existing.mode.as_deref().unwrap_or(TUNNEL_MODE_DEPLOYED);
+        let verb = if mode == TUNNEL_MODE_ATTACHED {
+            "detach"
+        } else {
+            "stop"
+        };
+        return Err(VirtuosoError::Execution(format!(
+            "tunnel already exists on port {} (mode={}); run `vcli tunnel {verb}` first",
+            existing.port, mode
+        )));
+    }
+
+    // SSHClient here is used purely as a transport wrapper — we don't call
+    // warm() (which would deploy a fresh daemon). The runner is configured
+    // by from_env() but no remote command runs until we explicitly call one.
+    let mut client = SSHClient::from_env(cfg.keep_remote_files)?;
+    let transport = client.transport();
+
+    let sessions = SessionInfo::list_remote(transport.as_ref())?;
+    if sessions.is_empty() {
+        return Err(VirtuosoError::NotFound(
+            "no Virtuoso sessions found on remote; run `vcli tunnel start` to deploy a fresh daemon".into()
+        ));
+    }
+
+    let host_hint = cfg.remote_host.as_deref();
+    let live = pick_live_session(sessions, transport.as_ref(), host_hint)?.ok_or_else(|| {
+        VirtuosoError::NotFound(
+            "found session(s) on remote but no live daemons (port not listening); \
+                 check that Virtuoso is running and the daemon process is alive"
+                .into(),
+        )
+    })?;
+
+    if dry_run {
+        return Ok(json!({
+            "action": "attach",
+            "resource": "tunnel",
+            "discovered": {
+                "session_id": live.id,
+                "remote_port": live.port,
+                "remote_host": live.host,
+                "created": live.created,
+                "user": live.user,
+            },
+            "dry_run": true,
+        }));
+    }
+
+    // Use the same port locally as the remote daemon listens on. Same-port
+    // forwarding keeps scripts that bind to the canonical daemon port
+    // working without reconfiguration. `open_tunnel` runs `ssh -L
+    // 127.0.0.1:<port>:127.0.0.1:<port>`, so this forwards to the
+    // discovered listener exactly.
+    let local_port = live.port;
+    client.open_tunnel(local_port)?;
+
+    let now_ms = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+
+    let state = TunnelState {
+        version: crate::models::CURRENT_STATE_VERSION,
+        port: local_port,
+        pid: client.tunnel_pid().unwrap_or(0),
+        remote_host: live.host.clone(),
+        setup_path: None,
+        profile: cfg.profile.clone(),
+        backend: Some("openssh".to_string()),
+        daemon_nonce: None,
+        executable_path: None,
+        start_identity: None,
+        ipc_endpoint: None,
+        token_path: None,
+        local_forward: Some(format!("L*:{local_port}")),
+        start_time_unix_ms: Some(now_ms),
+        health: None,
+        config_digest: None,
+        mode: Some(TUNNEL_MODE_ATTACHED.into()),
+        attached_remote_port: Some(live.port),
+        attached_session_id: Some(live.id.clone()),
+    };
+    state
+        .save()
+        .map_err(|e| VirtuosoError::Ssh(format!("save tunnel state: {e}")))?;
+
+    // Mirror the remote session metadata into the local cache so subsequent
+    // `vcli session show` works without another SSH round-trip.
+    let transport = client.transport();
+    let sessions_synced = SessionInfo::sync_from_remote(transport.as_ref()).unwrap_or(0);
+
+    Ok(json!({
+        "status": "attached",
+        "mode": TUNNEL_MODE_ATTACHED,
+        "session_id": live.id,
+        "remote_port": live.port,
+        "local_port": local_port,
+        "remote_host": live.host,
+        "pid": client.tunnel_pid().unwrap_or(0),
+        "sessions_synced": sessions_synced,
+    }))
+}
+
 pub fn stop(force: bool, dry_run: bool) -> Result<Value> {
     let cfg = Config::from_env()?;
 
@@ -52,6 +176,8 @@ pub fn stop(force: bool, dry_run: bool) -> Result<Value> {
         None => return Err(VirtuosoError::NotFound("no running tunnel found".into())),
     };
 
+    let mode = state.mode.as_deref().unwrap_or(TUNNEL_MODE_DEPLOYED);
+
     if dry_run {
         return Ok(json!({
             "action": "stop",
@@ -60,16 +186,19 @@ pub fn stop(force: bool, dry_run: bool) -> Result<Value> {
                 "port": state.port,
                 "pid": state.pid,
                 "remote_host": state.remote_host,
+                "mode": mode,
             },
-            "will_cleanup_remote": !cfg.keep_remote_files,
+            // Attached daemons belong to Virtuoso — stop must not rm -rf them.
+            "will_cleanup_remote": !cfg.keep_remote_files && mode == TUNNEL_MODE_DEPLOYED,
             "dry_run": true,
         }));
     }
 
-    // Clean up remote files BEFORE killing tunnel.
-    // The cleanup path is profile-scoped (see transport::tunnel::setup_dir_for_profile)
-    // so stopping profile A's tunnel doesn't wipe profile B's setup.
-    if !cfg.keep_remote_files {
+    // Remote cleanup is gated on mode:
+    //   - deployed: we own the setup dir under /tmp/, safe to rm -rf
+    //   - attached: Virtuoso owns the daemon, the setup dir may be in use;
+    //     use `vcli tunnel detach` instead, which only touches local state
+    if !cfg.keep_remote_files && mode == TUNNEL_MODE_DEPLOYED {
         match SSHClient::from_env(cfg.keep_remote_files) {
             Ok(client) => {
                 let setup_dir =
@@ -80,41 +209,59 @@ pub fn stop(force: bool, dry_run: bool) -> Result<Value> {
             }
             Err(e) => tracing::warn!("could not connect for cleanup: {e}"),
         }
+    } else if mode == TUNNEL_MODE_ATTACHED {
+        tracing::info!(
+            "attached mode: skipping remote cleanup (daemon belongs to Virtuoso; \
+             use `vcli tunnel detach` if you only want to disconnect)"
+        );
     }
 
-    #[cfg(unix)]
-    {
-        let cmdline_path = format!("/proc/{}/cmdline", state.pid);
-        let is_ssh = std::fs::read_to_string(&cmdline_path)
-            .map(|c| c.contains("ssh"))
-            .unwrap_or(false);
-
-        if is_ssh || force {
-            let result = unsafe { libc::kill(state.pid as i32, libc::SIGTERM) };
-            if result != 0 && !force {
-                tracing::warn!("could not kill process {}", state.pid);
-            }
-        } else {
-            tracing::warn!(
-                "PID {} is not an SSH process, skipping kill (use --force to override)",
-                state.pid
-            );
-        }
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = std::process::Command::new("taskkill")
-            .args(["/PID", &state.pid.to_string(), "/F"])
-            .output();
-    }
+    kill_tunnel_pid(state.pid, force);
 
     TunnelState::clear()?;
 
     Ok(json!({
         "status": "stopped",
+        "mode": mode,
         "port": state.port,
         "pid": state.pid,
+    }))
+}
+
+/// Disconnect a tunnel that was opened by [`attach`].
+///
+/// Unlike [`stop`], `detach` never touches the remote daemon: it kills the
+/// local SSH tunnel process and clears state. The remote Virtuoso session
+/// keeps running and its daemon keeps listening; users reconnect with
+/// `vcli tunnel attach` (or the daemon is shut down independently by Virtuoso).
+///
+/// Returns `Err(NotFound)` when there is no tunnel, and
+/// `Err(Execution)` when the recorded tunnel is in `deployed` mode (use
+/// `tunnel stop` instead, since deployed tunnels own a setup dir that
+/// needs cleanup).
+pub fn detach() -> Result<Value> {
+    let state = TunnelState::load()?
+        .ok_or_else(|| VirtuosoError::NotFound("no attached tunnel found".into()))?;
+
+    let mode = state.mode.as_deref().unwrap_or(TUNNEL_MODE_DEPLOYED);
+    if mode != TUNNEL_MODE_ATTACHED {
+        return Err(VirtuosoError::Execution(format!(
+            "this is a {mode} tunnel, not attached; use `vcli tunnel stop` instead"
+        )));
+    }
+
+    kill_tunnel_pid(state.pid, false);
+
+    TunnelState::clear()?;
+
+    Ok(json!({
+        "status": "detached",
+        "mode": TUNNEL_MODE_ATTACHED,
+        "port": state.port,
+        "pid": state.pid,
+        "session_id": state.attached_session_id,
+        "remote_port": state.attached_remote_port,
+        "remote_host": state.remote_host,
     }))
 }
 
@@ -495,6 +642,30 @@ impl HostnameCheck {
             "mismatch": self.mismatch,
         })
     }
+}
+
+#[cfg(unix)]
+fn kill_tunnel_pid(pid: u32, force: bool) {
+    let cmdline_path = format!("/proc/{pid}/cmdline");
+    let is_ssh = std::fs::read_to_string(&cmdline_path)
+        .map(|c| c.contains("ssh"))
+        .unwrap_or(false);
+
+    if is_ssh || force {
+        let result = unsafe { libc::kill(pid as i32, libc::SIGTERM) };
+        if result != 0 && !force {
+            tracing::warn!("could not kill process {pid}");
+        }
+    } else {
+        tracing::warn!("PID {pid} is not an SSH process, skipping kill (use --force to override)");
+    }
+}
+
+#[cfg(not(unix))]
+fn kill_tunnel_pid(pid: u32, _force: bool) {
+    let _ = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/F"])
+        .output();
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -381,6 +381,34 @@ enum TunnelCmd {
 
     /// Run full connection diagnostics
     Diagnose,
+
+    /// Connect to an existing Virtuoso daemon (does not deploy or clean up)
+    #[command(long_about = "Discover an already-running Virtuoso daemon via \
+            `~/.cache/virtuoso_bridge/sessions/*.json` and open an SSH tunnel to it.\n\n\
+            Unlike `tunnel start`, this does **not** deploy a fresh daemon or \
+            bridge.il — the remote daemon is owned by Virtuoso and is left \
+            running. Use `tunnel detach` to drop the local side of the connection.\n\n\
+            Examples:\n  \
+            virtuoso tunnel attach\n  \
+            virtuoso tunnel attach --dry-run --format json")]
+    Attach {
+        /// Preview without opening the tunnel or writing state
+        #[arg(long)]
+        dry_run: bool,
+    },
+
+    /// Disconnect a tunnel opened by `tunnel attach` (does not stop the remote daemon)
+    #[command(
+        long_about = "Kill the local SSH tunnel opened by `tunnel attach` and clear state. \
+            The remote Virtuoso daemon is **not** stopped — it belongs to Virtuoso \
+            and keeps listening. Use `tunnel attach` again to reconnect.\n\n\
+            If the recorded tunnel was opened by `tunnel start` (deployed mode), \
+            this command refuses: use `tunnel stop` instead, which also cleans up \
+            the remote setup directory.\n\n\
+            Examples:\n  \
+            virtuoso tunnel detach"
+    )]
+    Detach,
 }
 
 #[derive(Subcommand)]
@@ -1523,6 +1551,8 @@ fn dispatch_tunnel(cmd: TunnelCmd, format: OutputFormat) -> error::Result<serde_
         TunnelCmd::Restart { timeout } => commands::tunnel::restart(Some(timeout)),
         TunnelCmd::Status => commands::tunnel::status(format),
         TunnelCmd::Diagnose => commands::tunnel::diagnose(),
+        TunnelCmd::Attach { dry_run } => commands::tunnel::attach(dry_run),
+        TunnelCmd::Detach => commands::tunnel::detach(),
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -402,7 +402,32 @@ pub struct TunnelState {
     /// Digest of the resolved config, for `tunnel status` drift detection.
     #[serde(default)]
     pub config_digest: Option<String>,
+
+    // --- v2.1 fields: tunnel lifecycle mode ---
+    /// `"deployed"` (a fresh daemon was started via `tunnel start`) or
+    /// `"attached"` (the tunnel piggybacks on a daemon launched by Virtuoso).
+    /// `None` on legacy v2 files — treated as `"deployed"` for backwards
+    /// compatibility. Plain string instead of an enum because `==` on a
+    /// literal is simpler than a serde-tagged variant and the surface is
+    /// narrow enough that a typo would be caught by a test.
+    #[serde(default)]
+    pub mode: Option<String>,
+    /// Remote daemon port this tunnel forwards to. Populated only when
+    /// `mode == "attached"`; `None` for deployed tunnels (the port there is
+    /// the daemon's own listening port, identical to `port`).
+    #[serde(default)]
+    pub attached_remote_port: Option<u16>,
+    /// Bridge session id this attach resolved to. Mirrors
+    /// `SessionInfo::id` for the daemon we discovered via
+    /// `~/.cache/virtuoso_bridge/sessions/*.json`.
+    #[serde(default)]
+    pub attached_session_id: Option<String>,
 }
+
+/// Mode value written to [`TunnelState::mode`] by `tunnel start`.
+pub const TUNNEL_MODE_DEPLOYED: &str = "deployed";
+/// Mode value written to [`TunnelState::mode`] by `tunnel attach`.
+pub const TUNNEL_MODE_ATTACHED: &str = "attached";
 
 /// Current `TunnelState` schema version written by this build.
 pub const CURRENT_STATE_VERSION: u32 = 2;
@@ -536,6 +561,9 @@ mod tests {
             start_time_unix_ms: Some(1_700_000_000_000),
             health: Some("ok".into()),
             config_digest: Some("deadbeef".into()),
+            mode: None,
+            attached_remote_port: None,
+            attached_session_id: None,
         };
         let json = serde_json::to_string(&s).unwrap();
         let back: TunnelState = serde_json::from_str(&json).unwrap();
@@ -576,6 +604,9 @@ mod tests {
             start_time_unix_ms: None,
             health: None,
             config_digest: None,
+            mode: None,
+            attached_remote_port: None,
+            attached_session_id: None,
         };
         let json = serde_json::to_string(&s).unwrap();
         // An old reader that only knows v1 fields must still accept it.

--- a/src/transport/daemon_lifecycle.rs
+++ b/src/transport/daemon_lifecycle.rs
@@ -136,6 +136,9 @@ mod tests {
             start_time_unix_ms: None,
             health: None,
             config_digest: None,
+            mode: None,
+            attached_remote_port: None,
+            attached_session_id: None,
         }
     }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -6,6 +6,7 @@ pub mod host_keys;
 pub mod identity;
 pub mod ipc;
 pub mod openssh;
+pub mod session_discovery;
 pub mod ssh;
 #[cfg(test)]
 pub mod testutil;

--- a/src/transport/session_discovery.rs
+++ b/src/transport/session_discovery.rs
@@ -22,24 +22,29 @@ use crate::error::Result;
 use crate::models::SessionInfo;
 use crate::transport::contract::{CommandRequest, RemoteTransport};
 
-/// `ss` invocation that returns listening sockets on a single port.
-/// Empty output ⇒ the port is not listening. `-H` suppresses the header,
-/// `-l` filters to listening sockets, `-t` to TCP. The `sport = :N` filter
-/// is portable across iproute2 versions shipped with RHEL 8/9, Debian 11+,
-/// Ubuntu 20.04+.
-const SS_PROBE_TEMPLATE: &str = "ss -tlnH 'sport = :{port}' 2>/dev/null";
+/// TCP-connect probe that reports whether `127.0.0.1:{port}` accepts a
+/// connection. Empty output ⇒ the port is not listening.
+///
+/// Uses bash's `/dev/tcp/{host}/{port}` pseudo-device rather than `ss`,
+/// `netstat`, or `nc -z`. `ss` ships with iproute2 (RHEL/Alma/Debian/Ubuntu
+/// in normal installs) but is missing from minimal images like the
+/// cadence-rocky test container, and a probe that fails silently to "port
+/// dead" is the worst kind of probe — it lies to the caller. Bash's
+/// `/dev/tcp` is built into bash itself, so the script works on every
+/// Linux image that ships bash (the only realistic Virtuoso host).
+const PORT_PROBE_TEMPLATE: &str = "(exec 3<>/dev/tcp/127.0.0.1/{port}) 2>/dev/null && echo alive";
 
 /// Probe the remote host for a listening socket on `port`.
 ///
-/// Returns `Ok(true)` when `ss` reports at least one matching line. Any
-/// error invoking `ss` (binary missing, permission denied, etc.) is folded
-/// into `Ok(false)` — for the purposes of session selection, "could not
+/// Returns `Ok(true)` when the probe prints `alive`. Any error invoking
+/// the probe (binary missing, permission denied, etc.) is folded into
+/// `Ok(false)` — for the purposes of session selection, "could not
 /// verify" is the same outcome as "not listening": we move on to the next
 /// candidate. The connection-level error from the runner itself
 /// (SSH failure, host unreachable) is propagated as `Err` because that
 /// affects every candidate and is the user's real problem.
 pub fn remote_port_alive(runner: &dyn RemoteTransport, port: u16) -> Result<bool> {
-    let script = SS_PROBE_TEMPLATE.replace("{port}", &port.to_string());
+    let script = PORT_PROBE_TEMPLATE.replace("{port}", &port.to_string());
     let result = runner.run_command(&CommandRequest::untimed(&script))?;
     Ok(!result.stdout.trim().is_empty())
 }
@@ -158,13 +163,13 @@ mod tests {
                 });
             }
             self.commands.lock().unwrap().push(req.command.clone());
-            // Parse the port out of `ss -tlnH 'sport = :NNN'`. The template
-            // emits exactly one colon immediately before the port, so
-            // splitting on `:` and taking the segment right after it is
-            // unambiguous.
+            // Parse the port out of the bash /dev/tcp probe. The template
+            // emits `127.0.0.1/<port>)`, so splitting on `127.0.0.1/` and
+            // taking the segment right after it gets us `<port>)`; the
+            // trailing `)` and any non-digit characters are then stripped.
             let port = req
                 .command
-                .split(':')
+                .split("127.0.0.1/")
                 .nth(1)
                 .and_then(|s: &str| s.split(|c: char| !c.is_ascii_digit()).next())
                 .and_then(|s: &str| s.parse::<u16>().ok());
@@ -172,7 +177,7 @@ mod tests {
             Ok(CommandResult {
                 exit_status: 0,
                 stdout: if listening {
-                    "LISTEN 0  128  *:1234  *:*\n".into()
+                    "alive\n".into()
                 } else {
                     String::new()
                 },

--- a/src/transport/session_discovery.rs
+++ b/src/transport/session_discovery.rs
@@ -1,0 +1,298 @@
+//! Discover a live RAMIC Bridge daemon on a remote host.
+//!
+//! `tunnel attach` uses this to pick which Virtuoso session to plug into
+//! without deploying a fresh daemon. The two helpers here are kept separate
+//! from `SessionInfo` (which only deals with on-disk metadata) because the
+//! question "is this daemon actually serving requests?" requires a live
+//! remote probe — the session JSON file alone can be stale (daemon crashed
+//! without cleaning its registration, or was launched by an earlier Virtuoso
+//! run that has since exited).
+//!
+//! What we deliberately do **not** do here:
+//! - Verify the daemon is piped to a live Virtuoso MPS via cdsServIpc. That
+//!   would need either `/proc/<pid>/cmdline` parsing or a SKILL-side
+//!   handshake; both add complexity for diminishing returns because the
+//!   common failure mode (MPS died but daemon still listens) is caught by
+//!   `tunnel diagnose`'s SKILL eval probe, which runs after the attach.
+//! - Touch the on-disk session cache. `tunnel attach` calls
+//!   `SessionInfo::sync_from_remote` itself; mixing writes here would
+//!   duplicate that responsibility.
+
+use crate::error::Result;
+use crate::models::SessionInfo;
+use crate::transport::contract::{CommandRequest, RemoteTransport};
+
+/// `ss` invocation that returns listening sockets on a single port.
+/// Empty output ⇒ the port is not listening. `-H` suppresses the header,
+/// `-l` filters to listening sockets, `-t` to TCP. The `sport = :N` filter
+/// is portable across iproute2 versions shipped with RHEL 8/9, Debian 11+,
+/// Ubuntu 20.04+.
+const SS_PROBE_TEMPLATE: &str = "ss -tlnH 'sport = :{port}' 2>/dev/null";
+
+/// Probe the remote host for a listening socket on `port`.
+///
+/// Returns `Ok(true)` when `ss` reports at least one matching line. Any
+/// error invoking `ss` (binary missing, permission denied, etc.) is folded
+/// into `Ok(false)` — for the purposes of session selection, "could not
+/// verify" is the same outcome as "not listening": we move on to the next
+/// candidate. The connection-level error from the runner itself
+/// (SSH failure, host unreachable) is propagated as `Err` because that
+/// affects every candidate and is the user's real problem.
+pub fn remote_port_alive(runner: &dyn RemoteTransport, port: u16) -> Result<bool> {
+    let script = SS_PROBE_TEMPLATE.replace("{port}", &port.to_string());
+    let result = runner.run_command(&CommandRequest::untimed(&script))?;
+    Ok(!result.stdout.trim().is_empty())
+}
+
+/// Pick the best live session from a list of candidates.
+///
+/// Selection rules (in order):
+/// 1. If `host_hint` is `Some(h)` and any live session has
+///    `host == h`, prefer the most recent of those.
+/// 2. Otherwise take the most recent live session overall.
+///
+/// "Most recent" sorts on `created` lexicographically. The field is a
+/// SKILL `getCurrentTime()` string like `"Aug 30 12:03:58 2026"`, which
+/// happens to sort correctly by wall-clock because SKILL's `Mon DD
+/// HH:MM:SS YYYY` is month-major. If we ever switch to ISO-8601 in
+/// ramic_bridge.il this keeps working.
+///
+/// A "live" session is one whose remote port is currently listening
+/// (verified via [`remote_port_alive`]). Candidates whose probe fails are
+/// silently dropped — `tunnel attach` is allowed to ignore dead daemons.
+///
+/// Returns:
+/// - `Ok(Some(session))` when at least one live candidate exists.
+/// - `Ok(None)` when every candidate is dead or the list is empty.
+/// - `Err(_)` only when the underlying SSH probe itself fails (network,
+///   auth) — not when individual ports happen to be unbound.
+pub fn pick_live_session(
+    sessions: Vec<SessionInfo>,
+    runner: &dyn RemoteTransport,
+    host_hint: Option<&str>,
+) -> Result<Option<SessionInfo>> {
+    if sessions.is_empty() {
+        return Ok(None);
+    }
+
+    // Sort newest-first. `created` is `Mon DD HH:MM:SS YYYY`; for two
+    // sessions from the same month this is wall-clock-ordered.
+    let mut by_recency = sessions;
+    by_recency.sort_by(|a, b| b.created.cmp(&a.created));
+
+    let mut candidates: Vec<SessionInfo> = if let Some(host) = host_hint {
+        let matching: Vec<SessionInfo> = by_recency
+            .iter()
+            .filter(|s| s.host == host)
+            .cloned()
+            .collect();
+        if matching.is_empty() {
+            by_recency
+        } else {
+            matching
+        }
+    } else {
+        by_recency
+    };
+
+    // Walk in recency order; first one whose port is listening wins.
+    while let Some(s) = candidates.first().cloned() {
+        if remote_port_alive(runner, s.port)? {
+            return Ok(Some(s));
+        }
+        candidates.remove(0);
+    }
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::contract::{
+        CommandRequest, CommandResult, Deadline, DownloadDirRequest, DownloadFileRequest,
+        TransportError, UploadFileRequest, UploadTextRequest,
+    };
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    /// Stub runner that records every script it gets and replays a fixed
+    /// sequence of stdout responses. `alive_ports` is the set of ports that
+    /// should report "listening"; everything else reports empty stdout.
+    struct StubRunner {
+        /// Set of ports whose `ss -tlnH 'sport = :P'` should return a fake
+        /// listening line. Iteration order over `HashSet` is unstable, so
+        /// tests assert against the recorded commands instead of probing
+        /// port order.
+        alive_ports: std::collections::HashSet<u16>,
+        commands: Mutex<Vec<String>>,
+        /// When true, `run_command` returns an error (simulates SSH down).
+        fail: bool,
+    }
+
+    impl StubRunner {
+        fn new(alive: &[u16]) -> Self {
+            Self {
+                alive_ports: alive.iter().copied().collect(),
+                commands: Mutex::new(Vec::new()),
+                fail: false,
+            }
+        }
+    }
+
+    impl RemoteTransport for StubRunner {
+        fn test_connection(
+            &self,
+            _deadline: Deadline,
+        ) -> std::result::Result<bool, TransportError> {
+            Ok(true)
+        }
+
+        fn run_command(
+            &self,
+            req: &CommandRequest,
+        ) -> std::result::Result<CommandResult, TransportError> {
+            if self.fail {
+                return Err(TransportError::RemoteExit {
+                    status: -1,
+                    stderr: "stub-fail".into(),
+                });
+            }
+            self.commands.lock().unwrap().push(req.command.clone());
+            // Parse the port out of `ss -tlnH 'sport = :NNN'`. The template
+            // emits exactly one colon immediately before the port, so
+            // splitting on `:` and taking the segment right after it is
+            // unambiguous.
+            let port = req
+                .command
+                .split(':')
+                .nth(1)
+                .and_then(|s: &str| s.split(|c: char| !c.is_ascii_digit()).next())
+                .and_then(|s: &str| s.parse::<u16>().ok());
+            let listening = port.map(|p| self.alive_ports.contains(&p)).unwrap_or(false);
+            Ok(CommandResult {
+                exit_status: 0,
+                stdout: if listening {
+                    "LISTEN 0  128  *:1234  *:*\n".into()
+                } else {
+                    String::new()
+                },
+                stderr: String::new(),
+                success: true,
+                duration: Duration::ZERO,
+            })
+        }
+
+        fn upload_file(&self, _req: &UploadFileRequest) -> std::result::Result<(), TransportError> {
+            Ok(())
+        }
+
+        fn upload_text(&self, _req: &UploadTextRequest) -> std::result::Result<(), TransportError> {
+            Ok(())
+        }
+
+        fn download_file(
+            &self,
+            _req: &DownloadFileRequest,
+        ) -> std::result::Result<(), TransportError> {
+            Ok(())
+        }
+
+        fn download_dir(
+            &self,
+            _req: &DownloadDirRequest,
+        ) -> std::result::Result<(), TransportError> {
+            Ok(())
+        }
+    }
+
+    fn session(id: &str, port: u16, host: &str, created: &str) -> SessionInfo {
+        SessionInfo {
+            id: id.into(),
+            port,
+            pid: 0,
+            host: host.into(),
+            user: "user1".into(),
+            created: created.into(),
+            daemon_user: None,
+            daemon_version: None,
+        }
+    }
+
+    #[test]
+    fn empty_list_returns_none() {
+        let runner = StubRunner::new(&[]);
+        let result = pick_live_session(vec![], &runner, None).unwrap();
+        assert!(result.is_none());
+        // No port probes should have been issued.
+        assert!(runner.commands.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn picks_live_session_when_present() {
+        // The newer-looking candidate is dead; the older-looking one is
+        // alive. Walking in recency order must probe the dead one first
+        // (and only that one, because the loop returns on the first hit).
+        let runner = StubRunner::new(&[46075]);
+        let sessions = vec![
+            session("new", 41469, "h", "Aug 30 12:03:00 2026"),
+            session("older", 46075, "h", "Aug 30 10:55:00 2026"),
+        ];
+        let result = pick_live_session(sessions, &runner, Some("h"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.id, "older");
+        // The 41469 candidate was probed (dead) and 46075 was probed (live).
+        let cmds = runner.commands.lock().unwrap();
+        assert_eq!(cmds.len(), 2);
+    }
+
+    #[test]
+    fn returns_none_when_all_dead() {
+        let runner = StubRunner::new(&[]);
+        let sessions = vec![
+            session("a", 41469, "h", "Aug 30 10:55:00 2026"),
+            session("b", 46075, "h", "Aug 30 12:03:00 2026"),
+        ];
+        let result = pick_live_session(sessions, &runner, None).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn host_hint_prefers_matching_then_recency() {
+        // host=h has 46075 (live) and 41469 (dead);
+        // host=other has 39000 (live, newer).
+        // With hint=Some("h"), the matcher picks from h's pool first
+        // and returns 46075 (the live h-session, even though 39000 is newer).
+        let runner = StubRunner::new(&[46075, 39000]);
+        let sessions = vec![
+            session("old-h", 41469, "h", "Aug 30 10:55:00 2026"),
+            session("new-h", 46075, "h", "Aug 30 12:03:00 2026"),
+            session("other", 39000, "other", "Aug 31 09:00:00 2026"),
+        ];
+        let result = pick_live_session(sessions, &runner, Some("h"))
+            .unwrap()
+            .unwrap();
+        assert_eq!(result.id, "new-h");
+    }
+
+    #[test]
+    fn no_host_hint_uses_recency_only() {
+        let runner = StubRunner::new(&[39000]);
+        let sessions = vec![
+            session("old", 41469, "h", "Aug 30 10:55:00 2026"),
+            session("newest", 39000, "other", "Aug 31 09:00:00 2026"),
+            session("mid", 46075, "h", "Aug 30 12:03:00 2026"),
+        ];
+        let result = pick_live_session(sessions, &runner, None).unwrap().unwrap();
+        assert_eq!(result.id, "newest");
+    }
+
+    #[test]
+    fn ssh_failure_propagates() {
+        let mut runner = StubRunner::new(&[46075]);
+        runner.fail = true;
+        let sessions = vec![session("s1", 46075, "h", "Aug 30 12:03:00 2026")];
+        let result = pick_live_session(sessions, &runner, None);
+        assert!(result.is_err());
+    }
+}

--- a/src/transport/tunnel.rs
+++ b/src/transport/tunnel.rs
@@ -380,6 +380,13 @@ impl SSHClient {
         TunnelState::load().ok().flatten().map(|s| s.port)
     }
 
+    /// OS PID of the SSH tunnel process spawned by [`Self::open_tunnel`]
+    /// (or by `warm()`), if any. Used by `tunnel attach` to record the
+    /// tunnel pid into `TunnelState` so `tunnel detach` / `stop` can signal it.
+    pub fn tunnel_pid(&self) -> Option<u32> {
+        self.tunnel_pid
+    }
+
     pub fn is_tunnel_alive(&self) -> bool {
         if let Some(pid) = self.tunnel_pid {
             #[cfg(unix)]
@@ -453,6 +460,15 @@ impl SSHClient {
             "failed to establish tunnel on any port; verify SSH: `{}`",
             self.runner().verify_cmd_hint()
         )))
+    }
+
+    /// Open an SSH tunnel forwarding the local port to the remote host.
+    ///
+    /// Used by `tunnel attach` to plug into a pre-existing daemon at a port
+    /// discovered from session metadata — no port walk, since the OS-assigned
+    /// port we want to reach is known up front.
+    pub fn open_tunnel(&mut self, port: u16) -> Result<()> {
+        self.try_ssh_tunnel(port)
     }
 
     fn try_ssh_tunnel(&mut self, port: u16) -> Result<()> {
@@ -543,6 +559,9 @@ impl SSHClient {
             start_time_unix_ms: None,
             health: None,
             config_digest: None,
+            mode: Some(crate::models::TUNNEL_MODE_DEPLOYED.into()),
+            attached_remote_port: None,
+            attached_session_id: None,
         };
         state.save().map_err(|e| VirtuosoError::Ssh(e.to_string()))
     }
@@ -682,6 +701,9 @@ mod tests {
             start_time_unix_ms: None,
             health: None,
             config_digest: None,
+            mode: None,
+            attached_remote_port: None,
+            attached_session_id: None,
         }
     }
 


### PR DESCRIPTION
## Context

`tunnel start` 只能部署新 daemon，无法复用已存在的 Virtuoso daemon。cadence-rocky 容器的实际场景是 Virtuoso + 由 `ipcBeginProcess` 启动的 daemon 已运行，用户只是想把 vcli 接进去。当前架构里 `tunnel start` 和 `tunnel stop` 隐含"我部署、我清理"的所有权语义——但当 Virtuoso 拥有 daemon 时，用户**没有权限也没有理由**去 stop 它。

行业标准（kubectl/docker/screen）的 4 动词模型把部署和连接分开：

| Verb | 副作用 |
|------|--------|
| `tunnel start` | 部署新 daemon + 建 tunnel |
| `tunnel stop` | 销毁 start 创建的一切（含远端） |
| `tunnel attach` | 连接已存在的 daemon（**只**建 tunnel + 保存 state） |
| `tunnel detach` | 断开（杀 tunnel、清 state、**不碰** daemon） |

## Changes

### 1. `feat(commands/tunnel)` — 新增 attach/detach 子命令

- `TunnelState` 加 `mode` / `attached_remote_port` / `attached_session_id` 三个 `Option<String/port>` 字段，`#[serde(default)]` 不破坏 v1/v2 文件
- 新模块 `src/transport/session_discovery.rs`：`remote_port_alive` + `pick_live_session`，按 host_hint 优先 + 按 created 排序挑 live session
- `SSHClient::open_tunnel(port)` 暴露 `try_ssh_tunnel` 入口，attach 复用
- `attach(dry_run)`：list_remote → pick_live → open_tunnel → 写 state(mode="attached") → sync_from_remote
- `detach()`：拒 deployed（建议 stop），杀 SSH tunnel，清 state，**不**调 cleanup_remote
- `stop()` 区分 mode：attached 跳过 `rm -rf /tmp/virtuoso_bridge_*/`（daemon 不归我们）

### 2. `fix(transport/session_discovery)` — 端口探测改用 bash /dev/tcp

cadence-rocky 容器未装 iproute2，attach 时 `ss -tlnH 'sport = :PORT'` 返回空 stdout 导致端口探测恒为 false。ss 静默失败是最坏情况——把"工具缺失"伪装成"端口未绑定"。

改用 bash 内建 `/dev/tcp/{host}/{port}`：
- 任何装 bash 的 Linux 镜像都能用
- 无外部依赖
- 失败语义清晰

## Test plan

```bash
cargo build && cargo test && cargo clippy --all-targets -- -D warnings

# cadence-rocky 容器验证
VB_PROFILE=localhost vcli tunnel attach
VB_PROFILE=localhost vcli tunnel status   # running=true
VCLI_CAPABILITY=admin VB_PROFILE=localhost vcli rpc call \
  --method skill.eval --params '{"code":"1+1"}'
# → {"output":"2","status":"success"}

VB_PROFILE=localhost vcli tunnel detach
# state.json 清掉；docker daemon PID 仍在；sessions/ 三个 JSON 仍在

# 探测路径单测（bash /dev/tcp 替换 ss 后，6 个测试全 pass）
cargo test --lib transport::session_discovery
```