### PR TITLE
fix(ramic_bridge): banner SSH 端口 fallback 22 + RB_SSH_PORT 注入 daemon env

### DIFF
--- a/resources/ramic_bridge.il
+++ b/resources/ramic_bridge.il
@@ -51,14 +51,17 @@ unless(boundp('RBIpc) RBIpc = 'unbound)
 unless(boundp('RBSessionId)   RBSessionId   = "")
 ; hostname-user prefix; RBIpcErrHandler appends the OS-assigned port to form the final unique ID
 unless(boundp('RBSessionBase) RBSessionBase = "")
-; SSH port for tunnel connection — read from env or default to 2222
+; SSH port for tunnel connection — read from env, default 22 (host network mode).
+; cadence-rocky runs in host network mode so container port 22 = host port 22;
+; bridge-mode + port-mapping users can override by setting RB_SSH_PORT in their
+; Virtuoso CIW env before loading ramic_bridge.il.
 unless(boundp('RBsshPort)
     RBsshPort = let((envPort)
         envPort = getShellEnvVar("RB_SSH_PORT")
         if(envPort then
             atoi(envPort)
         else
-            2222
+            22
         )
     )
 )
@@ -168,7 +171,7 @@ procedure(RBStart()
 			RBSessionBase = sprintf(nil "%s-%s" hostname username)
 			; Start the daemon with port=0 (OS assigns free port).
 			; RBIpcErrHandler will parse PORT:N from stderr and write session file.
-			RBIpc = ipcBeginProcess(sprintf(nil "env VCLI_CAPABILITY=admin %s %s 0" RBDPath host) "" 'RBIpcDataHandler 'RBIpcErrHandler 'RBIpcFinishHandler logpath)
+			RBIpc = ipcBeginProcess(sprintf(nil "env RB_SSH_PORT=%d VCLI_CAPABILITY=admin %s %s 0" RBsshPort RBDPath host) "" 'RBIpcDataHandler 'RBIpcErrHandler 'RBIpcFinishHandler logpath)
 		)
 		printf("[RAMIC Bridge (%L)] start at (%s)\n" RBIpc getCurrentTime())
 	)


### PR DESCRIPTION
## Context

ramic_bridge.il 的 `RBsshPort` fallback 写死 2222，源自 cadence-rocky 早期用 bridge 网络模式 + 2222→22 端口映射的时期。切到 host network mode 后 container port 22 = host port 22，**banner 一直显示 `SSH: 2222` 但实际 SSH 在 22**，误导用户。

**示例 banner（修前）**：
```
┌─────────────────────────────────────────┐
│  vcli (Virtuoso CLI Bridge) — Ready     │
├─────────────────────────────────────────┤
│  Session : dean-user1-39827              │
│  Port    : 39827                         │
│  SSH     : 2222         ← 错的          │
│  Version : 1.0.0                         │
│  Daemon  : ~/.cargo/bin/virtuoso-daemon  │
└─────────────────────────────────────────┘
```

**根因**：
1. `RBsshPort` fallback 写死 `2222`
2. daemon 启动命令 `ipcBeginProcess("env VCLI_CAPABILITY=admin ...")` 没传 `RB_SSH_PORT`，所以 SKILL bridge 的 fallback 兜底

## Changes

### `resources/ramic_bridge.il:54-65` — SSH port fallback
- 注释更新为 host network mode 上下文 + cadence-rocky 说明
- fallback `2222` → `22`（host network mode 默认值）

### `resources/ramic_bridge.il:174` — daemon env
- `env VCLI_CAPABILITY=admin ...` → `env RB_SSH_PORT=%d VCLI_CAPABILITY=admin ...`
- `%d` 用 SKILL 变量 `RBsshPort`（line 58）插值，banner 显示的端口和 daemon 实际端口对齐

## Compatibility

`RB_SSH_PORT` env override 路径保留：
- bridge-mode + 端口映射用户在 CIW 启动前 `setenv RB_SSH_PORT <port>` 即可
- 不传则用新默认 22（host network mode 现状）

## Test plan

```bash
# cadence-rocky 容器内手动验证
docker exec cadence-rocky bash -c 'pkill -f virtuoso-daemon; sleep 2'
# 进 Virtuoso CIW 重 load ramic_bridge.il（触发 _RBAutoStart → vcli → RBStart）
# 期望 banner:
#   SSH : 22           ← 之前是 2222
#   Port: <新端口>
# docker ps 看 daemon 进程命令:
docker exec cadence-rocky ps -ef | grep virtuoso-daemon
# 期望: env RB_SSH_PORT=22 VCLI_CAPABILITY=admin ...  ← RB_SSH_PORT=22 在 env 里
```