### PR TITLE
fix(ramic_bridge): RBsshPort 移除 unless(boundp) 守卫，load 时重新读 env

### DIFF
--- a/resources/ramic_bridge.il
+++ b/resources/ramic_bridge.il
@@ -51,18 +51,21 @@ unless(boundp('RBIpc) RBIpc = 'unbound)
 unless(boundp('RBSessionId)   RBSessionId   = "")
 ; hostname-user prefix; RBIpcErrHandler appends the OS-assigned port to form the final unique ID
 unless(boundp('RBSessionBase) RBSessionBase = "")
-; SSH port for tunnel connection — read from env, default 22 (host network mode).
+; SSH port for tunnel connection — re-read from env on every load. This is
+; env-derived config, NOT session state, so the unless(boundp(...)) guard
+; that protects RBSessionId/RBSessionBase does NOT apply here. Without the
+; unconditional reassignment, reloads would preserve a stale value bound by
+; an earlier load (the original bug — banner kept showing 2222 after fallback
+; changed to 22). Falls back to 22 for host network mode.
 ; cadence-rocky runs in host network mode so container port 22 = host port 22;
 ; bridge-mode + port-mapping users can override by setting RB_SSH_PORT in their
 ; Virtuoso CIW env before loading ramic_bridge.il.
-unless(boundp('RBsshPort)
-    RBsshPort = let((envPort)
-        envPort = getShellEnvVar("RB_SSH_PORT")
-        if(envPort then
-            atoi(envPort)
-        else
-            22
-        )
+RBsshPort = let((envPort)
+    envPort = getShellEnvVar("RB_SSH_PORT")
+    if(envPort then
+        atoi(envPort)
+    else
+        22
     )
 )
 


### PR DESCRIPTION
## Context

PR #13 把 banner SSH 端口 fallback 改成 22 + 在 daemon 启动命令里注入 `RB_SSH_PORT=%d`，但合并后 cadence-rocky 容器里的 banner **仍然显示 `SSH: 2222`**。

## Root cause

`resources/ramic_bridge.il:58` 用 `unless(boundp('RBsshPort))` 守卫 RBsshPort 赋值：

```skill
unless(boundp('RBsshPort)
    RBsshPort = let((envPort) ...))
```

`unless(boundp(...))` 是 session-state 模式——`RBSessionId` / `RBSessionBase` 用它保持 reload 间稳定。但 RBsshPort 是 **env-derived config，不是 session state**。

后果：
1. cadence-rocky 在 bridge-mode 时期（port mapping 2222→22）首次 `load(ramic_bridge.il)`，SKILL 把 `RBsshPort = 2222` 绑到 symbol table
2. 后续切到 host network mode + PR #13 把 fallback 改成 22
3. 用户在 CIW 里 `load()` 重新求值时，`boundp('RBsshPort)` 已经为真 → 守卫体不执行 → fallback 22 永远跑不到
4. daemon 重启时仍用 stale `RBsshPort=2222` → banner 错

## Fix

移除 RBsshPort 的 `unless(boundp(...))` 守卫，每次 load 重新读 env。注释里明确：

- 这是 env-derived config，**不**套 session-state 模式
- `RBSessionId` / `RBSessionBase` 的 boundp 守卫**保留**——它们是真 session state
- env override 路径不变：bridge-mode 用户在 CIW 启动前 `setenv("RB_SSH_PORT" "<port>")` 仍优先于 fallback

```diff
- unless(boundp('RBsshPort)
-     RBsshPort = let((envPort)
-         envPort = getShellEnvVar("RB_SSH_PORT")
-         if(envPort then atoi(envPort) else 2222)
-     )
- )
+ RBsshPort = let((envPort)
+     envPort = getShellEnvVar("RB_SSH_PORT")
+     if(envPort then atoi(envPort) else 22)
+ )
```

## Operational note (重要)

`/home/user1/git/virtuoso-cli/resources/ramic_bridge.il` **不是** host `/home/dean/git/virtuoso-cli/resources/ramic_bridge.il` 的 bind-mount——容器内是独立拷贝。CIW 里 reload 前需要先把本 PR 的 .il 同步到容器：

```bash
# 三步：同步 + reload + 重启 daemon
docker cp resources/ramic_bridge.il cadence-rocky:/home/user1/git/virtuoso-cli/resources/
docker exec cadence-rocky bash -c 'mtime /home/user1/git/virtuoso-cli/resources/ramic_bridge.il'  # 验证
```

容器 CIW 里：
```
load("/home/user1/git/virtuoso-cli/resources/ramic_bridge.il")
RBStop()
vcli()
```

## Test plan

```bash
# 修前：banner SSH: 2222
# 修后：banner SSH: 22
docker exec cadence-rocky ps -ef | grep virtuoso-daemon
# 期望 cmdline: env RB_SSH_PORT=22 VCLI_CAPABILITY=admin ...
```

不引入测试代码改动——纯 SKILL 行为修正，验证靠 reload 后的 banner 输出。