### PR TITLE
fix(x11): harden screenshot artifact fetch + local-mode support

### DIFF
--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -1873,13 +1873,22 @@ impl RemoteTransport for LocalTransport {
 
     fn download_file(
         &self,
-        _req: &crate::transport::contract::DownloadFileRequest,
+        req: &crate::transport::contract::DownloadFileRequest,
     ) -> std::result::Result<(), crate::transport::contract::TransportError> {
-        Err(
-            crate::transport::contract::TransportError::UnsupportedOperation(
-                "download_file not supported on LocalTransport".into(),
-            ),
-        )
+        if req.deadline.is_expired() {
+            return Err(crate::transport::contract::TransportError::QueueTimeout {
+                request: req.id.clone(),
+                after_secs: 0,
+            });
+        }
+        // LocalTransport runs on the same host as vcli, so the "remote" and
+        // "local" paths live on the same filesystem — a plain copy is correct.
+        std::fs::copy(&req.remote, &req.local).map_err(|e| {
+            crate::transport::contract::TransportError::LocalIo(format!(
+                "local file copy failed: {e}"
+            ))
+        })?;
+        Ok(())
     }
 
     fn download_dir(

--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -20,6 +20,7 @@ use include_dir::{include_dir, Dir};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fmt::Write as _;
+use uuid::Uuid;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -911,10 +912,15 @@ pub fn action_x11(
         )));
     }
 
-    // Step 4: Check geometry bounds for click/drag operations
+    // Step 4: Check geometry bounds for click/drag operations.
+    // A zero-sized geometry means the window bounds are unknown (unparsed or
+    // abnormal); don't blanket-reject — trust the caller's coordinates instead.
     if let (Some(op_x), Some(op_y)) = (*x, *y) {
         let geom = &resolved.geometry;
-        if op_x < 0 || op_y < 0 || op_x >= geom.w || op_y >= geom.h {
+        if geom.w > 0
+            && geom.h > 0
+            && (op_x < 0 || op_y < 0 || op_x >= geom.w || op_y >= geom.h)
+        {
             return Err(VirtuosoError::Config(format!(
                 "coordinates ({op_x}, {op_y}) out of bounds for window size {}x{}",
                 geom.w, geom.h
@@ -948,7 +954,7 @@ pub fn action_x11(
             .ok_or_else(|| VirtuosoError::Config("screenshot requires --output-dir".into()))?;
         // Use a random temp name on the GUI host to avoid colliding with
         // prior runs or concurrent agents targeting the same DISPLAY.
-        let token = std::process::id() ^ (start.elapsed().as_nanos() as u32);
+        let token = Uuid::new_v4();
         let safe_name = format!("vcli_shot_{token}.png");
         let remote_path = format!("/tmp/{safe_name}");
         let remote_cmd = format!(
@@ -972,8 +978,12 @@ pub fn action_x11(
         match runner.fetch_file(&remote_path, dir, Duration::from_secs(*timeout_secs)) {
             Ok(()) => {}
             Err(e) => {
-                // LocalTransport doesn't support fetch_file; the import wrote
-                // directly to the local /tmp which was then renamed by caller.
+                // The import already wrote the PNG to remote_path on the GUI
+                // host; since the fetch failed, clean it up there. Best-effort.
+                let _ = runner.run_command(&CommandRequest::untimed(format!(
+                    "rm -f {}",
+                    shell_escape(&remote_path)
+                )));
                 return Err(VirtuosoError::Execution(format!(
                     "screenshot fetch failed: {e}"
                 )));
@@ -983,7 +993,12 @@ pub fn action_x11(
         let local_path_buf = std::path::PathBuf::from(dir).join(&safe_name);
         match validate_png_artifact(&local_path_buf) {
             Ok((size, hash)) => {
-                let _ = std::fs::remove_file(&remote_path); // best-effort remote cleanup
+                // Best-effort cleanup of the temp PNG on the GUI host (remote
+                // or local — the runner abstracts the host).
+                let _ = runner.run_command(&CommandRequest::untimed(format!(
+                    "rm -f {}",
+                    shell_escape(&remote_path)
+                )));
                 (
                     vec![out],
                     Some(ArtifactInfo {
@@ -996,6 +1011,11 @@ pub fn action_x11(
             }
             Err(e) => {
                 let _ = std::fs::remove_file(&local_path_buf); // cleanup invalid file
+                // Also remove the temp PNG left on the GUI host.
+                let _ = runner.run_command(&CommandRequest::untimed(format!(
+                    "rm -f {}",
+                    shell_escape(&remote_path)
+                )));
                 return Err(e);
             }
         }
@@ -1337,7 +1357,9 @@ fn validate_png_artifact(
 ) -> std::result::Result<(u64, String), VirtuosoError> {
     use std::io::{Read, Seek};
 
-    let metadata = std::fs::metadata(path).map_err(|e| {
+    // Use symlink_metadata so the check does not follow the link — a plain
+    // `metadata` would resolve the target and never report a symlink.
+    let metadata = std::fs::symlink_metadata(path).map_err(|e| {
         VirtuosoError::Execution(format!("cannot stat screenshot path {:?}: {e}", path))
     })?;
 

--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -20,9 +20,9 @@ use include_dir::{include_dir, Dir};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::fmt::Write as _;
-use uuid::Uuid;
 use std::sync::Arc;
 use std::time::Duration;
+use uuid::Uuid;
 
 static RESOURCES: Dir = include_dir!("$CARGO_MANIFEST_DIR/resources");
 
@@ -917,10 +917,7 @@ pub fn action_x11(
     // abnormal); don't blanket-reject — trust the caller's coordinates instead.
     if let (Some(op_x), Some(op_y)) = (*x, *y) {
         let geom = &resolved.geometry;
-        if geom.w > 0
-            && geom.h > 0
-            && (op_x < 0 || op_y < 0 || op_x >= geom.w || op_y >= geom.h)
-        {
+        if geom.w > 0 && geom.h > 0 && (op_x < 0 || op_y < 0 || op_x >= geom.w || op_y >= geom.h) {
             return Err(VirtuosoError::Config(format!(
                 "coordinates ({op_x}, {op_y}) out of bounds for window size {}x{}",
                 geom.w, geom.h
@@ -1011,7 +1008,7 @@ pub fn action_x11(
             }
             Err(e) => {
                 let _ = std::fs::remove_file(&local_path_buf); // cleanup invalid file
-                // Also remove the temp PNG left on the GUI host.
+                                                               // Also remove the temp PNG left on the GUI host.
                 let _ = runner.run_command(&CommandRequest::untimed(format!(
                     "rm -f {}",
                     shell_escape(&remote_path)
@@ -2941,6 +2938,128 @@ mod tests {
             result.is_err(),
             "screenshot path with .. should be rejected"
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // validate_png_artifact: rejection branches (review #1 / #5)
+    // ---------------------------------------------------------------------------
+
+    fn write_temp_png(bytes: &[u8], name: &str) -> std::path::PathBuf {
+        let p = std::env::temp_dir().join(name);
+        std::fs::write(&p, bytes).expect("write temp png");
+        p
+    }
+
+    #[test]
+    fn validate_png_artifact_accepts_valid_png() {
+        let mut data = Vec::new();
+        data.extend_from_slice(super::PNG_MAGIC);
+        data.resize(128, 0); // >= 64 bytes
+        let p = write_temp_png(&data, "vcli_test_png_valid.png");
+        let res = super::validate_png_artifact(&p);
+        assert!(res.is_ok(), "valid PNG should pass: {res:?}");
+        let (size, hash) = res.unwrap();
+        assert_eq!(size, 128);
+        assert_eq!(hash.len(), 64);
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn validate_png_artifact_rejects_tiny_file() {
+        let data = vec![0u8; 10];
+        let p = write_temp_png(&data, "vcli_test_png_tiny.png");
+        let res = super::validate_png_artifact(&p);
+        assert!(res.is_err(), "file < 64 bytes must be rejected");
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn validate_png_artifact_rejects_wrong_magic() {
+        let mut data = vec![0u8; 128];
+        data[0..4].copy_from_slice(b"NOPE");
+        let p = write_temp_png(&data, "vcli_test_png_badmagic.png");
+        let res = super::validate_png_artifact(&p);
+        assert!(res.is_err(), "wrong magic must be rejected");
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_png_artifact_rejects_symlink() {
+        // Locks review #1: symlink_metadata (not metadata) must make the
+        // is_symlink() branch reachable.
+        let mut data = Vec::new();
+        data.extend_from_slice(super::PNG_MAGIC);
+        data.resize(128, 0);
+        let target = write_temp_png(&data, "vcli_test_png_symlink_target.png");
+        let link = std::env::temp_dir().join("vcli_test_png_symlink.png");
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink(&target, &link).expect("create symlink");
+        let res = super::validate_png_artifact(&link);
+        assert!(res.is_err(), "symlink must be rejected");
+        let _ = std::fs::remove_file(&link);
+        let _ = std::fs::remove_file(&target);
+    }
+
+    // ---------------------------------------------------------------------------
+    // MouseButtonGuard: best-effort mouseup on drop (review #5)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn mouse_button_guard_drops_best_effort_mouseup_when_armed() {
+        let win = WindowInfo {
+            frame_id: "0x1".into(),
+            window_id: "0x2".into(),
+            dismiss_id: "0x3".into(),
+            display: Some(":0".into()),
+            xauthority: None,
+            title: "t".into(),
+            class: vec![],
+            geometry: Geometry {
+                x: 0,
+                y: 0,
+                w: 100,
+                h: 100,
+            },
+            pid: Some(12345),
+            visible: true,
+        };
+        let t = RecordingTransport::new();
+        {
+            let mut g = super::MouseButtonGuard::new(&t, "env DISPLAY=:0 ", &win, Some(1));
+            g.arm();
+            // guard dropped at end of scope
+        }
+        let cmds = t.commands.lock().unwrap();
+        assert!(
+            cmds.iter().any(|c| c.contains("mouseup")),
+            "armed MouseButtonGuard must issue best-effort mouseup on drop; got {cmds:?}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // LocalTransport::download_file (review #3)
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn local_transport_download_file_copies_local_file() {
+        let src = std::env::temp_dir().join("vcli_test_dl_src.png");
+        let dst = std::env::temp_dir().join("vcli_test_dl_dst.png");
+        let _ = std::fs::remove_file(&dst);
+        std::fs::write(&src, b"hello-world-png-contents").expect("write src");
+        let req = crate::transport::contract::DownloadFileRequest::untimed(
+            src.display().to_string(),
+            dst.clone(),
+        );
+        let res = super::LocalTransport::new().download_file(&req);
+        assert!(
+            res.is_ok(),
+            "LocalTransport::download_file should copy: {res:?}"
+        );
+        let copied = std::fs::read(&dst).expect("read dst");
+        assert_eq!(copied, b"hello-world-png-contents");
+        let _ = std::fs::remove_file(&src);
+        let _ = std::fs::remove_file(&dst);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to issue #30 / the `x11.rs` screenshot-path review. Fixes the blocking
local-mode breakage and the two 🟠 items, plus the same-batch 🟡 nice-to-haves,
and adds the unit tests the review found missing.

## Changes (`src/transport/x11.rs` only)

- **#3 (blocking) — local-mode screenshot was completely broken.**
  `LocalTransport::download_file` returned `UnsupportedOperation`, so the screenshot
  flow failed whenever `VB_REMOTE_HOST` is unset. Implement it as a plain
  `std::fs::copy(remote, local)`; the trait default `fetch_file` already derives the
  local path, so no change to `action_x11` is needed.
- **#1 (🟠) — `validate_png_artifact` symlink check was dead code.**
  `std::fs::metadata` follows the link, so `is_symlink()` could never be true. Switched
  to `std::fs::symlink_metadata`.
- **#2 (🟠) — remote temp PNG was never cleaned.**
  `std::fs::remove_file(&remote_path)` runs locally and deletes nothing on the GUI
  host. Clean it via `runner.run_command("rm -f …")` in the success, validation-failure,
  and fetch-error arms (the last also leaked the local `/tmp` file the import had
  already written).
- **#4 (🟡) — weak screenshot token.** Replaced `PID ^ elapsed-nanos` with
  `Uuid::new_v4()` (already a dependency).
- **#6 (🟡) — 0×0 window geometry blanket-rejected every click/drag.** Skip the bounds
  check when either dimension is zero (untracked geometry) instead of failing closed.
- **#5 (🟡) — test gaps.** Added unit tests for `validate_png_artifact` (valid PNG +
  three rejection branches; the symlink case locks #1), `MouseButtonGuard::drop`
  (best-effort mouseup when armed), and `LocalTransport::download_file`. The
  ClickRel xdotool sequence already had three passing tests.

## Residual follow-on (not in this PR)

`File::open` at the validation step still follows a symlink; since the symlink branch
now returns first, it is unreachable in practice, but an `O_NOFOLLOW` read would be the
fully symlink-resistant fix. Low severity (local evidence dir) — noted for later.

## Acceptance

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib x11` ✅ (83 passed, +6 new)
- Full `cargo test`: 836 lib tests pass, 0 failed. The single failure is the
  pre-existing baseline env test `tests/config.rs::test_config_timeout_default`
  (fails because `VB_TIMEOUT=60` is set in the local environment; unrelated to this PR).
