### PR TITLE
fix(x11): validate_png_artifact open is symlink-resistant (O_NOFOLLOW)

### DIFF
--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -1375,10 +1375,29 @@ fn validate_png_artifact(
         )));
     }
 
+    // Open the file. On Unix, refuse to follow a symlink (O_NOFOLLOW) so a
+    // race between the symlink_metadata check above and this open cannot swap
+    // in a symlink pointing outside the evidence directory.
+    let mut file = {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_NOFOLLOW)
+                .open(path)
+                .map_err(|e| {
+                    VirtuosoError::Execution(format!("cannot open screenshot path {:?}: {e}", path))
+                })?
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::File::open(path).map_err(|e| {
+                VirtuosoError::Execution(format!("cannot open screenshot path {:?}: {e}", path))
+            })?
+        }
+    };
     // Check magic bytes.
-    let mut file = std::fs::File::open(path).map_err(|e| {
-        VirtuosoError::Execution(format!("cannot open screenshot path {:?}: {e}", path))
-    })?;
     let mut header = [0u8; 8];
     file.read_exact(&mut header).map_err(|e| {
         VirtuosoError::Execution(format!(


### PR DESCRIPTION
## Summary
Follow-up to #32 / issue #30. `validate_png_artifact` already rejected symlinks via `symlink_metadata`, but `File::open` still followed them — a TOCTOU race between the stat check and the open. This makes the open itself symlink-resistant on Unix with `O_NOFOLLOW`.

## Change
- `src/transport/x11.rs` `validate_png_artifact`: replace `std::fs::File::open(path)` with an `OpenOptions` open carrying `O_NOFOLLOW` under `#[cfg(unix)]`; non-Unix keeps plain `File::open`.

## Why
Defense-in-depth: closes the window where a symlink swapped in between the `symlink_metadata` check (rejects symlinks) and the `File::open` could point the open outside the local evidence directory. The evidence dir is local / low-risk, so this is hardening, not a live-exploit fix.

## Gates
- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test --lib x11` 83 passed (incl. `validate_png_artifact_rejects_symlink`) ✅
- CI to be verified post-push.
