### PR TITLE
fix(x11): populate window display field in action_x11 so strict DISPLAY matching can pass

### DIFF
--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -895,6 +895,14 @@ pub fn action_x11(
         .stdout
         .lines()
         .filter_map(|l| serde_json::from_str::<WindowInfo>(l.trim()).ok())
+        .map(|mut w| {
+            // The helper emits no `display` field; annotate it here exactly like
+            // `list_windows` does so `resolve_unique_window`'s strict DISPLAY
+            // matching can pass (fixes `action-x11` always returning not_found).
+            w.display = Some(display.to_string());
+            w.xauthority = env.xauthority.clone();
+            w
+        })
         .collect();
 
     // Step 2: Resolve unique window with strict PID + DISPLAY matching


### PR DESCRIPTION
## Summary

Fixes #34. `vcli window action-x11` always returned `not_found` because `action_x11()` collected the window list from the X11 helper **without populating the `display` field**, while `list_windows()` does. The helper JSON has no `display` key, so `resolve_unique_window()`'s strict DISPLAY matching always failed.

## Change

Align `action_x11()` with `list_windows()` by annotating `display`/`xauthority` on each window before resolving:

```rust
.map(|mut w| {
    w.display = Some(display.to_string());
    w.xauthority = env.xauthority.clone();
    w
})
```

## Verification

- End-to-end on isolated Xvfb test window (WM_CLASS=virtuoso): `type "hello"` → 5 chars reach the window; single-key `key` and `ctrl+s` events captured; `screenshot` → PNG validated (magic bytes + SHA-256).
- `cargo test --lib x11`: 77 passed / 0 failed.
