### PR TITLE
chore(skills): add pr-review-hardening skill (project-level)

### DIFF
--- a/.workbuddy/skills/pr-review-hardening/SKILL.md
+++ b/.workbuddy/skills/pr-review-hardening/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: pr-review-hardening
+description: "Verify the accuracy of a GitHub PR review (or a pasted review draft) against the actual code before acting, fix the confirmed bugs one seam at a time, and confirm with the real CI run rather than trusting local-green. Use when the user hands over a PR review and asks to fix the review comments, apply these changes, review this and merge, or confirm whether a review is accurate. This skill applies when the task involves acting on a code review, a GitHub PR, the gh CLI, CI verification, or single-seam commit discipline."
+agent_created: true
+---
+
+# PR Review Hardening
+
+## Overview
+
+Turn a submitted PR review into a trustworthy, merge-ready change set. The
+default failure mode is to blindly apply every review comment — including
+false positives, out-of-diff items, and severity over-ratings — then declare
+victory on a green local test run that the real CI later rejects. This skill
+enforces three gates: **verify accuracy first**, **fix one seam per commit**,
+and **confirm with the actual CI run**, not the local build.
+
+## When to Use
+
+- The user pastes a PR review (their own draft or a teammate's) and asks to act
+  on it ("fix these", "apply", "is this accurate?", "review and merge").
+- A review is in Request-changes state and the next step is remediation.
+- Any task touching a GitHub PR where CI status must be trusted (not assumed).
+
+## Workflow
+
+### Phase 1 — Verify review accuracy before touching code
+
+Do not start editing on the first reading of the review. For each numbered
+item, verify against the real repository state:
+
+1. **Existence.** Does the cited bug exist at the cited file/line? Read the
+   actual file on the relevant branch/commit; grep the symbol. Line numbers in
+   the review may be from a stale read or a different branch.
+2. **False-positive.** Did the review claim something is missing when it
+   already exists? Reviewers frequently read only part of a large file. Grep
+   the whole file (especially the `#[cfg(test)]` / test module at the bottom)
+   before accepting "no test / not implemented" claims.
+3. **Scope.** Is the item inside this PR's diff? Run
+   `git diff --stat BASE..HEAD` (or the PR's merge-base). Files/lines
+   outside the diff are out of scope — flag them, do not fix them in this PR.
+4. **Missed items.** While reading, record real bugs the review omitted (e.g.,
+   an error path that leaks a temp file, a dead-code branch that can never
+   trigger). Add them as additional findings.
+5. **Blast radius.** Don't inherit the review's severity. A "symlink rejection
+   is dead code" sounds like a remote exploit but is defense-in-depth if it
+   only validates a locally-fetched file.
+
+Produce a **corrected review** before editing: for each original item mark
+`Confirmed` / `False-positive (evidence: …)` / `Out-of-scope (not in diff)` /
+`Missed (new finding)`, and list new findings. See
+`references/workflow.md` for the template. This protects the user from acting on
+wrong claims.
+
+### Phase 2 — Fix one seam per commit
+
+- One commit per concern. Zero behavior change within a seam. The commit
+  message references the review item ID, e.g.
+  `#3 LocalTransport::download_file → std::fs::copy(remote, local)`.
+- Prefer `git commit -F FILE` (and `gh pr create --body-file FILE`): the
+  default shell is **fish**, where heredocs, `VAR=x cmd` prefixes, and long
+  inline bodies fail. Write bodies to a temp file under `/tmp`.
+- Run the acceptance gates per seam (fmt / clippy `-D warnings` / targeted
+  test) before committing so a failure is attributable to one change.
+
+### Phase 3 — Confirm with the real CI run (never local-green alone)
+
+Local `cargo test` / `npm test` green is necessary but not sufficient.
+
+1. After opening the PR: `gh run list --branch BRANCH --limit 5` to find the
+   run IDs, then `gh run watch RUN_ID` (or
+   `gh run view ID --json conclusion -q .conclusion`). Watch BOTH the "CI"
+   run (includes security/audit jobs) and the "Integration Matrix" run.
+2. After `gh pr merge`, `git fetch` and re-verify `main`'s post-merge runs — a
+   green PR branch does not guarantee green `main` (matrix/merge interactions).
+3. Verify a squash-merged commit's scope: `git show --stat SHA`. GitHub's
+   merge echo can look like it touched many files when it changed one.
+
+## Environment Gotchas
+
+- **Shell is fish.** Avoid multi-line `if`/`for` and heredocs; use `bash` for
+  control flow; write message bodies to files and pass `--body-file`.
+- **clippy `-D warnings`** flags `needless_borrows_for_generic_args`:
+  `untimed(&format!(...))` → drop the `&` → `untimed(format!(...))`.
+- **Concurrent automation may switch git branches / stash your work**
+  mid-session. Commit early; if preserving a WIP, use a named stash and verify
+  non-destructively (`git stash apply` then `git diff HEAD --stat`) BEFORE
+  `git stash drop`. If the apply is a no-op (content already in HEAD), the
+  stash is redundant and safe to drop.
+- **Baseline env failures.** `cargo test` may show a pre-existing,
+  env-dependent failure unrelated to the change (e.g., `test_config_timeout_default`
+  when `VB_TIMEOUT` is set). Confirm it is pre-existing, not a regression.
+
+## Resources
+
+`references/workflow.md` — corrected-review template, per-phase command
+recipes, and a seam-commit checklist.

--- a/.workbuddy/skills/pr-review-hardening/references/workflow.md
+++ b/.workbuddy/skills/pr-review-hardening/references/workflow.md
@@ -1,0 +1,150 @@
+# PR Review Hardening — Workflow Reference
+
+Detailed recipes and templates for the three-phase workflow in `SKILL.md`.
+Load this file when executing the skill; keep it out of the main SKILL.md body.
+
+---
+
+## Phase 1 — Corrected-review template
+
+Produce this BEFORE editing. Paste it back to the user so wrong claims are
+visible before any code changes.
+
+```markdown
+## Corrected review — <PR/branch>
+
+**Verdict:** Request-changes / Approved-with-nits / Accurate
+**Scope:** src/transport/x11.rs only (the screenshot path). Files outside this
+diff are flagged out-of-scope and raised separately.
+
+### Original item #N — <one-line summary>
+- Status: Confirmed | False-positive | Out-of-scope | Missed
+- Evidence: src/transport/x11.rs:1340 — `std::fs::metadata` follows the link,
+  so `is_symlink()` can never fire. Fix: `symlink_metadata`.
+- Action: <what will be done / was wrong in the claim>
+
+### New finding (reviewer missed)
+- src/transport/x11.rs:977 — the fetch-error arm returns before cleaning the
+  local /tmp PNG written by `import`. Leaks a temp file in local mode.
+```
+
+Severity legend used in this repo:
+`🔴 Blocking` / `🟠 High` / `🟡 Important` / `⚪ Minor` / `✅ Done-well`.
+
+Key checks (from SKILL.md Phase 1):
+- **Existence** — read the real file; grep the symbol; don't trust line numbers
+  copied from a stale read.
+- **False-positive** — grep the whole file incl. the bottom test module before
+  accepting "no test / missing" claims.
+- **Scope** — `git diff --stat BASE...HEAD`; items outside the diff are
+  out-of-scope, raise separately.
+- **Missed items** — record real bugs the review omitted.
+- **Blast radius** — rate severity from the *merged* data flow, not the worst
+  theoretical case.
+
+---
+
+## Phase 2 — Single-seam fix commands
+
+```bash
+# One branch from the target base (verify HEAD first)
+git fetch --quiet origin
+git checkout -b fix/TOPIC origin/main
+
+# Edit one concern, then gate BEFORE committing:
+cargo fmt --check            # if it fails: cargo fmt && cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test --lib MODULE    # targeted, not full suite, per seam
+
+# Commit one seam; write body to /tmp to survive fish shell
+cat > /tmp/msg.txt <<'EOF'
+#3 LocalTransport::download_file: implement as std::fs::copy(remote, local)
+
+VB_REMOTE_HOST unset selects LocalTransport, which returned
+UnsupportedOperation from download_file, breaking local-mode screenshots.
+EOF
+git add src/transport/x11.rs
+git commit -F /tmp/msg.txt
+
+# Push + open PR with body from file (fish-safe)
+git push -u origin fix/TOPIC
+gh pr create --base main --head fix/TOPIC \
+  --title "fix(x11): TOPIC" --body-file /tmp/pr_body.md
+```
+
+Seam-commit checklist (per commit):
+- [ ] Exactly one concern (one review item, or one test group).
+- [ ] No unrelated refactor / formatting mixed in.
+- [ ] `cargo fmt --check` / `clippy -D warnings` / targeted test pass.
+- [ ] Message names the review item ID it resolves.
+- [ ] `git diff --stat BASE...HEAD` shows only intended files.
+
+---
+
+## Phase 3 — Real-CI verification commands
+
+```bash
+# Find runs for the PR branch
+gh run list --branch fix/TOPIC --limit 5
+
+# Watch both jobs to completion (Integration Matrix is the 6-job one)
+gh run watch MATRIX_RUN_ID
+gh run watch CI_RUN_ID
+
+# Or poll conclusion directly
+gh run view RUN_ID --json conclusion -q .conclusion
+# → "success" / "failure"
+
+# After merge, confirm main (not just the branch)
+git fetch --quiet origin
+gh run list --branch main --limit 4
+gh run watch POST_MERGE_RUN_ID
+
+# Verify a squash-merged commit touched only intended files
+git show --stat MERGED_SHA
+```
+
+Post-merge rules:
+- A green PR branch does **not** guarantee green `main` (matrix × merge
+  interactions). Always re-verify `main`'s runs after `gh pr merge`.
+- `gh run view --json conclusion` is the source of truth; the GitHub UI
+  "checks" rollup can lag.
+
+---
+
+## Common clippy `-D warnings` traps
+
+- `needless_borrows_for_generic_args`:
+  `CommandRequest::untimed(&format!(...))` → `untimed(format!(...))`.
+- `unused_borrows`: a `let x = &y;` that is never reborrowed — drop the `&`.
+- After editing, a linter/hook may reformat the file; re-read before the next
+  Edit so `old_string` still matches.
+
+---
+
+## Git-session safety (concurrent automation)
+
+If a background automation switches branches or stashes mid-session:
+
+```bash
+# Diagnose
+git branch --show-current
+git stash list
+git rev-parse HEAD
+git merge-base --is-ancestor $(git rev-parse stash@{N}^1) HEAD \
+  && echo "stash parent is ancestor of HEAD"
+
+# Verify a stash is redundant BEFORE dropping (non-destructive)
+git stash apply stash@{N}
+git diff HEAD --stat          # empty => content already in HEAD
+git status --short | grep -v '.workbuddy'
+# If empty and no tracked changes: redundant, safe to drop
+git stash drop stash@{N}
+
+# If apply created a duplicate (e.g., duplicate `pub mod sys;`):
+git restore FILE            # undo the duplicate, keep HEAD version
+git stash drop stash@{N}
+```
+
+Never `git stash drop` before a non-destructive `git stash apply` + diff check.
+Preserve unrelated stashes (old sessions) untouched.


### PR DESCRIPTION
## Summary

Adds the `pr-review-hardening` skill at project level (`.workbuddy/skills/`) so
all collaborators share it via the repo. The user-level copy was already
created and validated with `package_skill.py` in this session.

## What the skill does

Three gates for acting on a GitHub PR review:

1. **Verify accuracy first** — for each review item, check existence /
   false-positive / out-of-diff scope / omissions / blast-radius, then emit a
   *corrected* review before touching code. (This caught 3 hard errors in a
   pasted draft: ClickRel already had 3 tests, the Cargo.toml version was
   already 1.2.0, and a symlink blast-radius was over-rated.)
2. **Fix one seam per commit** — one logical change per commit, zero behavior
   change, commit message references the review item id.
3. **Confirm with the real CI run** — `gh run watch` / `--json conclusion`,
   re-verify `main` after merge, scope-check squash commits with
   `git show --stat`.

## Scope

- Only the skill directory is added: `.workbuddy/skills/pr-review-hardening/`
  (`SKILL.md` + `references/workflow.md`). No source code, no CI changes.
- No build/test impact — CI here only sanity-checks the repo still builds.

## Verification

- Skill packaged and validated via the skill-creator `package_skill.py`
  (passed; zip at `/tmp/pr-review-hardening.zip`).
- Commit is a single seam; `git diff --cached --stat` shows only the 2 skill
  files.
