### PR TITLE
fix(x11): normalize hyphenated key chords to xdotool '+' form

### DIFF
--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -1186,11 +1186,16 @@ fn build_xdotool_actions(
         }
         X11Operation::Key => {
             // xdotool key --window <id> <key>...
+            // xdotool separates chord modifiers/keys with `+` (e.g. `ctrl+s`).
+            // Older xdotool releases (e.g. 3.20200624.1) reject the hyphenated
+            // form `ctrl-s`, and no X11 keysym name contains a hyphen, so
+            // normalizing `-` to `+` is safe and makes `key --text "ctrl-s"`
+            // work across xdotool versions.
             let t =
                 text.ok_or_else(|| VirtuosoError::Config("key operation requires --text".into()))?;
             let mut argv = vec!["key".into(), "--window".into(), wid];
             for key in t.split_whitespace() {
-                argv.push(key.to_string());
+                argv.push(key.replace('-', "+"));
             }
             Ok(vec![("key".into(), argv)])
         }
@@ -3350,10 +3355,32 @@ mod tests {
         assert_eq!(action.len(), 1);
         let (sub, argv) = &action[0];
         assert_eq!(sub, "key");
-        assert_eq!(argv, &["key", "--window", "0x400002", "ctrl-s"]);
+        // Hyphenated chords (`ctrl-s`) are normalized to xdotool's `+` form.
+        assert_eq!(argv, &["key", "--window", "0x400002", "ctrl+s"]);
         assert!(
             !argv.windows(2).any(|w| w[0] == "--window" && w[1] == "key"),
             "regression: --window must come AFTER subcommand"
+        );
+    }
+
+    #[test]
+    fn build_xdotool_actions_key_normalizes_hyphen_chords_across_tokens() {
+        // `ctrl-s Return` and `ctrl-shift-x` (multi-token + hyphen chord) both
+        // normalize `-` → `+`; keysyms with underscores (KP_Subtract) are
+        // untouched since they contain no hyphen.
+        let action = build_xdotools_actions_key("0x400002", "ctrl-shift-x Return KP_Subtract");
+        let (sub, argv) = &action[0];
+        assert_eq!(sub, "key");
+        assert_eq!(
+            argv,
+            &[
+                "key",
+                "--window",
+                "0x400002",
+                "ctrl+shift+x",
+                "Return",
+                "KP_Subtract"
+            ]
         );
     }
 


### PR DESCRIPTION
## 背景
`action-x11 key --text "ctrl-s"`（连字符 chord）在旧版 xdotool（如 Ubuntu 20.04 的 3.20200624.1）上失败：xdotool 用 `+` 分隔 chord（`ctrl+s`），连字符形式 `ctrl-s` 被当作不存在的 keysym 拒绝。**升级 xdotool 也无法解决**（xdotool 各版本均不支持连字符）。

## 修复
在 `X11Operation::Key` 分支将 key 文本每个空白分隔 token 中的 `-` 规范化为 `+`。因为 X11 keysym 名不含连字符（如 `KP_Subtract` 用下划线），替换安全：
- `ctrl-s` → `ctrl+s`
- `ctrl-shift-x` → `ctrl+shift+x`
- `KP_Subtract` / `Return` 等单键不受影响

## 测试
- 更新 `build_xdotool_actions_key_argv_shape` 断言（连字符 → 加号）
- 新增 `build_xdotool_actions_key_normalizes_hyphen_chords_across_tokens`（多 token + 连字符 chord + 下划线 keysym 不变）

本地 x11 测试通过，fmt/clippy 干净。
