### PR TITLE
fix(window): repair SKILL screenshot generation (quote path, 3-arg if)

### DIFF
--- a/src/client/window_ops.rs
+++ b/src/client/window_ops.rs
@@ -91,10 +91,11 @@ impl WindowOps {
     /// (as `load("{path}")` does), otherwise `/path/x.png` parses as an
     /// invalid identifier. The success check uses the 3-arg `if(cond t e)`
     /// form — SKILL rejects `if(cond t else e)` with a `lineread/read: syntax
-    /// error`.
+    /// error` — and `isFile` must run AFTER `system` (it probes the file the
+    /// capture just created; checking first always returns nil).
     fn skill_capture(path_escaped: &str) -> String {
         format!(
-            r#"let((cmd ok) cmd = strcat("import -window root -silent " "{path}") ok = isFile("{path}") system(cmd) if(ok "{path}" nil)"#,
+            r#"let((cmd) cmd = strcat("import -window root -silent " "{path}") system(cmd) if(isFile("{path}") "{path}" nil))"#,
             path = path_escaped
         )
     }
@@ -210,11 +211,12 @@ mod tests {
     #[test]
     fn screenshot_skill_uses_three_arg_if_and_quoted_path() {
         // Regression: skill_capture previously emitted `if(ok {path} else nil)`
-        // (mixing the 3-arg if form with the `else` keyword) AND left {path}
-        // unquoted (`escape_skill_string` returns a bare escaped string).
-        // Both make Virtuoso fail with "lineread/read: syntax error" when the
-        // SKILL is evaluated. The correct form quotes the path and uses the
-        // 3-arg if without the `else` keyword.
+        // (mixing the 3-arg if form with the `else` keyword), left {path}
+        // unquoted (`escape_skill_string` returns a bare escaped string), and
+        // probed `isFile` BEFORE `system` (so the freshly-created file was
+        // never seen and the SKILL always returned nil). All three make
+        // Virtuoso fail. The correct form quotes the path, uses the 3-arg if,
+        // and checks `isFile` AFTER `system`.
         let ops = WindowOps;
         let skill = ops.screenshot("/tmp/screen.png");
         assert!(
@@ -222,12 +224,22 @@ mod tests {
             "path must be quoted as a SKILL string literal, got: {skill}"
         );
         assert!(
-            skill.contains("if(ok \"/tmp/screen.png\" nil)"),
+            skill.contains("if(isFile(\"/tmp/screen.png\") \"/tmp/screen.png\" nil)"),
             "must use 3-arg if form without else keyword, got: {skill}"
         );
         assert!(
             !skill.contains("else nil"),
             "must not emit `else` in 3-arg if, got: {skill}"
+        );
+        // isFile must come after system(cmd) so it probes the file the
+        // capture just created.
+        let sys_pos = skill.find("system(cmd)").expect("must call system(cmd)");
+        let isfile_pos = skill
+            .find("isFile(")
+            .expect("must check isFile after system");
+        assert!(
+            sys_pos < isfile_pos,
+            "isFile must run AFTER system(cmd), got: {skill}"
         );
     }
 

--- a/src/client/window_ops.rs
+++ b/src/client/window_ops.rs
@@ -94,7 +94,7 @@ impl WindowOps {
     /// error`.
     fn skill_capture(path_escaped: &str) -> String {
         format!(
-            r#"let((cmd ok) cmd = strcat("import -window root -silent " "{path}") ok = fileexists("{path}") system(cmd) if(ok "{path}" nil)"#,
+            r#"let((cmd ok) cmd = strcat("import -window root -silent " "{path}") ok = isFile("{path}") system(cmd) if(ok "{path}" nil)"#,
             path = path_escaped
         )
     }
@@ -204,7 +204,7 @@ mod tests {
             skill.contains("import -window root -silent"),
             "should use import"
         );
-        assert!(skill.contains("fileexists"), "should verify file");
+        assert!(skill.contains("isFile"), "should verify file with isFile");
     }
 
     #[test]
@@ -218,7 +218,7 @@ mod tests {
         let ops = WindowOps;
         let skill = ops.screenshot("/tmp/screen.png");
         assert!(
-            skill.contains("fileexists(\"/tmp/screen.png\")"),
+            skill.contains("isFile(\"/tmp/screen.png\")"),
             "path must be quoted as a SKILL string literal, got: {skill}"
         );
         assert!(

--- a/src/client/window_ops.rs
+++ b/src/client/window_ops.rs
@@ -85,9 +85,16 @@ impl WindowOps {
 
     /// SKILL fragment: run X11 import and return path on success, nil on failure.
     /// This uses `import` from ImageMagick, which is always available on Linux.
+    ///
+    /// `path_escaped` is the raw (quote-escaped) path from
+    /// `escape_skill_string`; it must be wrapped in SKILL string quotes here
+    /// (as `load("{path}")` does), otherwise `/path/x.png` parses as an
+    /// invalid identifier. The success check uses the 3-arg `if(cond t e)`
+    /// form — SKILL rejects `if(cond t else e)` with a `lineread/read: syntax
+    /// error`.
     fn skill_capture(path_escaped: &str) -> String {
         format!(
-            r#"let((cmd ok) cmd = strcat("import -window root -silent " {path}) ok = fileexists({path}) system(cmd) if(ok {path} else nil)"#,
+            r#"let((cmd ok) cmd = strcat("import -window root -silent " "{path}") ok = fileexists("{path}") system(cmd) if(ok "{path}" nil)"#,
             path = path_escaped
         )
     }
@@ -198,6 +205,30 @@ mod tests {
             "should use import"
         );
         assert!(skill.contains("fileexists"), "should verify file");
+    }
+
+    #[test]
+    fn screenshot_skill_uses_three_arg_if_and_quoted_path() {
+        // Regression: skill_capture previously emitted `if(ok {path} else nil)`
+        // (mixing the 3-arg if form with the `else` keyword) AND left {path}
+        // unquoted (`escape_skill_string` returns a bare escaped string).
+        // Both make Virtuoso fail with "lineread/read: syntax error" when the
+        // SKILL is evaluated. The correct form quotes the path and uses the
+        // 3-arg if without the `else` keyword.
+        let ops = WindowOps;
+        let skill = ops.screenshot("/tmp/screen.png");
+        assert!(
+            skill.contains("fileexists(\"/tmp/screen.png\")"),
+            "path must be quoted as a SKILL string literal, got: {skill}"
+        );
+        assert!(
+            skill.contains("if(ok \"/tmp/screen.png\" nil)"),
+            "must use 3-arg if form without else keyword, got: {skill}"
+        );
+        assert!(
+            !skill.contains("else nil"),
+            "must not emit `else` in 3-arg if, got: {skill}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 背景
`vcli window screenshot`（SKILL 路径）在任何真实 Virtuoso 上都稳定失败，报错：
```
lineread/read: syntax error encountered in input at line 1 column 117 in file *ciwInPort*
```
排查确认：**生产 daemon 桥接正常**（`vcli skill exec '1+1'` 返回 `2`），根因在 vcli 自身生成的 SKILL 代码（`src/client/window_ops.rs::skill_capture`）有两处语法错误。

## 根因
`skill_capture` 生成的 SKILL：
```skill
let((cmd ok) cmd = strcat("import -window root -silent " {path}) ok = fileexists({path}) system(cmd) if(ok {path} else nil)
```
1. **{path} 未加引号**：`escape_skill_string` 返回的是裸（已转义）字符串，必须用 SKILL 字符串字面量包裹（同 `build_bootstrap_skill` 的 `load("{path}")` 模式）。`/tmp/x.png` 裸出现会被解析为非法标识符 → 语法错误。
2. **`if(ok {path} else nil)` 混用 else 关键字**：SKILL 的三参数 if 形式是 `if(cond t e)`，不支持 `else` 关键字（那是 then/else 多语句形式）→ 语法错误。

## 修复
```skill
let((cmd ok) cmd = strcat("import -window root -silent " "{path}") ok = fileexists("{path}") system(cmd) if(ok "{path}" nil)
```
路径加引号 + 三参数 if。`screenshot_by_pattern` 内嵌 `skill_capture`，一并修复。

## 测试
新增 `screenshot_skill_uses_three_arg_if_and_quoted_path` 回归测试（断言引号路径 + 三参数 if + 无 `else nil`）。既有测试仅检查子串存在、未查 SKILL 语法，故未捕获此 bug。

## 验证
需在云电脑重编译 vcli 后对生产 Virtuoso 实测 `window screenshot`（此前 100% 失败）。
