### PR TITLE
fix(x11): dismiss segfault — set ctypes argtypes so 64-bit Display* isn't truncated

### DIFF
--- a/resources/x11_dismiss_dialog.py
+++ b/resources/x11_dismiss_dialog.py
@@ -477,6 +477,27 @@ def dismiss_window(display, win_id_str, action, title="", target_is_explicit=Fal
 
     xlib = ctypes.cdll.LoadLibrary(xlib_path)
     xtst = ctypes.cdll.LoadLibrary(xtst_path)
+    # Explicit ctypes signatures are mandatory: without argtypes/restype,
+    # ctypes defaults every argument to a 32-bit C int, truncating the 64-bit
+    # Display* returned by XOpenDisplay. Every X call below then dereferences a
+    # corrupted pointer -> SIGSEGV (exit 139) on 64-bit hosts. See issue "fix:
+    # dismiss-window-x11 / dismiss-dialog segfault".
+    _XDisplay = ctypes.c_void_p
+    _XID = ctypes.c_ulong
+    xlib.XOpenDisplay.argtypes = [ctypes.c_char_p]
+    xlib.XOpenDisplay.restype = _XDisplay
+    xlib.XFlush.argtypes = [_XDisplay]
+    xlib.XFlush.restype = ctypes.c_int
+    xlib.XCloseDisplay.argtypes = [_XDisplay]
+    xlib.XCloseDisplay.restype = ctypes.c_int
+    xlib.XRaiseWindow.argtypes = [_XDisplay, _XID]
+    xlib.XRaiseWindow.restype = ctypes.c_int
+    xlib.XSetInputFocus.argtypes = [_XDisplay, _XID, ctypes.c_int, ctypes.c_ulong]
+    xlib.XSetInputFocus.restype = ctypes.c_int
+    xlib.XKeysymToKeycode.argtypes = [_XDisplay, ctypes.c_ulong]
+    xlib.XKeysymToKeycode.restype = ctypes.c_uint
+    xtst.XTestFakeKeyEvent.argtypes = [_XDisplay, ctypes.c_uint, ctypes.c_int, ctypes.c_ulong]
+    xtst.XTestFakeKeyEvent.restype = ctypes.c_int
     dpy = xlib.XOpenDisplay(None)
     if not dpy:
         raise RuntimeError("cannot open display %s" % display)


### PR DESCRIPTION
## Problem

`vcli window dismiss-dialog` and `vcli window dismiss-window-x11` both **crash with SIGSEGV (exit 139)** on 64-bit hosts. The X11 dismiss helper (`resources/x11_dismiss_dialog.py::dismiss_window`) calls libX11/libXtst through raw `ctypes` with **no `argtypes`/`restype` declared**.

ctypes then defaults every argument to a 32-bit C `int`, truncating the 64-bit `Display*` returned by `XOpenDisplay`. Every subsequent X call (`XKeysymToKeycode`, `XTestFakeKeyEvent`, `XRaiseWindow`, `XSetInputFocus`, `XFlush`, `XCloseDisplay`) dereferences a corrupted pointer → SIGSEGV.

**Reproduced on** production Virtuoso `:5.0` and isolated Xvfb `:99` — both crash identically. `find-dialogs` is unaffected (no ctypes use).

## Fix

Declare explicit `argtypes`/`restype` for every libX11/libXtst entry point before use. Correctness fix only — no behavior change on 32-bit hosts (where the default int truncation happened to be a no-op).

## Verification

- `cargo build` / `cargo clippy` clean
- `cargo test --lib x11`: 95 passed (incl. existing dismiss tests)
- Requires on-box confirm after merge: dismiss enter/escape/alt-y/alt-n/alt-o no longer segfault (currently blocked by the SIGSEGV, so tests can't exercise the helper end-to-end in CI)
