### PR TITLE
fix(gui): boundary batch — multi-window disambiguation, dismiss default, type ASCII, key validation, timeout, close

### DIFF
--- a/src/commands/window.rs
+++ b/src/commands/window.rs
@@ -365,6 +365,7 @@ pub fn action_x11(
     text: Option<&str>,
     button: Option<u8>,
     output_dir: Option<&str>,
+    timeout_secs: u64,
     explicit_display: Option<&str>,
 ) -> Result<Value> {
     use crate::config::Config;
@@ -391,7 +392,7 @@ pub fn action_x11(
         button,
         text,
         output_dir,
-        timeout_secs: 30,
+        timeout_secs,
     };
     let result = x11::action_x11(runner.as_ref(), &client_id, user, &inputs)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1445,8 +1445,8 @@ enum WindowCmd {
 
     /// Dismiss the currently active blocking dialog
     DismissDialog {
-        /// Action to take: cancel (default) or ok
-        #[arg(long, default_value = "cancel")]
+        /// Action to send: enter | escape | alt-y | alt-n | alt-o (default: escape)
+        #[arg(long, default_value = "escape")]
         action: String,
         /// Report dialog name without clicking
         #[arg(long)]
@@ -1513,7 +1513,7 @@ enum WindowCmd {
         /// DISPLAY value (e.g. :0, :1)
         #[arg(long)]
         display: String,
-        /// Operation: activate | key | type | click-rel | drag-rel | screenshot | wait
+        /// Operation: activate | key | type | click-rel | drag-rel | screenshot | wait | close
         #[arg(long)]
         operation: String,
         /// Relative X coordinate (for click-rel, drag-rel). Negative values are
@@ -1534,6 +1534,10 @@ enum WindowCmd {
         /// Output directory for screenshots
         #[arg(long)]
         output_dir: Option<String>,
+        /// Timeout in seconds for the operation (default: 30). For `wait`, this
+        /// is the maximum time to poll for the title pattern before giving up.
+        #[arg(long, default_value = "30")]
+        timeout: u64,
         /// Override the detected DISPLAY
         #[arg(long)]
         display_override: Option<String>,
@@ -2124,6 +2128,7 @@ fn dispatch_window(cmd: WindowCmd) -> error::Result<serde_json::Value> {
             button,
             text,
             output_dir,
+            timeout,
             display_override,
         } => commands::window::action_x11(
             &window_id,
@@ -2135,6 +2140,7 @@ fn dispatch_window(cmd: WindowCmd) -> error::Result<serde_json::Value> {
             text.as_deref(),
             button,
             output_dir.as_deref(),
+            timeout,
             display_override.as_deref(),
         ),
     }

--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -641,6 +641,7 @@ pub enum X11Operation {
     DragRel,
     Screenshot,
     Wait,
+    Close,
 }
 
 impl X11Operation {
@@ -654,8 +655,9 @@ impl X11Operation {
             "drag-rel" => Ok(Self::DragRel),
             "screenshot" => Ok(Self::Screenshot),
             "wait" => Ok(Self::Wait),
+            "close" => Ok(Self::Close),
             _ => Err(VirtuosoError::Config(format!(
-                "unknown operation '{}': must be one of activate|key|type|click-rel|drag-rel|screenshot|wait",
+                "unknown operation '{}': must be one of activate|key|type|click-rel|drag-rel|screenshot|wait|close",
                 s
             ))),
         }
@@ -670,6 +672,7 @@ impl X11Operation {
             Self::DragRel => "drag-rel",
             Self::Screenshot => "screenshot",
             Self::Wait => "wait",
+            Self::Close => "close",
         }
     }
 }
@@ -715,7 +718,7 @@ pub fn validate_action_params(
 
     // Operation-specific validation
     match op {
-        X11Operation::Activate => {
+        X11Operation::Activate | X11Operation::Close => {
             // no extra params beyond the common ones
         }
         X11Operation::Screenshot => {
@@ -806,6 +809,7 @@ pub fn validate_action_params(
             // wait uses a condition expression in --text; validated by the caller
             None
         }
+        X11Operation::Close => None,
     };
 
     Ok(details.unwrap_or_default())
@@ -928,19 +932,48 @@ pub fn action_x11(
 
     let windows = parse_window_list(&out.stdout, display, env.xauthority.as_ref());
 
-    // Step 2: Resolve unique window with strict PID + DISPLAY matching
-    let resolved = resolve_unique_window(&windows, *pid, display, None)?;
+    // Step 2: Resolve the target window. When an explicit window_id is given,
+    // match by id + PID + DISPLAY directly — this disambiguates multiple windows
+    // sharing one PID (common in Virtuoso: CIW + tool windows same process).
+    // Without window_id, fall back to resolve_unique_window which errors on
+    // multi-window ambiguity.
+    let resolved = if !window_id.is_empty() {
+        let wid = *window_id;
+        let matched: Vec<&WindowInfo> = windows
+            .iter()
+            .filter(|w| {
+                w.pid == Some(*pid)
+                    && w.display.as_deref() == Some(display)
+                    && (w.window_id == wid || w.dismiss_id == wid || w.frame_id == wid)
+            })
+            .collect();
+        match matched.len() {
+            0 => {
+                return Err(VirtuosoError::NotFound(format!(
+                    "no window with id '{window_id}' matching PID={pid} DISPLAY={display}"
+                )))
+            }
+            1 => matched.into_iter().next().unwrap().clone(),
+            _ => {
+                return Err(VirtuosoError::Conflict(format!(
+                    "multiple windows matching id '{window_id}' PID={pid} DISPLAY={display}",
+                )))
+            }
+        }
+    } else {
+        resolve_unique_window(&windows, *pid, display, None)?
+    };
 
-    // Step 3: Verify exact window_id match. A requested id that resolves to a
-    // different window means the caller referenced a window that does not exist
-    // (or no longer matches this pid) — NotFound, not a multi-window ambiguity.
-    if resolved.window_id != *window_id
+    // Step 3 (legacy): verify the resolved window matches the requested id.
+    // When window_id drove the match in Step 2 this is a no-op.
+    if !window_id.is_empty()
+        && resolved.window_id != *window_id
         && resolved.dismiss_id != *window_id
         && resolved.frame_id != *window_id
     {
         return Err(VirtuosoError::NotFound(format!(
-            "no window with id '{window_id}' matching PID={pid} DISPLAY={display} (resolved to '{}')",
-            resolved.window_id
+            "no window with id '{}' matching PID={pid} DISPLAY={display} (resolved to '{}')",
+            window_id, resolved.window_id
         )));
     }
 
@@ -1143,6 +1176,24 @@ pub fn action_x11(
     };
 
     let duration_ms = start.elapsed().as_millis() as u64;
+
+    // P2-1: xdotool key exits 0 even for invalid key names (it only prints
+    // "No such key name '...'. Ignoring it." to stderr). Detect that explicitly
+    // so the caller gets a real error instead of a false success.
+    if operation == X11Operation::Key {
+        for out in &results {
+            if out.stderr.contains("No such key name") {
+                let detail = out
+                    .stderr
+                    .lines()
+                    .find(|l| l.contains("No such key name"))
+                    .unwrap_or("")
+                    .trim();
+                return Err(VirtuosoError::Config(format!("invalid key name: {detail}")));
+            }
+        }
+    }
+
     // wait's success is the match outcome (matched within timeout), not the
     // exit status of the last polling helper run.
     let success = if operation == X11Operation::Wait {
@@ -1154,7 +1205,9 @@ pub fn action_x11(
     // Build sanitized details
     let details = match operation {
         X11Operation::Activate => None,
-        X11Operation::Key | X11Operation::Type => Some(format!(
+        X11Operation::Close => None,
+        X11Operation::Key => Some(format!("key: {}", text.unwrap_or(""))),
+        X11Operation::Type => Some(format!(
             "text_length: {}",
             text.map(|s| s.len()).unwrap_or(0)
         )),
@@ -1251,6 +1304,17 @@ fn build_xdotool_actions(
             // xdotool type --window <id> -- <text>
             let t =
                 text.ok_or_else(|| VirtuosoError::Config("type operation requires --text".into()))?;
+            // xdotool type drives XTestFakeKeyEvent and only supports ASCII
+            // keysyms. Non-ASCII text (CJK, emoji, full-width) is silently
+            // dropped by xdotool — detect it upfront and fail loudly instead
+            // of reporting a false success.
+            if !t.is_ascii() {
+                return Err(VirtuosoError::Config(format!(
+                    "type operation supports ASCII only; got non-ASCII text ({} bytes). \
+                     Use clipboard paste (xclip + ctrl+v) for non-ASCII input",
+                    t.len()
+                )));
+            }
             Ok(vec![(
                 "type".into(),
                 vec!["type".into(), "--window".into(), wid, "--".into(), t.into()],
@@ -1335,6 +1399,14 @@ fn build_xdotool_actions(
                     vec!["mouseup".into(), "--window".into(), wid, btn],
                 ),
             ])
+        }
+        X11Operation::Close => {
+            // Close the window via Alt+F4 (standard WM close shortcut). xdotool
+            // cannot send WM_DELETE directly, so Alt+F4 is the portable path.
+            Ok(vec![(
+                "key".into(),
+                vec!["key".into(), "--window".into(), wid, "alt+F4".into()],
+            )])
         }
         X11Operation::Screenshot | X11Operation::Wait => {
             // Handled specially in action_x11, not via xdotool


### PR DESCRIPTION
## Summary

Fixes all actionable items from the GUI capability boundary test (2026-09-03): 3 P1, 3 P2 (2 verified non-bugs), 2 P3, plus 1 new operation.

### P1-1 — multi-window PID disambiguation
`action-x11` now resolves by `window_id + PID + DISPLAY` directly when `--window-id` is given. Previously `resolve_unique_window` raised `Conflict` before the window-id check ran, making it impossible to target any window when a Virtuoso process had multiple windows (CIW + tool windows same PID).

### P1-2 + P3-1 — dismiss-dialog default action
`--action` default changed from `cancel` (invalid) to `escape`; help text corrected. `dismiss-window-x11` already defaulted to `enter`.

### P1-3 — type non-ASCII rejection
`type` now rejects non-ASCII text with a clear `config_error`. `xdotool type` only supports ASCII keysyms; CJK/emoji was silently dropped while reporting success.

### P2-1 — invalid key name detection
`key` now checks xdotool stderr for `No such key name` and reports `config_error` instead of false success (xdotool exits 0 on bad key names).

### P3-2 — key details
`key` operation details now show `key: <name>` instead of `text_length: N`.

### P2-3 — configurable timeout
`action-x11` gains `--timeout` flag (default 30s). For `wait`, this is the maximum poll duration.

### P2-6 (partial) — close operation
New `close` operation sends `Alt+F4` to the target window.

### Verified non-bugs
- **P2-2** click-rel bounds: geometry corresponds to the same `window_id` xdotool uses; bounds are self-consistent.
- **P2-4** list-windows geometry: already present under nested `geometry` key (test script was reading flat `w`/`h`).

## Remaining (opened as issues)
- P2-5 SKILL reflection depth (only 1/3 windows, kind=unknown)
- P2-6 absolute-click / minimize / maximize / double-click
- P3-3 windows without `_NET_WM_PID` cannot be operated on

## Verification
- `cargo build` / `cargo clippy`: clean (0 warnings)
- `cargo test --lib x11`: 95 passed
- On-box (post-merge): multi-window PID disambiguation, type non-ASCII rejection, close operation, custom timeout
