### PR TITLE
fix(gui): stress-test boundary fixes — dismiss-dialog false positive, --window-id, wait empty pattern, dismissed geometry

### DIFF
--- a/resources/x11_dismiss_dialog.py
+++ b/resources/x11_dismiss_dialog.py
@@ -37,6 +37,10 @@ MAX_DIALOG_HEIGHT = 420
 MAX_DIALOG_WHEN_LARGE_WIDTH = 1000
 MAX_DIALOG_WHEN_LARGE_HEIGHT = 300
 MIN_DIALOG_DIM = 20
+# For NORMAL/unknown windows (no explicit DIALOG type or transient hint), the
+# geometric fallback must reject wide-and-shallow tool windows (e.g. "Bus Style
+# Tools" 720x275 = 2.62 aspect). Real dialogs are roughly square-ish.
+MAX_NORMAL_DIALOG_ASPECT = 2.2
 
 VALID_ACTIONS = ("enter", "escape", "alt-y", "alt-n", "alt-o")
 TITLE_ACTIONS = (
@@ -207,6 +211,13 @@ def find_dialogs(display):
                 mapped = True
         if not mapped:
             continue
+        # For NORMAL/unknown windows (semantic fallback), reject wide-and-shallow
+        # tool windows by aspect ratio. Explicit DIALOG/transient windows bypass
+        # this check — they are dialogs by definition regardless of shape.
+        if semantic is None:
+            aspect = w / float(h) if h > 0 else 0
+            if aspect > MAX_NORMAL_DIALOG_ASPECT:
+                continue
         dialogs.append({
             "window_id": win_id,
             "title": child_title,
@@ -712,6 +723,13 @@ def main():
                     )
                 except (RuntimeError, ValueError) as exc:
                     result = {"error": str(exc), "window_id": d["window_id"]}
+                # Backfill geometry from find_dialogs — dismiss_window's return
+                # value carries identity/action fields but not x/y/w/h, which
+                # callers need for audit logging and post-dismiss verification.
+                if "error" not in result:
+                    for geom_key in ("x", "y", "w", "h"):
+                        if geom_key in d and geom_key not in result:
+                            result[geom_key] = d[geom_key]
                 print(json.dumps(result))
     sys.exit(0)
 

--- a/src/commands/window.rs
+++ b/src/commands/window.rs
@@ -202,6 +202,7 @@ pub fn dismiss_dialog_x11(
     action: &str,
     dry_run: bool,
     explicit_display: Option<&str>,
+    window_id: Option<&str>,
 ) -> Result<Value> {
     use crate::config::Config;
     use crate::transport::x11;
@@ -222,6 +223,7 @@ pub fn dismiss_dialog_x11(
         explicit_display,
         action,
         dry_run,
+        window_id,
     )?;
     let mut out = serde_json::to_value(&result)
         .map_err(|e| VirtuosoError::Execution(format!("failed to serialize X11 result: {e}")))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1458,6 +1458,11 @@ enum WindowCmd {
         /// Override the detected DISPLAY (X11 bypass only).
         #[arg(long)]
         display: Option<String>,
+        /// Dismiss only the dialog belonging to this window id (frame/app/child
+        /// id from `list-windows-x11`). Without this, all detected dialogs are
+        /// dismissed. X11 bypass only.
+        #[arg(long)]
+        window_id: Option<String>,
     },
 
     /// List dialogs visible via X11 SSH bypass (no keypress sent)
@@ -2097,9 +2102,15 @@ fn dispatch_window(cmd: WindowCmd) -> error::Result<serde_json::Value> {
             dry_run,
             x11,
             display,
+            window_id,
         } => {
             if x11 {
-                commands::window::dismiss_dialog_x11(&action, dry_run, display.as_deref())
+                commands::window::dismiss_dialog_x11(
+                    &action,
+                    dry_run,
+                    display.as_deref(),
+                    window_id.as_deref(),
+                )
             } else {
                 commands::window::dismiss_dialog(&action, dry_run)
             }

--- a/src/rpc/dispatcher.rs
+++ b/src/rpc/dispatcher.rs
@@ -588,7 +588,8 @@ impl RpcDispatcher {
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
                 let display = params.get("display").and_then(|v| v.as_str());
-                crate::commands::window::dismiss_dialog_x11(&action, dry_run, display)
+                let window_id = params.get("window_id").and_then(|v| v.as_str());
+                crate::commands::window::dismiss_dialog_x11(&action, dry_run, display, window_id)
             }
             "list_windows_x11" => {
                 // Enumerate every Virtuoso-related X11 window (no keypress).

--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -409,7 +409,14 @@ pub fn list_dialogs(
     let mut dialogs = Vec::new();
     for env in &envs {
         let display = env.display.as_deref().unwrap_or("");
-        let cmd = build_helper_cmd(&helper, display, env.xauthority.as_deref(), false, "enter");
+        let cmd = build_helper_cmd(
+            &helper,
+            display,
+            env.xauthority.as_deref(),
+            false,
+            "enter",
+            None,
+        );
         let out = runner.run_command(&CommandRequest::with_exec_timeout(
             &cmd,
             Duration::from_secs(30),
@@ -453,6 +460,7 @@ pub fn dismiss(
     explicit_display: Option<&str>,
     action: &str,
     dry_run: bool,
+    window_id: Option<&str>,
 ) -> Result<DismissResult> {
     let helper = ensure_helper_uploaded(runner, user, client_id)?;
     let mut found = Vec::new();
@@ -468,6 +476,7 @@ pub fn dismiss(
             env.xauthority.as_deref(),
             !dry_run,
             action,
+            window_id,
         );
         let out = runner.run_command(&CommandRequest::with_exec_timeout(
             &cmd,
@@ -774,7 +783,17 @@ pub fn validate_action_params(
             }
         }
         X11Operation::Wait => {
-            // wait condition (in --text) is evaluated by the caller's polling loop
+            // wait condition (in --text) is evaluated by the caller's polling loop;
+            // an empty pattern matches every title (substring match) so reject it
+            // to avoid immediate false-positive matches.
+            let t = text.ok_or_else(|| {
+                VirtuosoError::Config("operation 'wait' requires --text parameter".into())
+            })?;
+            if t.is_empty() {
+                return Err(VirtuosoError::Config(
+                    "operation 'wait' requires non-empty --text (empty pattern matches every window)".into(),
+                ));
+            }
         }
     }
 
@@ -1659,12 +1678,20 @@ fn build_helper_cmd(
     xauthority: Option<&str>,
     do_dismiss: bool,
     action: &str,
+    window_id: Option<&str>,
 ) -> String {
     // Quote the remote path with single quotes; the helper is ASCII so this is safe.
     let mut s = format!("python3 '{}'", helper_remote_path);
     s.push(' ');
     s.push_str(&shell_escape(display));
-    if do_dismiss {
+    if let Some(wid) = window_id {
+        // Explicit target: bypass the dialog-size filter and dismiss this window
+        // directly (frame/app/child id all accepted by the helper).
+        s.push_str(" --dismiss-window ");
+        s.push_str(&shell_escape(wid));
+        s.push_str(" --action ");
+        s.push_str(action);
+    } else if do_dismiss {
         s.push_str(" --dismiss");
         s.push_str(" --action ");
         s.push_str(action);
@@ -2167,6 +2194,7 @@ mod tests {
             None,
             true,
             "alt-o",
+            None,
         );
         assert!(cmd.contains("'/tmp/virtuoso_bridge/x/x11_dismiss_dialog_abc.py'"));
         assert!(cmd.contains("--dismiss"));
@@ -2176,8 +2204,23 @@ mod tests {
 
     #[test]
     fn build_helper_cmd_propagates_xauthority_when_set() {
-        let cmd = build_helper_cmd("/h.py", ":0", Some("/tmp/.X11-unix/X0"), false, "enter");
+        let cmd = build_helper_cmd(
+            "/h.py",
+            ":0",
+            Some("/tmp/.X11-unix/X0"),
+            false,
+            "enter",
+            None,
+        );
         assert!(cmd.contains("XAUTHORITY=/tmp/.X11-unix/X0"));
+    }
+
+    #[test]
+    fn build_helper_cmd_explicit_window_id_uses_dismiss_window_flag() {
+        let cmd = build_helper_cmd("/h.py", ":0", None, true, "escape", Some("0x2603394"));
+        assert!(cmd.contains("--dismiss-window 0x2603394"));
+        assert!(cmd.contains("--action escape"));
+        assert!(!cmd.contains("--dismiss "));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes all 4 issues found in the 2026-09-03 stress-test boundary exploration (20 extreme scenarios on production Virtuoso :5.0).

### P1 — dismiss-dialog false positive on NORMAL tool windows
The geometric fallback classified "Bus Style Tools" (720x275, NORMAL, no transient) as a dialog. Added `MAX_NORMAL_DIALOG_ASPECT=2.2` check for `semantic=None` windows. Explicit DIALOG/transient windows bypass the aspect check.

### P2 — dismiss-dialog gains `--window-id`
Target a specific window (frame/app/child id from `list-windows-x11`), bypassing the dialog-size filter. Propagates through `dismiss_dialog_x11` → `x11::dismiss` → `build_helper_cmd` (`--dismiss-window` flag). RPC dispatcher updated.

### P2 — wait rejects empty pattern
`wait --text ""` previously matched immediately (empty substring is in every title). Now returns `config_error`, consistent with type/key non-empty validation.

### P3 — dismissed array geometry backfill
`dismissed` entries now carry `x/y/w/h` from `find_dialogs`, instead of defaulting to 0. `found` and `dismissed` arrays report consistent geometry.

## Verification
- `cargo build` / `cargo clippy`: clean (0 warnings)
- `cargo test --lib x11`: 96 passed (+1 new test for `--dismiss-window` flag)
- `python3 -m unittest tests.docs.test_x11_dismiss_dialog`: 26 passed
- On-box (post-merge): dismiss-dialog no longer matches Bus Style Tools; `--window-id` targets specific window; wait empty pattern rejected; dismissed geometry populated
