### PR TITLE
fix(gui): dialog_info_from_dismiss_value reads x/y/w/h from helper output

### DIFF
--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -1616,10 +1616,10 @@ fn dialog_info_from_dismiss_value(
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string(),
-        x: 0,
-        y: 0,
-        w: 0,
-        h: 0,
+        x: val.get("x").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+        y: val.get("y").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+        w: val.get("w").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
+        h: val.get("h").and_then(|v| v.as_i64()).unwrap_or(0) as i32,
         child: val
             .get("child")
             .and_then(|v| v.as_str())


### PR DESCRIPTION
Follow-up to #56/#57: the helper now emits x/y/w/h in dismiss_window results, but `dialog_info_from_dismiss_value()` hardcoded them to 0. Now reads from the JSON value. On-box `dismiss-dialog --window-id <id> --dry-run` reports actual geometry.