### PR TITLE
fix(gui): set DISPLAY env before xwininfo reachability check

### DIFF
--- a/resources/x11_dismiss_dialog.py
+++ b/resources/x11_dismiss_dialog.py
@@ -709,6 +709,7 @@ def main():
     # Verify the X display is actually reachable before enumerating or acting.
     # Without this, xwininfo failures inside discover_windows are swallowed and
     # the caller sees an empty window list — indistinguishable from "no windows".
+    os.environ["DISPLAY"] = display
     try:
         subprocess.check_output(
             ["xwininfo", "-root"],


### PR DESCRIPTION
Regression fix for #59: the xwininfo -root display check ran before setting os.environ['DISPLAY'], so it always failed on non-default DISPLAYs like :99. Set DISPLAY first.