### PR TITLE
fix(gui): extend minimized-window support to screenshot and dismiss-dialog

### DIFF
--- a/resources/x11_dismiss_dialog.py
+++ b/resources/x11_dismiss_dialog.py
@@ -243,10 +243,35 @@ def _find_app_child(display, frame_id_str):
 
 
 def _find_window_by_id(display, win_id_str):
-    """Resolve a frame/app/child id to the canonical discover_windows entry."""
+    """Resolve a frame/app/child id to the canonical discover_windows entry.
+
+    Falls back to xdotool getwindowname for minimized/unmapped windows that
+    discover_windows filters out (it skips windows with mapped=False). This
+    lets dismiss-window target windows that were minimized between the
+    list-windows snapshot and the dismiss call.
+    """
     for w in discover_windows(display):
         if win_id_str in (w.get("frame_id"), w.get("window_id"), w.get("dismiss_id")):
             return w
+    # xdotool fallback for minimized/unmapped windows.
+    try:
+        title = subprocess.check_output(
+            ["xdotool", "getwindowname", win_id_str],
+            stderr=subprocess.PIPE,
+        ).decode("utf-8", "replace").strip()
+        if title:
+            return {
+                "frame_id": win_id_str,
+                "window_id": win_id_str,
+                "dismiss_id": win_id_str,
+                "title": title,
+                "class": [],
+                "pid": None,
+                "visible": False,
+                "geometry": {"x": 0, "y": 0, "w": 0, "h": 0},
+            }
+    except (subprocess.CalledProcessError, OSError):
+        pass
     return None
 
 

--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -1080,6 +1080,23 @@ pub fn action_x11(
         let token = Uuid::new_v4();
         let safe_name = format!("vcli_shot_{token}.png");
         let remote_path = format!("/tmp/{safe_name}");
+        // If the window was resolved via the xdotool fallback (minimized or
+        // unmapped), ImageMagick `import -window` cannot capture it — restore
+        // it first with windowactivate, which maps and raises the window.
+        // This is best-effort: if activate fails, the import will report the
+        // original error rather than masking it.
+        if !resolved.visible {
+            let activate_cmd = format!(
+                "{}xdotool windowactivate {}",
+                display_prefix,
+                shell_escape(&resolved.window_id)
+            );
+            let _ = runner.run_command(&CommandRequest::with_exec_timeout(
+                &activate_cmd,
+                Duration::from_secs(5),
+            ));
+            std::thread::sleep(Duration::from_millis(150));
+        }
         let remote_cmd = format!(
             "{}import -window {} {}",
             display_prefix,


### PR DESCRIPTION
The P2 xdotool fallback (#59) let action-x11 key/click/type operate on minimized windows, but screenshot and dismiss-dialog still failed:

1. **screenshot**: ImageMagick `import -window` cannot capture unmapped windows. Now auto-restores via `xdotool windowactivate` before import when resolved.visible=false.
2. **dismiss-dialog --window-id**: helper `_find_window_by_id` only searched discover_windows (skips unmapped). Now falls back to `xdotool getwindowname` for minimized windows.