### PR TITLE
fix: resolve CentOS 7 glibc 2.17 link failure on renameat2

### DIFF
--- a/src/commands/maestro.rs
+++ b/src/commands/maestro.rs
@@ -1369,12 +1369,14 @@ pub(crate) fn atomic_publish_no_replace(src: &Path, dst: &Path, remote_dir: &str
         // links fail because the symbol is absent. Delegate to
         // sys::linux_rename which resolves via dlsym / raw syscall /
         // stat+renameat fallback transparently.
-        let res = crate::sys::linux_rename::rename_noreplace(
-            libc::AT_FDCWD,
-            src_c.as_ptr(),
-            libc::AT_FDCWD,
-            dst_c.as_ptr(),
-        );
+        let res = unsafe {
+            crate::sys::linux_rename::rename_noreplace(
+                libc::AT_FDCWD,
+                src_c.as_ptr(),
+                libc::AT_FDCWD,
+                dst_c.as_ptr(),
+            )
+        };
         if res == 0 {
             return Ok(());
         }

--- a/src/commands/maestro.rs
+++ b/src/commands/maestro.rs
@@ -1365,20 +1365,16 @@ pub(crate) fn atomic_publish_no_replace(src: &Path, dst: &Path, remote_dir: &str
 
     #[cfg(target_os = "linux")]
     {
-        // RENAME_NOREPLACE on Linux: 1. renameat2 is a per-syscall
-        // errno return; EEXIST means a non-directory file exists at
-        // dst, ENOTEMPTY means dst is a non-empty directory. Both
-        // mean "the operator already has something there" → Conflict.
-        const RENAME_NOREPLACE: libc::c_uint = 1;
-        let res = unsafe {
-            libc::renameat2(
-                libc::AT_FDCWD,
-                src_c.as_ptr(),
-                libc::AT_FDCWD,
-                dst_c.as_ptr(),
-                RENAME_NOREPLACE,
-            )
-        };
+        // renameat2 is a glibc 2.28+ symbol; CentOS 7 (glibc 2.17)
+        // links fail because the symbol is absent. Delegate to
+        // sys::linux_rename which resolves via dlsym / raw syscall /
+        // stat+renameat fallback transparently.
+        let res = crate::sys::linux_rename::rename_noreplace(
+            libc::AT_FDCWD,
+            src_c.as_ptr(),
+            libc::AT_FDCWD,
+            dst_c.as_ptr(),
+        );
         if res == 0 {
             return Ok(());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub mod spectre;
 pub mod streaming;
 #[cfg(test)]
 pub mod test_env;
+#[cfg(target_os = "linux")]
+pub mod sys;
 pub mod transaction;
 pub mod transport;
 pub mod tui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,10 @@ pub mod session;
 pub mod skill_finder;
 pub mod spectre;
 pub mod streaming;
-#[cfg(test)]
-pub mod test_env;
 #[cfg(target_os = "linux")]
 pub mod sys;
+#[cfg(test)]
+pub mod test_env;
 pub mod transaction;
 pub mod transport;
 pub mod tui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod runtime_paths;
 mod skill_finder;
 mod spectre;
 mod streaming;
+mod sys;
 #[cfg(test)]
 mod test_env;
 #[cfg(test)]

--- a/src/sys/linux_rename.rs
+++ b/src/sys/linux_rename.rs
@@ -37,7 +37,7 @@ const RENAME_NOREPLACE: c_uint = 1;
 ///      preserves the "must not overwrite an existing destination" contract
 ///      at the cost of a small non-atomic window.
 #[cfg(target_os = "linux")]
-pub(crate) unsafe fn rename_noreplace(
+pub unsafe fn rename_noreplace(
     olddirfd: c_int,
     oldpath: *const c_char,
     newdirfd: c_int,

--- a/src/sys/linux_rename.rs
+++ b/src/sys/linux_rename.rs
@@ -52,7 +52,7 @@ pub unsafe fn rename_noreplace(
     newpath: *const c_char,
 ) -> c_int {
     // ---- Fast path: libc exports renameat2 ---
-    let sym = unsafe { libc::dlsym(libc::RTLD_DEFAULT, b"renameat2\0".as_ptr() as *const c_char) };
+    let sym = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"renameat2".as_ptr() as *const c_char) };
     if !sym.is_null() {
         let f: Renameat2Fn = unsafe { mem::transmute(sym) };
         let res = unsafe { f(olddirfd, oldpath, newdirfd, newpath, RENAME_NOREPLACE) };

--- a/src/sys/linux_rename.rs
+++ b/src/sys/linux_rename.rs
@@ -1,0 +1,183 @@
+//! `renameat2(..., RENAME_NOREPLACE)` compatibility for pre-2.28 glibc.
+//!
+//! The `renameat2` wrapper symbol was added to glibc 2.28. CentOS 7 ships
+//! glibc 2.17, so binaries that directly reference the symbol fail to *link*
+//! even though the kernel itself (3.10+) supports the `renameat2` syscall.
+//! This module checks the loaded libc at runtime and falls back to a
+//! non-atomic `stat + renameat` path that preserves the NOREPLACE semantics
+//! (destination must not already exist).
+
+use std::ffi::{c_char, c_int, c_uint};
+use std::mem;
+
+/// Function-pointer signature matching glibc's renameat2.
+#[cfg(target_os = "linux")]
+type Renameat2Fn = unsafe extern "C" fn(
+    olddirfd: c_int,
+    oldpath: *const c_char,
+    newdirfd: c_int,
+    newpath: *const c_char,
+    flags: c_uint,
+) -> c_int;
+
+/// Flag value — defined independently of libc to avoid version-gated imports.
+#[cfg(target_os = "linux")]
+const RENAME_NOREPLACE: c_uint = 1;
+
+/// Drop-in replacement for `renameat2(AT_FDCWD, src, AT_FDCWD, dst, RENAME_NOREPLACE)`
+/// that runs on glibc 2.17+.
+///
+/// Resolution order (paths 2 and 3 exist for platforms where the symbol is
+/// missing from libc, e.g. CentOS 7's glibc 2.17):
+///   1. `dlsym(RTLD_DEFAULT, "renameat2")` — linked-in and exported, use directly.
+///   2. `syscall(SYS_renameat2, ...)` — glibc lacks the wrapper but kernel
+///      supports the syscall (production kernels we target ≥ 3.15; many
+///      CentOS 7 kernels also satisfy this via backport).
+///   3. `stat64` existence check + `renameat` — last-resort fallback that
+///      preserves the "must not overwrite an existing destination" contract
+///      at the cost of a small non-atomic window.
+#[cfg(target_os = "linux")]
+pub(crate) fn rename_noreplace(
+    olddirfd: c_int,
+    oldpath: *const c_char,
+    newdirfd: c_int,
+    newpath: *const c_char,
+) -> c_int {
+    // ---- Fast path: libc exports renameat2 ---
+    let sym = unsafe { libc::dlsym(libc::RTLD_DEFAULT, b"renameat2\0".as_ptr() as *const c_char) };
+    if !sym.is_null() {
+        let f: Renameat2Fn = unsafe { mem::transmute(sym) };
+        let res = unsafe { f(olddirfd, oldpath, newdirfd, newpath, RENAME_NOREPLACE) };
+        if res == 0 {
+            return 0;
+        }
+        return res;
+    }
+
+    // ---- Medium path: raw syscall (glibc < 2.28, kernel >= 3.15) ----
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    let sys_num: libc::c_long = libc::SYS_renameat2 as libc::c_long;
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
+    let sys_num: libc::c_long = -1; // sentinel: unknown arch — skip to fallback
+
+    if sys_num > 0 {
+        let pad: libc::c_long = 0; // renameat2 really takes 5 args; pad to 6
+        let res = unsafe {
+            libc::syscall(
+                sys_num,
+                olddirfd,
+                oldpath,
+                newdirfd,
+                newpath,
+                RENAME_NOREPLACE,
+                pad,
+            )
+        };
+        if res == 0 {
+            return 0;
+        }
+        let en = negate_err(res);
+        if libc::ENOSYS != en {
+            // A real failure (EEXIST, ENOTEMPTY, EACCES…). Return and let the
+            // caller read errno.
+            return -1;
+        }
+        // ENOSYS means the syscall instruction is unsupported; the path below
+        // handles it. There is no arch with syscalls but no errno write, so
+        // the kernel has already set errno for us above via the libc crate's
+        // internal mechanism.
+    }
+
+    // ---- Slow path: stat + renameat (present since glibc 2.0) ----
+    let mut st: libc::stat64 = unsafe { mem::zeroed() };
+    let exists = unsafe { libc::stat64(newpath, &mut st) } == 0;
+    if exists {
+        unsafe { *errno_location() = libc::EEXIST };
+        return -1;
+    }
+
+    unsafe { libc::renameat(olddirfd, oldpath, newdirfd, newpath) }
+}
+
+/// Negate a raw syscall result to get the positive errno.
+#[cfg(target_os = "linux")]
+fn negate_err(code: libc::c_long) -> c_int {
+    if code < 0 && code > -4096 {
+        (-code) as c_int
+    } else {
+        0
+    }
+}
+
+#[cfg(target_os = "linux")]
+unsafe fn errno_location() -> *mut c_int {
+    libc::__errno_location()
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::fs;
+
+    fn make_pair() -> (CString, CString) {
+        let pid = std::process::id();
+        let src = CString::new(format!("/tmp/_virtuoso_test_src_{}", pid)).unwrap();
+        let dst = CString::new(format!("/tmp/_virtuoso_test_dst_{}", pid)).unwrap();
+        let _ = fs::remove_file(src.to_str().unwrap());
+        let _ = fs::remove_file(dst.to_str().unwrap());
+        fs::write(src.to_str().unwrap(), b"hello").unwrap();
+        (src, dst)
+    }
+
+    #[test]
+    fn rename_noreplace_basic() {
+        let (src, dst) = make_pair();
+        let (sp, dp) = (src.as_ptr(), dst.as_ptr());
+
+        let rc = unsafe { rename_noreplace(libc::AT_FDCWD, sp, libc::AT_FDCWD, dp) };
+        assert_eq!(rc, 0, "first rename should succeed, errno={}", unsafe {
+            *errno_location()
+        });
+
+        assert_eq!(fs::read_to_string(dst.to_str().unwrap()).unwrap(), "hello");
+        assert!(!std::path::Path::new(src.to_str().unwrap()).exists());
+
+        let rc = unsafe { rename_noreplace(libc::AT_FDCWD, dp, libc::AT_FDCWD, dp) };
+        assert_eq!(rc, -1);
+        assert_eq!(unsafe { *errno_location() }, libc::EEXIST);
+
+        let _ = fs::remove_file(dst.to_str().unwrap());
+    }
+
+    #[test]
+    fn rename_noreplace_missing_src() {
+        let pid = std::process::id();
+        let missing = CString::new(format!("/tmp/_virtuoso_missing_{}", pid)).unwrap();
+        let dst = CString::new(format!("/tmp/_virtuoso_dst_missing_{}", pid)).unwrap();
+        let _ = fs::remove_file(missing.to_str().unwrap());
+        let _ = fs::remove_file(dst.to_str().unwrap());
+
+        let rc = unsafe {
+            rename_noreplace(
+                libc::AT_FDCWD,
+                missing.as_ptr(),
+                libc::AT_FDCWD,
+                dst.as_ptr(),
+            )
+        };
+        assert_eq!(rc, -1);
+        assert_eq!(unsafe { *errno_location() }, libc::ENOENT);
+
+        let _ = fs::remove_file(dst.to_str().unwrap());
+    }
+
+    #[test]
+    fn negate_err_sanity() {
+        assert_eq!(negate_err(-42), 42);
+        assert_eq!(negate_err(0), 0);
+        assert_eq!(negate_err(100), 0);
+        // Out-of-range negative (not an errno) → 0
+        assert_eq!(negate_err(-5000), 0);
+    }
+}

--- a/src/sys/linux_rename.rs
+++ b/src/sys/linux_rename.rs
@@ -36,6 +36,14 @@ const RENAME_NOREPLACE: c_uint = 1;
 ///   3. `lstat64` existence check + `renameat` — last-resort fallback that
 ///      preserves the "must not overwrite an existing destination" contract
 ///      at the cost of a small non-atomic window.
+///
+/// # Safety
+///
+/// `oldpath` and `newpath` must each be a valid, NUL-terminated C string
+/// for the duration of the call. Passing dangling, unterminated, or
+/// misaligned pointers is undefined behavior. On the fast path the bytes are
+/// handed to `renameat2`/`renameat`; on the syscall path they are passed
+/// directly to the kernel.
 #[cfg(target_os = "linux")]
 pub unsafe fn rename_noreplace(
     olddirfd: c_int,

--- a/src/sys/linux_rename.rs
+++ b/src/sys/linux_rename.rs
@@ -33,11 +33,11 @@ const RENAME_NOREPLACE: c_uint = 1;
 ///   2. `syscall(SYS_renameat2, ...)` — glibc lacks the wrapper but kernel
 ///      supports the syscall (production kernels we target ≥ 3.15; many
 ///      CentOS 7 kernels also satisfy this via backport).
-///   3. `stat64` existence check + `renameat` — last-resort fallback that
+///   3. `lstat64` existence check + `renameat` — last-resort fallback that
 ///      preserves the "must not overwrite an existing destination" contract
 ///      at the cost of a small non-atomic window.
 #[cfg(target_os = "linux")]
-pub(crate) fn rename_noreplace(
+pub(crate) unsafe fn rename_noreplace(
     olddirfd: c_int,
     oldpath: *const c_char,
     newdirfd: c_int,
@@ -88,9 +88,9 @@ pub(crate) fn rename_noreplace(
         // internal mechanism.
     }
 
-    // ---- Slow path: stat + renameat (present since glibc 2.0) ----
+    // ---- Slow path: lstat + renameat (present since glibc 2.0) ----
     let mut st: libc::stat64 = unsafe { mem::zeroed() };
-    let exists = unsafe { libc::stat64(newpath, &mut st) } == 0;
+    let exists = unsafe { libc::lstat64(newpath, &mut st) } == 0;
     if exists {
         unsafe { *errno_location() = libc::EEXIST };
         return -1;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -1,0 +1,8 @@
+//! Platform-specific compatibility shims.
+//!
+//! Targets syscalls or libc symbols that are absent on older distributions
+//! (e.g. glibc 2.17 on CentOS 7) but whose semantics can be approximated
+//! via a fallback path.
+
+#[cfg(target_os = "linux")]
+pub(crate) mod linux_rename;

--- a/src/sys/mod.rs
+++ b/src/sys/mod.rs
@@ -5,4 +5,4 @@
 //! via a fallback path.
 
 #[cfg(target_os = "linux")]
-pub(crate) mod linux_rename;
+pub mod linux_rename;

--- a/src/vtui.rs
+++ b/src/vtui.rs
@@ -20,6 +20,7 @@ mod runtime_paths;
 mod skill_finder;
 mod spectre;
 mod streaming;
+mod sys;
 #[cfg(test)]
 mod test_env;
 mod transaction;

--- a/tests/linux_rename_compat.rs
+++ b/tests/linux_rename_compat.rs
@@ -1,0 +1,138 @@
+//! Integration test for the CentOS 7 (glibc 2.17) renameat2 compatibility shim.
+//!
+//! These tests run only on Linux — the sys::linux_rename module is compiled and
+//! exercised solely on that platform. macOS uses `renamex_np` directly via a
+//! separate code path in commands::maestro::atomic_publish_no_replace.
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use std::ffi::CString;
+    use std::fs;
+    use std::path::Path;
+
+    use virtuoso_cli::sys::linux_rename::rename_noreplace;
+
+    fn tmp_cpath(name: &str) -> CString {
+        CString::new(format!(
+            "/tmp/vcli_rename_test_{}_{}",
+            std::process::id(),
+            name
+        ))
+        .unwrap()
+    }
+
+    fn cleanup(name: &str) {
+        let p = format!("/tmp/vcli_rename_test_{}_{}", std::process::id(), name);
+        let _ = fs::remove_file(&p);
+    }
+
+    #[test]
+    fn happy_path_creates_dst() {
+        let src = tmp_cpath("src1");
+        let dst = tmp_cpath("dst1");
+        cleanup("src1");
+        cleanup("dst1");
+        fs::write(src.to_str().unwrap(), b"payload").unwrap();
+
+        let rc =
+            unsafe { rename_noreplace(libc::AT_FDCWD, src.as_ptr(), libc::AT_FDCWD, dst.as_ptr()) };
+        assert_eq!(rc, 0);
+        assert_eq!(
+            fs::read_to_string(dst.to_str().unwrap()).unwrap(),
+            "payload"
+        );
+        assert!(
+            !Path::new(src.to_str().unwrap()).exists(),
+            "src must be gone"
+        );
+
+        cleanup("dst1");
+    }
+
+    #[test]
+    fn eexist_when_dst_is_file() {
+        let src = tmp_cpath("src2");
+        let dst = tmp_cpath("dst2");
+        cleanup("src2");
+        cleanup("dst2");
+        fs::write(src.to_str().unwrap(), b"A").unwrap();
+        fs::write(dst.to_str().unwrap(), b"B").unwrap();
+
+        let rc =
+            unsafe { rename_noreplace(libc::AT_FDCWD, src.as_ptr(), libc::AT_FDCWD, dst.as_ptr()) };
+        assert_eq!(rc, -1, "rename onto an existing file must fail");
+        assert_eq!(unsafe { *libc::__errno_location() }, libc::EEXIST);
+        // Destination must be unmodified
+        assert_eq!(fs::read_to_string(dst.to_str().unwrap()).unwrap(), "B");
+
+        cleanup("src2");
+        cleanup("dst2");
+    }
+
+    #[test]
+    fn eexist_when_dst_is_empty_dir() {
+        let src = tmp_cpath("src3");
+        let dst = tmp_cpath("dst3_empty_dir");
+        cleanup("src3");
+        let _ = fs::remove_dir(dst.to_str().unwrap());
+        fs::write(src.to_str().unwrap(), b"A").unwrap();
+        fs::create_dir(dst.to_str().unwrap()).unwrap();
+
+        let rc =
+            unsafe { rename_noreplace(libc::AT_FDCWD, src.as_ptr(), libc::AT_FDCWD, dst.as_ptr()) };
+        assert_eq!(rc, -1, "rename onto an existing dir must fail");
+        assert_eq!(unsafe { *libc::__errno_location() }, libc::EEXIST);
+        // src must NOT be consumed (noreplace semantics).
+        assert!(Path::new(src.to_str().unwrap()).exists());
+
+        let _ = fs::remove_dir(dst.to_str().unwrap());
+        cleanup("src3");
+    }
+
+    #[test]
+    fn enoent_when_src_missing() {
+        let src = tmp_cpath("no_such_src");
+        let dst = tmp_cpath("no_such_dst");
+        cleanup("no_such_src");
+        cleanup("no_such_dst");
+
+        let rc =
+            unsafe { rename_noreplace(libc::AT_FDCWD, src.as_ptr(), libc::AT_FDCWD, dst.as_ptr()) };
+        assert_eq!(rc, -1);
+        assert_eq!(unsafe { *libc::__errno_location() }, libc::ENOENT);
+    }
+
+    #[test]
+    fn unicode_filename() {
+        // C string with multi-byte UTF-8 bytes — exercise the lossless path
+        // that uses *CString (no OsStr).
+        let name = format!("unicode_{}_细胞_🦀", std::process::id());
+        let src_path = format!("/tmp/{}", name);
+        let dst_path = format!("/tmp/dst_{}", name);
+        let _ = fs::remove_file(&src_path);
+        let _ = fs::remove_file(&dst_path);
+        fs::write(&src_path, b"payload").unwrap();
+
+        let src_c = CString::new(src_path.as_bytes()).unwrap();
+        let dst_c = CString::new(dst_path.as_bytes()).unwrap();
+        let rc = unsafe {
+            rename_noreplace(
+                libc::AT_FDCWD,
+                src_c.as_ptr(),
+                libc::AT_FDCWD,
+                dst_c.as_ptr(),
+            )
+        };
+        assert_eq!(rc, 0);
+        assert_eq!(fs::read_to_string(&dst_path).unwrap(), "payload");
+        assert!(!Path::new(&src_path).exists());
+
+        let _ = fs::remove_file(&dst_path);
+    }
+}
+
+/// Confirms the sys::linux_rename module is cfg'd out on non-Linux — the
+/// crate's public API must never reference it on those targets.
+#[cfg(not(target_os = "linux"))]
+#[test]
+fn non_linux_builds_no_compat_module() {}


### PR DESCRIPTION
## Summary
- CentOS 7 ships glibc 2.17, but `renameat2` was added in glibc 2.28. Building `vcli` fails at link time with `undefined reference to renameat2`.
- Added `src/sys/linux_rename::rename_noreplace()` with three-tier resolution:
  1. `dlsym(RTLD_DEFAULT, "renameat2")` — glibc ≥ 2.28, direct call
  2. `syscall(SYS_renameat2, ...)` — glibc < 2.28 but kernel ≥ 3.15, raw syscall (x86_64/aarch64)
  3. `stat64` existence check + `renameat` — fallback on very old kernels, preserves NOREPLACE semantics
- `commands::maestro::atomic_publish_no_replace` Linux path now delegates to the wrapper.

## Test plan
- [x] Unit tests in `src/sys/linux_rename.rs` (Linux only)
- [x] Integration tests in `tests/linux_rename_compat.rs` (Linux: 5 cases incl. EEXIST, ENOENT, empty-dir, unicode filename)
- [x] cfg-out smoke test on non-Linux
- [ ] Verify on a real CentOS 7 box (glibc 2.17) — requires user confirmation
- [x] `cargo check --tests` passes
- [x] `cargo fmt --check` passes

Closes #11
