### PR TITLE
fix(CI): restore main Check & Lint gate (batch args + fmt)

### DIFF
--- a/src/commands/window.rs
+++ b/src/commands/window.rs
@@ -425,9 +425,8 @@ pub fn action_x11_batch(
     use crate::transport::x11;
     use std::io::{BufRead, BufReader};
 
-    let file = std::fs::File::open(file_path).map_err(|e| {
-        VirtuosoError::Config(format!("cannot open batch file '{file_path}': {e}"))
-    })?;
+    let file = std::fs::File::open(file_path)
+        .map_err(|e| VirtuosoError::Config(format!("cannot open batch file '{file_path}': {e}")))?;
     let reader = BufReader::new(file);
     let mut actions = Vec::new();
     for (line_no, line) in reader.lines().enumerate() {
@@ -439,10 +438,7 @@ pub fn action_x11_batch(
             continue;
         }
         let action: x11::BatchAction = serde_json::from_str(trimmed).map_err(|e| {
-            VirtuosoError::Config(format!(
-                "invalid JSON on line {}: {e}",
-                line_no + 1
-            ))
+            VirtuosoError::Config(format!("invalid JSON on line {}: {e}", line_no + 1))
         })?;
         actions.push(action);
     }
@@ -458,20 +454,17 @@ pub fn action_x11_batch(
     let client_id = x11::client_id_for(&config);
     let effective_default_display = explicit_display.or(default_display);
 
-    let result = x11::action_x11_batch(
-        runner.as_ref(),
-        &client_id,
-        user,
-        &actions,
+    let batch_inputs = x11::BatchX11Inputs {
+        actions: &actions,
         default_pid,
-        effective_default_display,
+        default_display: effective_default_display,
         direct,
         timeout_secs,
-    )?;
+    };
+    let result = x11::action_x11_batch(runner.as_ref(), &client_id, user, &batch_inputs)?;
 
-    let out = serde_json::to_value(&result).map_err(|e| {
-        VirtuosoError::Execution(format!("failed to serialize batch result: {e}"))
-    })?;
+    let out = serde_json::to_value(&result)
+        .map_err(|e| VirtuosoError::Execution(format!("failed to serialize batch result: {e}")))?;
     Ok(out)
 }
 

--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -697,10 +697,11 @@ pub fn parse_scroll_spec(spec: &str) -> Result<(String, u32)> {
     let spec = spec.trim();
     let (direction, count) = match spec.split_once(':') {
         Some((d, c)) => {
-            let count: u32 = c
-                .trim()
-                .parse()
-                .map_err(|_| VirtuosoError::Config(format!("invalid scroll count in '{spec}': must be an integer")))?;
+            let count: u32 = c.trim().parse().map_err(|_| {
+                VirtuosoError::Config(format!(
+                    "invalid scroll count in '{spec}': must be an integer"
+                ))
+            })?;
             (d, count)
         }
         None => (spec, 1),
@@ -818,7 +819,9 @@ pub fn validate_action_params(
             // scroll requires a direction spec in --text: "up" | "down" |
             // "left" | "right", optionally "direction:count" (count 1..=100).
             let t = text.ok_or_else(|| {
-                VirtuosoError::Config("operation 'scroll' requires --text direction (up|down|left|right)".into())
+                VirtuosoError::Config(
+                    "operation 'scroll' requires --text direction (up|down|left|right)".into(),
+                )
             })?;
             parse_scroll_spec(t)?;
             // optional button must be 1/2/3
@@ -1515,12 +1518,15 @@ pub fn action_x11_batch(
     runner: &dyn RemoteTransport,
     client_id: &str,
     user: Option<&str>,
-    actions: &[BatchAction],
-    default_pid: Option<u32>,
-    default_display: Option<&str>,
-    direct: bool,
-    timeout_secs: u64,
+    inputs: &BatchX11Inputs<'_>,
 ) -> Result<BatchResult> {
+    let BatchX11Inputs {
+        actions,
+        default_pid,
+        default_display,
+        direct,
+        timeout_secs,
+    } = *inputs;
     let start = std::time::Instant::now();
     let mut results = Vec::with_capacity(actions.len());
     let mut succeeded = 0usize;
@@ -1632,10 +1638,8 @@ pub fn action_x11_batch(
             }
         }
         let script = script_parts.join("; ");
-        let total_timeout =
-            Duration::from_secs(timeout_secs * prepared.len().max(1) as u64);
-        let out =
-            runner.run_command(&CommandRequest::with_exec_timeout(&script, total_timeout))?;
+        let total_timeout = Duration::from_secs(timeout_secs * prepared.len().max(1) as u64);
+        let out = runner.run_command(&CommandRequest::with_exec_timeout(&script, total_timeout))?;
         let exec_duration_ms = exec_start.elapsed().as_millis() as u64;
 
         let mut cmd_exit_codes: std::collections::HashMap<(usize, usize), i32> =
@@ -1782,6 +1786,18 @@ pub struct ActionX11Inputs<'a> {
     /// scan. Trusts the caller-provided window_id and runs xdotool directly.
     /// ~25x faster for click/key/type. Not compatible with `wait` or `screenshot`.
     pub direct: bool,
+}
+
+/// Bundles batch-level inputs for `action_x11_batch`; mirrors the CLI flags.
+///
+/// Packed into a single struct so the function signature stays under the
+/// clippy `too_many_arguments` ceiling while remaining self-documenting.
+pub struct BatchX11Inputs<'a> {
+    pub actions: &'a [BatchAction],
+    pub default_pid: Option<u32>,
+    pub default_display: Option<&'a str>,
+    pub direct: bool,
+    pub timeout_secs: u64,
 }
 
 /// Build xdotool commands for an action operation.
@@ -1966,7 +1982,12 @@ fn build_xdotool_actions(
                     button.into(),
                 ]
             } else {
-                vec!["click".into(), "--window".into(), wid.clone(), button.into()]
+                vec![
+                    "click".into(),
+                    "--window".into(),
+                    wid.clone(),
+                    button.into(),
+                ]
             };
             let mut cmds = Vec::with_capacity(2);
             if x.is_some() || y.is_some() {
@@ -2723,7 +2744,10 @@ mod tests {
 
     #[test]
     fn scroll_operation_roundtrips_str() {
-        assert_eq!(X11Operation::from_str("scroll").unwrap(), X11Operation::Scroll);
+        assert_eq!(
+            X11Operation::from_str("scroll").unwrap(),
+            X11Operation::Scroll
+        );
         assert_eq!(X11Operation::Scroll.as_str(), "scroll");
     }
 
@@ -2738,13 +2762,22 @@ mod tests {
         assert_eq!(parse_scroll_spec("down").unwrap(), ("down".to_string(), 1));
         assert_eq!(parse_scroll_spec("up").unwrap(), ("up".to_string(), 1));
         assert_eq!(parse_scroll_spec("left").unwrap(), ("left".to_string(), 1));
-        assert_eq!(parse_scroll_spec("right").unwrap(), ("right".to_string(), 1));
+        assert_eq!(
+            parse_scroll_spec("right").unwrap(),
+            ("right".to_string(), 1)
+        );
     }
 
     #[test]
     fn scroll_parses_direction_count() {
-        assert_eq!(parse_scroll_spec("down:3").unwrap(), ("down".to_string(), 3));
-        assert_eq!(parse_scroll_spec("up:100").unwrap(), ("up".to_string(), 100));
+        assert_eq!(
+            parse_scroll_spec("down:3").unwrap(),
+            ("down".to_string(), 3)
+        );
+        assert_eq!(
+            parse_scroll_spec("up:100").unwrap(),
+            ("up".to_string(), 100)
+        );
     }
 
     #[test]
@@ -2769,20 +2802,17 @@ mod tests {
             visible: true,
         };
         // down:3 -> click --repeat 3 button 5
-        let cmds = build_xdotool_actions(
-            &w, X11Operation::Scroll, None, None, None, Some("down:3"),
-        )
-        .unwrap();
+        let cmds =
+            build_xdotool_actions(&w, X11Operation::Scroll, None, None, None, Some("down:3"))
+                .unwrap();
         assert_eq!(cmds.len(), 1);
         let (_, argv) = &cmds[0];
         assert_eq!(argv[0], "click");
         assert!(argv.contains(&"--repeat".to_string()));
         assert!(argv.contains(&"5".to_string()));
         // up -> single click button 4
-        let cmds = build_xdotool_actions(
-            &w, X11Operation::Scroll, None, None, None, Some("up"),
-        )
-        .unwrap();
+        let cmds =
+            build_xdotool_actions(&w, X11Operation::Scroll, None, None, None, Some("up")).unwrap();
         let (_, argv) = &cmds[0];
         assert_eq!(argv[0], "click");
         assert!(!argv.contains(&"--repeat".to_string()));
@@ -2804,7 +2834,12 @@ mod tests {
             visible: true,
         };
         let cmds = build_xdotool_actions(
-            &w, X11Operation::Scroll, Some(10), Some(20), None, Some("down"),
+            &w,
+            X11Operation::Scroll,
+            Some(10),
+            Some(20),
+            None,
+            Some("down"),
         )
         .unwrap();
         assert_eq!(cmds.len(), 2);


### PR DESCRIPTION
## Summary

`main`'s `ci.yml` **Check & Lint** job has been red for ~10h — both `cargo fmt --check` (13 violations) and `cargo clippy --all-targets -- -D warnings` (`too_many_arguments` on `action_x11_batch`) were failing, so the clippy step was being skipped and the gate was effectively blind.

- Introduce `BatchX11Inputs<'a>` mirroring the existing `ActionX11Inputs` pattern; `action_x11_batch` signature drops from **8 args → 4** (clears `clippy::too_many_arguments`, ceiling 7).
- The command-layer caller in `src/commands/window.rs` builds the struct before the call.
- `cargo fmt` applied to clear the 13 formatting violations from the direct-to-main feat commits (`action-x11-batch`, `--direct`, `scroll`).

**Zero behavior change** — batch execution logic identical, only the parameter-bundle shape changed.

## Verification (local)

- `cargo fmt --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅ (no warnings)
- `cargo test` → **862 passed**, 2 failed

The 2 failures (`identity`, `daemon_lifecycle` `sysctl KERN_PROCARGS2`) are **environmental** — they fail locally under the macOS sandbox with `errno 5 (EPERM)` and are untouched by this change. They pass on CI runners.

## Test plan

- CI `ci.yml` Check & Lint should go green on this branch.
