### PR TITLE
style(x11): run cargo fmt on --direct maximize hint (unbreak main fmt gate)

### DIFF
--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -115,7 +115,7 @@ pub fn load(file: &str, skillpp: bool) -> Result<Value> {
     let client = VirtuosoClient::from_env()?;
 
     let result = client.load_il(file, skillpp)?;
-    let skillpp_mode = result.metadata.get("skillpp_mode").is_some();
+    let skillpp_mode = result.metadata.contains_key("skillpp_mode");
 
     Ok(json!({
         "status": "success",

--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -2138,15 +2138,14 @@ pub fn action_x11_batch(
                 failed += 1;
                 // Maximize needs xdotool >= 3.20210804.1 (windowstate). Give a
                 // specific hint instead of the generic non-zero-exit message.
-                let err_msg = if pa.operation == "maximize"
-                    && out.stderr.contains("Unknown command")
-                {
-                    "maximize requires xdotool >= 3.20210804.1 (windowstate subcommand); \
+                let err_msg =
+                    if pa.operation == "maximize" && out.stderr.contains("Unknown command") {
+                        "maximize requires xdotool >= 3.20210804.1 (windowstate subcommand); \
                      installed xdotool is too old. Use activate/minimize/close or upgrade xdotool."
-                        .to_string()
-                } else {
-                    "xdotool command returned non-zero exit code".to_string()
-                };
+                            .to_string()
+                    } else {
+                        "xdotool command returned non-zero exit code".to_string()
+                    };
                 results.push(BatchActionResult {
                     index: pa.index,
                     operation: pa.operation.clone(),


### PR DESCRIPTION
## Problem

`origin/main` is currently **red** on the `Check & Lint` gate — for **two
independent reasons**. Every other job stays green.

Evidence — run [33812921924](https://github.com/deanyou/virtuoso-cli/actions/runs/33812921924) on `58d862f`:

| Job | Result |
|---|---|
| Build | ✅ success |
| Test | ✅ success |
| Check & Lint | 🔴 **failure** |
| Security Audit | ✅ success |

### 1. rustfmt violation (from `58d862f`)

*fix(x11): add maximize version hint to --direct path too* landed without
running `cargo fmt`.

### 2. clippy violation (from `acf3d72`)

```
error: unnecessary use of `get("skillpp_mode").is_some()`
   --> src/commands/skill.rs:118:40
help: replace it with: `contains_key("skillpp_mode")`
= note: `-D clippy::unnecessary-get-then-check` implied by `-D warnings`
```

## Fix

Two commits, one per blocker:

**`2edb03b` — style(x11): run cargo fmt**

Re-indents the `let err_msg = if ...` block in `action_x11_batch`
(`src/transport/x11.rs:2138`) into rustfmt's preferred shape. 1 file, 1 hunk,
7 insertions / 8 deletions, whitespace only.

**`a56f0ee` — fix(skill): satisfy clippy `unnecessary_get_then_check`**

```rust
-let skillpp_mode = result.metadata.get("skillpp_mode").is_some();
+let skillpp_mode = result.metadata.contains_key("skillpp_mode");
```

Semantically identical (`get(k).is_some()` == `contains_key(k)`).

**Zero behavior change** across both commits.

## Gates (local)

- `cargo fmt --check` → clean
- `cargo clippy --all-targets -- -D warnings` → clean
- `cargo test` → 881 passed (3 `transport::daemon_lifecycle` /
  `transport::tunnel` tests fail locally with `sysctl KERN_PROCARGS2: errno 5`,
  a pre-existing macOS sandbox limitation confirmed on a clean tree)

## Why its own PR

This unblocks `main` so the pending `list_windows` version-tolerance PR can be
rebased onto a green base, instead of bundling unrelated lint fixes into a
functional change.

Refs #50.
