### PR TITLE
fix(gui-debug): env allowlist, session-aware vcli, dynamic CIW coordinates

### DIFF
--- a/.claude/skills/virtuoso-gui-debug/SKILL.md
+++ b/.claude/skills/virtuoso-gui-debug/SKILL.md
@@ -71,10 +71,10 @@ ssh ubuntu-docker "cat /tmp/virtuoso-daemon.log | grep PORT"
 ### 一、连接 Session
 ```bash
 # 列出所有 session
-VCLI_CAPABILITY=admin VB_PORT=33817 VB_REMOTE_HOST=localhost vcli session list
+VCLI_CAPABILITY=admin VB_PORT=XXXXX VB_REMOTE_HOST=localhost vcli session list
 
 # 查看 session 详情
-VCLI_CAPABILITY=admin VB_PORT=33817 VB_REMOTE_HOST=localhost vcli session show dean-user1-33817
+VCLI_CAPABILITY=admin VB_PORT=XXXXX VB_REMOTE_HOST=localhost vcli session show dean-user1-XXXXX
 ```
 
 关键字段：
@@ -94,13 +94,13 @@ ssh ubuntu-docker "ls /tmp/.X11-unix/"
 ssh ubuntu-docker "ps aux | grep virtuoso | grep -v grep"
 
 # 方法3：逐个尝试（常见 :0, :1, :99）
-vcli window list-windows-x11 --display :99 --session dean-user1-33817
+vcli window list-windows-x11 --display :99 --session dean-user1-XXXXX
 ```
 
 ### 三、发现窗口
 ```bash
 # 列出指定 DISPLAY 上的所有窗口
-vcli window list-windows-x11 --display :99 --session dean-user1-33817
+vcli window list-windows-x11 --display :99 --session dean-user1-XXXXX
 ```
 
 输出字段说明：
@@ -116,7 +116,7 @@ vcli window list-windows-x11 --display :99 --session dean-user1-33817
 
 快速筛选：
 ```bash
-vcli window list-windows-x11 --display :99 --session dean-user1-33817 | python3 -c "
+vcli window list-windows-x11 --display :99 --session dean-user1-XXXXX | python3 -c "
 import json,sys
 for w in json.load(sys.stdin)['windows']:
     print(w['window_id'], w['pid'], w['title'][:40])
@@ -130,7 +130,7 @@ for w in json.load(sys.stdin)['windows']:
 vcli window action-x11 \
   --window-id 0x3000000 \
   --display :99 \
-  --session dean-user1-33817 \
+  --session dean-user1-XXXXX \
   --pid 393027 \
   --operation <OP> \
   --direct
@@ -423,11 +423,11 @@ The live executor uses `vcli window action-x11 --direct` by default, skipping he
 ```bash
 # Default (fast, 260ms):
 python3 scripts/gui_runner.py run scenario.json --output out --executor live \
-    --session dean-user1-33817 --vcli ~/.cargo/bin/vcli --ssh-host ubuntu-docker
+    --session dean-user1-XXXXX --vcli ~/.cargo/bin/vcli --ssh-host ubuntu-docker
 
 # Full validation (slow, 1350ms, use --no-direct):
 python3 scripts/gui_runner.py run scenario.json --output out --executor live \
-    --session dean-user1-33817 --vcli ~/.cargo/bin/vcli --ssh-host ubuntu-docker \
+    --session dean-user1-XXXXX --vcli ~/.cargo/bin/vcli --ssh-host ubuntu-docker \
     --no-direct
 ```
 

--- a/.claude/skills/virtuoso-gui-debug/SKILL.md
+++ b/.claude/skills/virtuoso-gui-debug/SKILL.md
@@ -423,11 +423,11 @@ The live executor uses `vcli window action-x11 --direct` by default, skipping he
 ```bash
 # Default (fast, 260ms):
 python3 scripts/gui_runner.py run scenario.json --output out --executor live \
-    --session dean-user1-37787 --vcli ~/.cargo/bin/vcli --ssh-host ubuntu-docker
+    --session dean-user1-33817 --vcli ~/.cargo/bin/vcli --ssh-host ubuntu-docker
 
 # Full validation (slow, 1350ms, use --no-direct):
 python3 scripts/gui_runner.py run scenario.json --output out --executor live \
-    --session dean-user1-37787 --vcli ~/.cargo/bin/vcli --ssh-host ubuntu-docker \
+    --session dean-user1-33817 --vcli ~/.cargo/bin/vcli --ssh-host ubuntu-docker \
     --no-direct
 ```
 

--- a/.claude/skills/virtuoso-gui-debug/scripts/vgui_runner/command_runner.py
+++ b/.claude/skills/virtuoso-gui-debug/scripts/vgui_runner/command_runner.py
@@ -26,11 +26,12 @@ __all__ = [
     "SshRunner",
 ]
 
-# Keys kept from the parent environment. Everything else (credentials,
-# license paths, DISPLAY, VB_*) is dropped before spawning a child.
-# Note: VB_PORT and VB_REMOTE_HOST are needed for vcli to connect to the daemon.
-# Note: HOME is needed for vcli to resolve paths like ~/.cache/virtuoso_bridge/sessions/.
-# Note: XDG_CACHE_HOME is needed for vcli to find session files.
+# Keys kept from the parent environment. Most credentials, license paths,
+# DISPLAY, and VB_* are dropped before spawning a child.
+# Explicitly allowed:
+#   VB_PORT, VB_REMOTE_HOST — needed for vcli to connect to the daemon
+#   HOME — needed for vcli to resolve ~/.cache/virtuoso_bridge/sessions/
+#   XDG_CACHE_HOME — needed for vcli to find session files
 _ENV_ALLOWLIST = ("PATH", "LANG", "LC_ALL", "HOME", "XDG_CACHE_HOME", "VB_PORT", "VB_REMOTE_HOST")
 _EXTRA_ENV = {"VCLI_CAPABILITY": "admin"}
 

--- a/.claude/skills/virtuoso-gui-debug/scripts/vgui_runner/command_runner.py
+++ b/.claude/skills/virtuoso-gui-debug/scripts/vgui_runner/command_runner.py
@@ -28,7 +28,10 @@ __all__ = [
 
 # Keys kept from the parent environment. Everything else (credentials,
 # license paths, DISPLAY, VB_*) is dropped before spawning a child.
-_ENV_ALLOWLIST = ("PATH", "LANG", "LC_ALL")
+# Note: VB_PORT and VB_REMOTE_HOST are needed for vcli to connect to the daemon.
+# Note: HOME is needed for vcli to resolve paths like ~/.cache/virtuoso_bridge/sessions/.
+# Note: XDG_CACHE_HOME is needed for vcli to find session files.
+_ENV_ALLOWLIST = ("PATH", "LANG", "LC_ALL", "HOME", "XDG_CACHE_HOME", "VB_PORT", "VB_REMOTE_HOST")
 _EXTRA_ENV = {"VCLI_CAPABILITY": "admin"}
 
 # A syntactically safe SSH hostname: no whitespace, shell metacharacters,

--- a/.claude/skills/virtuoso-gui-debug/scripts/vgui_runner/live_executor.py
+++ b/.claude/skills/virtuoso-gui-debug/scripts/vgui_runner/live_executor.py
@@ -346,16 +346,12 @@ class LiveExecutor(Executor):
             self.window_id = window.get("dismiss_id") or window.get("window_id")
             self._scenario_display = scenario.display
             self._scenario_pid = int(effective_pid)
-            # Store window geometry for CIW_INPUT click coordinates
-            # Use vcli reported geometry, but cap at reasonable values for CIW
+            # Store window geometry for CIW_INPUT click coordinates.
+            # Use vcli-reported geometry directly — no artificial cap, since
+            # high-DPI CIW windows can be 1200+ pixels wide.
             geom = window.get("geometry", {})
-            # CIW windows are typically around 600-800 wide and 500-700 tall
-            # Use reported values but cap to reasonable bounds
-            reported_w = geom.get("w", 800)
-            reported_h = geom.get("h", 600)
-            # Cap at 800x700 max (typical CIW window size)
-            self._window_width = min(reported_w, 800)
-            self._window_height = min(reported_h, 700)
+            self._window_width = geom.get("w", 800)
+            self._window_height = geom.get("h", 600)
 
             # 3. exclusive DISPLAY lock
             lock = _DisplayLock(scenario.display)
@@ -793,9 +789,11 @@ class LiveExecutor(Executor):
         w = self._window_width
         h = self._window_height
         click_x = w // 2  # Center X
-        # Use 90% of height to ensure we're in the input area
-        # CIW input is typically at the bottom of the window
-        click_y = max(int(h * 0.9), h - 100)  # At least 100px from top
+        # CIW input line is typically at the bottom ~10% of the window.
+        # Use 90% of height, but ensure we're at least 100px from the top
+        # and at most 5px from the bottom (stay inside the window).
+        click_y = max(int(h * 0.9), h - 100)
+        click_y = min(click_y, h - 5)
         # 1. Activate the CIW window
         self._run_action("activate")
         # 2. Click the input line (bottom center of window)

--- a/.claude/skills/virtuoso-gui-debug/scripts/vgui_runner/live_executor.py
+++ b/.claude/skills/virtuoso-gui-debug/scripts/vgui_runner/live_executor.py
@@ -185,7 +185,12 @@ class LiveExecutor(Executor):
     # ------------------------------------------------------------------
 
     def _vcli_argv(self, *args: str) -> List[str]:
+        """Build vcli argv without session (for session list, etc.)."""
         return [self._vcli, *args, "--format", "json"]
+
+    def _vcli_argv_with_session(self, *args: str) -> List[str]:
+        """Build vcli argv with --session flag for commands that need daemon access."""
+        return [self._vcli, "--session", self._session_id, *args, "--format", "json"]
 
     def _run_json(self, argv: List[str], timeout_seconds: int) -> Dict[str, Any]:
         result = self._runner.run(argv, timeout_seconds)
@@ -338,6 +343,16 @@ class LiveExecutor(Executor):
             self.window_id = window.get("dismiss_id") or window.get("window_id")
             self._scenario_display = scenario.display
             self._scenario_pid = int(effective_pid)
+            # Store window geometry for CIW_INPUT click coordinates
+            # Use vcli reported geometry, but cap at reasonable values for CIW
+            geom = window.get("geometry", {})
+            # CIW windows are typically around 600-800 wide and 500-700 tall
+            # Use reported values but cap to reasonable bounds
+            reported_w = geom.get("w", 800)
+            reported_h = geom.get("h", 600)
+            # Cap at 800x700 max (typical CIW window size)
+            self._window_width = min(reported_w, 800)
+            self._window_height = min(reported_h, 700)
 
             # 3. exclusive DISPLAY lock
             lock = _DisplayLock(scenario.display)
@@ -523,7 +538,7 @@ class LiveExecutor(Executor):
                     }
                 expression = expected["expression"]
                 data = self._run_json(
-                    self._vcli_argv("skill", "exec", expression),
+                    self._vcli_argv_with_session("skill", "exec", expression),
                     _TIMEOUT_ACTION,
                 )
                 actual = data.get("output", "")
@@ -765,12 +780,18 @@ class LiveExecutor(Executor):
         wid = self.window_id
         if not wid:
             raise RuntimeError("CIW_INPUT requires a bound window")
+        # Calculate click position based on window geometry
+        # CIW input line is typically at bottom 10-20% of the window
+        w = getattr(self, '_window_width', 800)
+        h = getattr(self, '_window_height', 600)
+        click_x = w // 2  # Center X
+        # Use 90% of height to ensure we're in the input area
+        # CIW input is typically at the bottom of the window
+        click_y = max(int(h * 0.9), h - 100)  # At least 100px from top
         # 1. Activate the CIW window
         self._run_action("activate")
         # 2. Click the input line (bottom center of window)
-        # Use click-rel with approximate bottom-center coordinates.
-        # The input line is ~20px from the bottom of the CIW window.
-        self._run_action("click-rel", x=400, y=870)
+        self._run_action("click-rel", x=click_x, y=click_y)
         # 3. Clear existing input if requested
         if clear_first:
             self._run_action("key", text="ctrl+a")

--- a/.claude/skills/virtuoso-gui-debug/scripts/vgui_runner/live_executor.py
+++ b/.claude/skills/virtuoso-gui-debug/scripts/vgui_runner/live_executor.py
@@ -179,6 +179,9 @@ class LiveExecutor(Executor):
         self._baseline_taken = False
         self._scenario_display: Optional[str] = None
         self._scenario_pid: int = 0
+        # Window geometry for CIW_INPUT click coordinates — set during precheck.
+        self._window_width: Optional[int] = None
+        self._window_height: Optional[int] = None
 
     # ------------------------------------------------------------------
     # helpers
@@ -782,8 +785,13 @@ class LiveExecutor(Executor):
             raise RuntimeError("CIW_INPUT requires a bound window")
         # Calculate click position based on window geometry
         # CIW input line is typically at bottom 10-20% of the window
-        w = getattr(self, '_window_width', 800)
-        h = getattr(self, '_window_height', 600)
+        if self._window_width is None or self._window_height is None:
+            raise RuntimeError(
+                "CIW_INPUT requires window geometry from precheck; "
+                "run precheck() before execute()"
+            )
+        w = self._window_width
+        h = self._window_height
         click_x = w // 2  # Center X
         # Use 90% of height to ensure we're in the input area
         # CIW input is typically at the bottom of the window

--- a/.claude/skills/virtuoso-gui-debug/tests/test_command_runner.py
+++ b/.claude/skills/virtuoso-gui-debug/tests/test_command_runner.py
@@ -73,7 +73,8 @@ class TestLocalRunner(unittest.TestCase):
         import json
 
         keys = set(json.loads(result.stdout))
-        allowed = {"PATH", "LANG", "LC_ALL", "VCLI_CAPABILITY"}
+        allowed = {"PATH", "LANG", "LC_ALL", "VCLI_CAPABILITY",
+                   "HOME", "XDG_CACHE_HOME", "VB_PORT", "VB_REMOTE_HOST"}
         # macOS injects system keys like __CF_USER_TEXT_ENCODING and LC_CTYPE
         # into every child; they carry no user data. Everything else — in
         # particular VB_*, DISPLAY, credentials — must be dropped.

--- a/.claude/skills/virtuoso-gui-debug/tests/test_live_executor.py
+++ b/.claude/skills/virtuoso-gui-debug/tests/test_live_executor.py
@@ -821,5 +821,90 @@ class TestWindowIdDisambiguation(unittest.TestCase):
             self.assertIn("not found", err["error"])
 
 
+class TestSessionAwareArgv(unittest.TestCase):
+    """Tests for _vcli_argv_with_session (PR #74)."""
+
+    def test_argv_without_session(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = FakeRunner([])
+            ex = make_executor(runner, tmp)
+            argv = ex._vcli_argv("session", "list")
+            self.assertEqual(argv[0], VCLI)
+            self.assertNotIn("--session", argv)
+            self.assertIn("--format", argv)
+
+    def test_argv_with_session(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = FakeRunner([])
+            ex = make_executor(runner, tmp)
+            argv = ex._vcli_argv_with_session("skill", "exec", "1+1")
+            self.assertEqual(argv[0], VCLI)
+            self.assertIn("--session", argv)
+            self.assertIn(SESSION, argv)
+            # --session comes before subcommand args
+            session_idx = argv.index("--session")
+            self.assertEqual(argv[session_idx + 1], SESSION)
+            self.assertIn("skill", argv)
+            self.assertIn("exec", argv)
+            self.assertIn("1+1", argv)
+
+
+class TestDynamicCiwCoordinates(unittest.TestCase):
+    """Tests for dynamic CIW click coordinate calculation (PR #74)."""
+
+    def _precheck_with_geometry(self, w, h):
+        """Run precheck with a window of given geometry, return executor."""
+        import tempfile
+        windows = json.dumps({
+            "display": DISPLAY,
+            "count": 1,
+            "windows": [{
+                "window_id": WINDOW_ID, "dismiss_id": WINDOW_ID,
+                "display": DISPLAY, "title": "CIW", "pid": PID,
+                "visible": True,
+                "geometry": {"x": 0, "y": 0, "w": w, "h": h},
+            }],
+        })
+        tmp = tempfile.TemporaryDirectory()
+        runner = FakeRunner([res(stdout=SESSIONS_OK), res(stdout=windows)])
+        ex = make_executor(runner, tmp.name)
+        err = ex.precheck(make_scenario())
+        self.assertIsNone(err, f"precheck failed: {err}")
+        return ex, tmp
+
+    def test_precheck_sets_window_geometry(self):
+        ex, tmp = self._precheck_with_geometry(900, 700)
+        try:
+            self.assertEqual(ex._window_width, 900)
+            self.assertEqual(ex._window_height, 700)
+        finally:
+            tmp.cleanup()
+
+    def test_large_window_not_capped(self):
+        """High-DPI windows (1200+ wide) should not be artificially capped."""
+        ex, tmp = self._precheck_with_geometry(1400, 1000)
+        try:
+            self.assertEqual(ex._window_width, 1400)
+            self.assertEqual(ex._window_height, 1000)
+        finally:
+            tmp.cleanup()
+
+    def test_ciw_input_requires_geometry(self):
+        """_ciw_input should raise if precheck hasn't set geometry."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            runner = FakeRunner([])
+            ex = make_executor(runner, tmp)
+            # Simulate window bound but geometry missing (shouldn't happen
+            # in practice since precheck sets both, but test the guard)
+            ex.window_id = WINDOW_ID
+            self.assertIsNone(ex._window_width)
+            with self.assertRaises(RuntimeError) as ctx:
+                ex._ciw_input("1+1")
+            self.assertIn("geometry", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `HOME`, `XDG_CACHE_HOME`, `VB_PORT`, `VB_REMOTE_HOST` to environment allowlist so vcli can resolve session files and connect to the daemon
- Add `_vcli_argv_with_session()` for commands that need daemon access
- Use session-aware argv in `ciw_eval` for SKILL expression execution
- Calculate CIW click coordinates dynamically from window geometry instead of hardcoded 400x870

## Test plan
- [x] Run `python3 scripts/gui_runner.py validate` — passed
- [x] Run `python3 scripts/gui_runner.py run test_scenario.json --executor fake` — passed
- [x] Run `python3 -m unittest discover tests` — 237 tests, all passed
- [ ] Manual test with live executor if remote session available

🤖 Generated with [Claude Code](https://claude.com/claude-code)