### PR TITLE
feat(target/context): target 选择与 CommandContext 单解析 + tunnel 所有权/转发验证修复

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-target/
+/target/
 Cargo.lock
 .env
 *.swp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,9 @@ All configuration via env vars — see `src/config.rs` `Config::from_env()`.
 Key vars: `VB_HOST`, `VB_PORT`, `VB_SESSION`, `VB_TIMEOUT` (default 30 s; set to 120 for busy servers),
 `VB_REMOTE_HOST`, `VB_JUMP_HOST`, `VB_CLIENT_ID`/`VB_PROFILE` (per-client scratch isolation),
 `VB_CACHE_DIR` / `VB_HOME` / `VB_LOG_DIR` / `VB_OUTPUT_DIR` / `VB_TMP_DIR` / `VB_STATE_DIR` / `VB_CONFIG_DIR`
-(overrides for `runtime_paths::cache_root` etc. — see `src/runtime_paths.rs`).
+(overrides for `runtime_paths::cache_root` etc. — see `src/runtime_paths.rs`),
+`VB_TARGETS_FILE` (explicit path to `targets.yaml`; overrides `~/.vcli/targets.yaml` — required on Windows,
+where `dirs::home_dir()` reads `FOLDERID_Profile` and ignores `HOME`).
 
 ## GUI Debugging
 

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ vcli [--profile P] [--session S] [--format json|table]
 | `VB_PROFILE` | — | Config profile (reads `VB_*_<profile>` vars) |
 | `VB_CLIENT_ID` | `$VB_PROFILE` or `gethostname()` | Per-client remote scratch scoping (e.g. `vcli-A`, `vcli-B`); isolates `/tmp/virtuoso_bridge/<client>/` paths between concurrent operators |
 | `VCLI_CAPABILITY` | `user` | Set to `admin` to unlock `vcli skill broadcast` and raw SKILL exec |
+| `VB_TARGETS_FILE` | `~/.vcli/targets.yaml` | Explicit path to the targets config file (needed on Windows, where `HOME` is ignored for home-dir lookup) |
 | `RB_DAEMON_PATH` | auto-detected | Override daemon binary path |
 
 ### SSH Remote Connection Setup
@@ -763,6 +764,7 @@ vcli [--profile P] [--session S] [--format json|table]
 | `VB_PROFILE` | - | 配置 profile（读取 `VB_*_<profile>` 变量） |
 | `VB_CLIENT_ID` | `$VB_PROFILE` 或 `gethostname()` | 每客户端远端 scratch 隔离标识（如 `vcli-A`、`vcli-B`）；隔离 `/tmp/virtuoso_bridge/<client>/` 路径，避免多操作员并发冲突 |
 | `VCLI_CAPABILITY` | `user` | 设为 `admin` 解锁 `vcli skill broadcast` 与原始 SKILL 执行权限 |
+| `VB_TARGETS_FILE` | `~/.vcli/targets.yaml` | targets 配置文件的显式路径（Windows 上 `HOME` 对 home 目录查找无效，必须用此变量） |
 | `RB_DAEMON_PATH` | 自动检测 | 覆盖 daemon 二进制路径 |
 
 ### SSH 远程连接配置

--- a/docs/p0a-config-callchain-inventory.md
+++ b/docs/p0a-config-callchain-inventory.md
@@ -90,6 +90,40 @@
 
 `tunnel status` 输出新增 `remote_bridge_port`（归属判别端口），便于诊断本地回退。
 
+### 5.2 tunnel 命令族三轮审阅修复（默认端口非约束 / 转发成功证明 / 部署-尚未就绪）
+
+针对 8cbf83a 后审阅的 4 项问题（本轮，代码已改、未提交）：
+
+| 问题 | 修复 |
+|---|---|
+| attach 无条件按 `cfg.port` 过滤，破坏 legacy 自动发现与 OS 分配端口 | `Config` 新增 `port_explicit: bool`（from_env 按 `VB_PORT` 是否存在、from_target 按 `target.port.is_some()`）。`attach_candidate_sessions()` 仅在「有 target 且 port_explicit」时按端口过滤；target 默认端口与 legacy/profile 一律保留自动发现。`CommandContext::validate_endpoint_ownership` 的端口臂同样只在 `port_explicit` 时生效（host 恒校验）——默认（hash-of-USER）端口不是端点约束，因为 daemon 绑定 OS 分配端口 |
+| `try_ssh_tunnel` 只探测本地端口连通，误判转发成功（端口被其他服务占用时 SSH 已退出） | 去掉 `-f`，spawn 出的 ssh 进程即转发持有者；`wait_for_forward()` 要求「ssh 子进程存活 + 本地端口可达」双条件，探测后再查一次子进程存活；失败即 kill+reap 该次进程，供下一本地端口重试。补真实端口占用测试（occupied+exited→Err、live+open→Ok、live+无监听→超时且子进程被回收） |
+| `ensure_tunnel` 失败时无条件 `cleanup_remote` 删除 profile 共享 setup 目录 | `ensure_tunnel`/`save_state`/`cleanup_remote` 整体删除（不再有"创建即部署隧道"的路径）；`SSHClient::warm()` 收敛为纯部署（返回 IL 路径，不建隧道、不写状态）。共享目录只由 `tunnel stop` 的既有归属决策回收 |
+| 远端 daemon 端口从未解析（`remote_bridge_port = cfg.port` 假设错误） | `SSHClient` 移除 `remote_bridge_port` 字段；`open_tunnel(local, remote)` 显式双端口。`tunnel start` 诚实报告「已部署，尚未就绪」（`daemon_started:false` + `next` 指引 attach）；attach 发现并验证 session 实际监听端口（`live.port`）后转发，并记录 `start_identity`。三态语义收敛：已有 session→attach 发现验证；固定端口启动→由 target 显式 `port` 约束 + attach 过滤；仅部署→start 报告未就绪 |
+
+`port_explicit` 补入全部 `Config { .. }` 字面量构造点（约 10 处，编译恢复）。
+
+### 5.3 四轮审阅修复（转发持有者证明 / ControlMaster 禁用 / restart 语义 / digest 补字段）
+
+针对第 4 轮审阅 4 项问题（本轮，代码已改、未提交）：
+
+| 问题 | 修复 |
+|---|---|
+| `wait_for_forward` 在 SSH 握手期（未尝试绑定前）被已有服务骗过「子进程存活 + 端口可达」 | 成功判定改为「ssh 自身 stderr 绑定标记 + 端口可达 + 子进程存活」三条件：`try_ssh_tunnel` 增加 `-v`，ssh 绑定成功后打印 `Local forwarding listening on 127.0.0.1 port <n>`（`ExitOnForwardFailure` 保证绑定失败即退出）；`wait_for_forward` 后台线程持续排空 stderr 防管道填满，匹配该标记才算成功。原「sleep 30 + 独立监听器→Ok」的误设测试改为「子进程打印绑定标记→Ok」，并补「无关端口已监听 + ssh 延迟失败→拒绝」测试 |
+| 记录的 PID 未必是转发持有者（ControlMaster=auto/ControlPersist=600 可能与假设冲突） | `try_ssh_tunnel` 显式加 `-o ControlMaster=no`，即使 `~/.ssh/config` 开启复用也不影响：spawn 出的 ssh 进程就是唯一的转发持有者，其 PID/start_identity 可验证 |
+| `restart` 执行 stop→start，而 start 现仅部署，断开后不恢复连接 | `restart` 先做无副作用预检 `discover_live_session()`（同 attach 的发现+归属校验），无存活 daemon 时在断开前拒绝；预检通过后 stop→attach（重新发现并建立转发）。`discover_live_session` 抽为 attach/restart 共用 |
+| `Config::digest` 未含 `port_explicit`（同端口数值下两种约束摘要相同） | digest 哈希输入补入 `port_explicit`；tests/config.rs 新增测试：仅切换 `port_explicit` 摘要必须变化、相同配置摘要确定性 |
+
+### 5.4 四轮修复的复检加固（本轮，代码已改、未提交）
+
+对 5.3 落地代码做静态复检 + 编译门禁后追加的 4 处加固：
+
+| 问题 | 修复 |
+|---|---|
+| `-v` 并非无条件生效：OpenSSH 只在用户配置未设 `LogLevel` 时才被 `-v` 抬高，`~/.ssh/config` 里的 `LogLevel QUIET` 会静默掉绑定标记，导致每次 attach 必超时 | 追加 `-o LogLevel=DEBUG1`（命令行 `-o` 优先级高于配置文件），标记输出不再受用户配置影响 |
+| `wait_for_forward` 固定 50×100 ms = 5 s 轮询上限，慢速跳板机握手来不及完成即误判超时；为覆盖慢链路而放大又会线性拖长「超时回收」单测 | 轮询预算参数化：`wait_for_forward(child, port, budget)`。生产走 `TUNNEL_FORWARD_BUDGET = 20 s`（失败路径由子进程退出立即返回，不依赖预算耗尽）；单测各自传短预算（5 s / 500 ms），整组仍约 3 s |
+| 绑定标记未按端口匹配：ssh 若在别的端口上完成绑定，也可能被当成目标端口的证明 | 标记串含端口（`…listening on 127.0.0.1 port <n>`），新增单测 `wait_for_forward_ignores_bind_marker_for_another_port` 固定该行为 |
+| `String::from_utf8_lossy(&log.lock().unwrap()[..])` 借用临时 `MutexGuard`（E0716，编译不通过）；且 `wait_for_forward` 头部残留两份重复文档块 | 抽出 `snapshot()` 辅助函数返回自有 `String`（并对 poisoned mutex 降级取值）；合并重复文档块 |
 
 ## 6. 待办（下一步）
 

--- a/docs/p0a-config-callchain-inventory.md
+++ b/docs/p0a-config-callchain-inventory.md
@@ -77,6 +77,20 @@
   `--profile` 四种选择均正确解析；目标缺失 exit 3、失效 active_target exit 2；
   `tunnel status` 输出含 `target` 与 `config_digest`。
 
+### 5.1 tunnel 命令族二轮审阅修复（本地回退 / attach 归属 / profile 参数）
+
+针对 f68bf12 后审阅的 4 项问题（提交后）：
+
+| 问题 | 修复 |
+|---|---|
+| `ensure_tunnel` 本地端口递增会改写远端身份 | 拆分本地/远端：`SSHClient.remote_bridge_port = cfg.port` 固定，`try_ssh_tunnel(local, remote)` 各自独立；本地端口回退时 `TunnelState` 用 `remote_bridge_port` 单独记录远端端口；`validate_tunnel_ownership` 以远端端口为判别（`remote_bridge_port.or(attached_remote_port).unwrap_or(port)`）；建隧失败清理远端 setup 目录 |
+| attach 未按目标端口筛选会话 | `scoped_attach_sessions()` 先按 `cfg.port` 过滤，再做存活探测与 `validate_session_ownership`；同主机不同端口会话不再误入本目标命名空间（3 单测） |
+| `stop_saved_tunnel`/`SSHClient::stop` 远端清理重读 env | 改用传入 `cfg`（`SSHClient::from_config`）构造清理连接；`SSHClient` 持有 `config` 供 `stop()` 使用，杜绝"env 主机 + context 目录"组合 |
+| `profile show` 丢失显式 `--profile` | `dispatch_profile(cmd, cli_profile)` 直传 CLI profile；配置管理命令仍校验 `--target`/`--profile` 冲突（exit 2）；2 bin 单测 |
+
+`tunnel status` 输出新增 `remote_bridge_port`（归属判别端口），便于诊断本地回退。
+
+
 ## 6. 待办（下一步）
 
 - 迁移 session 命令族（list/show/current/cleanup/history）到 `&CommandContext`；

--- a/docs/p0a-config-callchain-inventory.md
+++ b/docs/p0a-config-callchain-inventory.md
@@ -52,15 +52,35 @@
 
 ## 4. 已完成（本阶段）
 
-- `src/target/resolve.rs`（新）：`resolve_selection` / `resolve_target` / `resolve` +
-  10 个单测（优先级、冲突、VB_TARGET、active_target、损坏配置报错）。
-- `src/main.rs`：接入 `resolve_selection`；`--target`+`--profile` 冲突报错（exit 2）；
-  目标不存在 exit 3；按 resolver 决定同步 env（profile/legacy 时清 `VB_TARGET`）。
-- `config.rs::from_env_with_profile` 的 `VB_TARGET` 分支标注为 TEMPORARY 桥接。
+- `src/target/resolve.rs`（新）：`resolve_selection` / `resolve_target` / `resolve` /
+  `resolve_from_selection` + 17 个单测（优先级、冲突、VB_TARGET、active_target、
+  失效 active_target 报错、最终配置层回归）。
+- `src/main.rs`：接入 resolver；`--target`+`--profile` 冲突报错（exit 2）；
+  目标不存在 exit 3；失效 active_target 报错（exit 2）；按 resolver 决定同步 env。
+- `config.rs::from_env_with_profile` 的 `VB_TARGET` 分支标注为 TEMPORARY 桥接；
+  新增 `from_env_with_profile_no_target`（resolver 隔离 VB_TARGET 干扰）；
+  新增 `Config::digest()`（身份摘要，F05）。
+- `src/context.rs`（新）：`CommandContext { config, target_id, config_digest }` +
+  `validate_session_ownership`（4 单测：摘要稳定性、归属通过/拒绝/跳过）。
 
-## 5. 待办（下一步）
+## 5. CommandContext 迁移进度（P0-A 进行中）
 
-- `CommandContext` 结构 + `VirtuosoClient::from_context`；
-- 迁移 76 处 `from_env` 调用点；
-- 删除 env 桥接分支；
-- target_id / config_digest 摘要计算（供 F05 校验）。
+| 命令族 | 状态 |
+|---|---|
+| tunnel（start/stop/restart/status/diagnose/attach/detach） | ✅ 已迁移：接收 `&CommandContext`，经 `ctx.config()` / `SSHClient::from_config` / `VirtuosoClient::from_context` 使用单次解析配置 |
+| `VirtuosoClient` | ✅ `from_context(ctx)` 新入口；`from_config(cfg, target_id)` 拆出；构造时做会话目标归属校验 |
+| session 命令族 | ⏳ 未迁移（仍经 env 重读） |
+| spectre/runner、skill、maestro 等 | ⏳ 未迁移（仍经 env 重读） |
+| env 桥接（`VB_TARGET`） | ⚠️ 保留给未迁移命令族；与 CommandContext 共用同一 `resolve_selection`，保证一致性 |
+
+- 端到端验证：`tunnel start --dry-run` 对 `--target`/`VB_TARGET`/active_target/
+  `--profile` 四种选择均正确解析；目标缺失 exit 3、失效 active_target exit 2；
+  `tunnel status` 输出含 `target` 与 `config_digest`。
+
+## 6. 待办（下一步）
+
+- 迁移 session 命令族（list/show/current/cleanup/history）到 `&CommandContext`；
+- 迁移 spectre/runner 与其余 `VirtuosoClient::from_env()` 调用点（76 处总量）；
+- 删除 `main()` 的 `VB_TARGET` env 桥接 + `config.rs` 的 `VB_TARGET` 分支
+  （全部命令族迁移完成后）；
+- `config_digest` 接入 daemon Hello 校验（P0-B 前哨，F05）。

--- a/docs/p0a-config-callchain-inventory.md
+++ b/docs/p0a-config-callchain-inventory.md
@@ -1,0 +1,66 @@
+# P0-A · 配置调用链盘点（Config Call-Chain Inventory）
+
+> 日期：2026-09-05
+> 目标：为「命令层显式接收已解析 Config（CommandContext）」的改造提供量化依据。
+> 对应外部审阅项：F06（删除 env 桥接还不够，调用链必须接收同一配置）、F05（配置摘要/身份校验）。
+
+## 1. 现状问题
+
+`main()` 把 `--target` / `--profile` / `--session` 通过 `set_var` 写进进程环境，
+命令层随后再次调用 `Config::from_env()` / `VirtuosoClient::from_env()` 从环境重建配置。
+后果：
+
+- 配置在进程内被解析两次以上（main 一次、各命令层一次），无单一权威来源；
+- `--profile` 与 `VB_TARGET` 的历史优先级矛盾（已修复：main 现在按
+  `target::resolve` 的决定同步 env，见 `src/main.rs` 的 `resolve_selection` 分支）；
+- 目标身份（target_id / config_digest）无法随配置传递，F05 的摘要校验无处挂载。
+
+## 2. 生产路径上的配置重读入口
+
+以下均为非测试代码里「从环境重建配置」的调用点：
+
+| 调用点 | 位置 | 说明 |
+|---|---|---|
+| `Config::from_env()` | `src/commands/tunnel.rs:12` | `tunnel start` |
+| `Config::from_env()` | `src/commands/tunnel.rs:61` | `tunnel attach` |
+| `Config::from_env()` | `src/commands/tunnel.rs:171` | `tunnel status` |
+| `Config::from_env()` | `src/transport/tunnel.rs:555,598` | SSHClient warm / 建连路径 |
+| `Config::from_env()` | `src/spectre/runner.rs:688` | Spectre runner 建连 |
+| `Config::from_env()` | `src/commands/session.rs:12` | session 命令读取 cfg |
+| `SSHClient::from_env` | `src/transport/tunnel.rs:559` | 由 cfg 构造 SSHRunner |
+| `VirtuosoClient::from_env()` | **76 处** | 主要入口，内部再走 `Config::from_env()` |
+| `McpConfig::from_env()` | `src/mcp/server.rs:11` | MCP 独立配置（另议） |
+| `TunnelState` / `SessionInfo` | `src/models.rs:472-495` | 按 profile 读写 session/tunnel 归属 |
+
+## 3. 结论：改造面与顺序
+
+- **大头是 `VirtuosoClient::from_env()`（76 处）**：它内部统一走
+  `Config::from_env()`，只需把「接收显式 Config」做进 `VirtuosoClient` 的构造路径，
+  即可一次性覆盖绝大多数调用点，无需逐命令改签名。
+- 优先级：先 `VirtuosoClient`（76 处）→ `tunnel` 命令（start/attach/status）→
+  `spectre/runner` → `session` 命令 → `MCP`。
+- 落点设计（与审阅报告 P0-A 一致）：
+  1. `main()` 调用 `target::resolve::resolve(cli.target, cli.profile)` 得到一次性的
+     `ResolvedTarget { name, config }`；
+  2. 构造轻量 `CommandContext { config, target_id: Option<String>, config_digest }`；
+  3. `VirtuosoClient::from_context(&CommandContext)` 成为新入口，`from_env()` 保留为
+     兼容封装；
+  4. 删除 `main()` 的 `VB_TARGET` env 桥接 + `config.rs::from_env_with_profile` 的
+     `VB_TARGET` 分支（当前已标注 TEMPORARY）。
+- `config_digest`：对非秘密字段（host/port/user/jump/backend/超时等）做确定性摘要，
+  供 daemon Hello / 请求身份校验（F05）。
+
+## 4. 已完成（本阶段）
+
+- `src/target/resolve.rs`（新）：`resolve_selection` / `resolve_target` / `resolve` +
+  10 个单测（优先级、冲突、VB_TARGET、active_target、损坏配置报错）。
+- `src/main.rs`：接入 `resolve_selection`；`--target`+`--profile` 冲突报错（exit 2）；
+  目标不存在 exit 3；按 resolver 决定同步 env（profile/legacy 时清 `VB_TARGET`）。
+- `config.rs::from_env_with_profile` 的 `VB_TARGET` 分支标注为 TEMPORARY 桥接。
+
+## 5. 待办（下一步）
+
+- `CommandContext` 结构 + `VirtuosoClient::from_context`；
+- 迁移 76 处 `from_env` 调用点；
+- 删除 env 桥接分支；
+- target_id / config_digest 摘要计算（供 F05 校验）。

--- a/docs/p0a-notes-env-evidence.md
+++ b/docs/p0a-notes-env-evidence.md
@@ -1,0 +1,70 @@
+# P0-A · 环境问题证据记录（未定论）
+
+> 日期：2026-09-05
+> 状态：**记录证据，不作"已彻底定位/已解决"的结论**。不修改全局 shell 配置。
+
+## 1. streaming 管道测试偶发失败（`transport::ssh`）
+
+**现象**：`streaming_pipeline_drains_large_producer_stderr_without_deadlock`
+在**隔离运行**时通过（默认构建约 0.74s），但在**全量 `cargo test --lib`
+并行负载**下偶发 `Timeout(20)`。
+
+**已抓取的确凿 panic**（`/tmp/libtest_full.log`）：
+
+```
+thread '...streaming_pipeline_drains_large_producer_stderr_without_deadlock' panicked at src/transport/ssh.rs:859:90:
+called `Result::unwrap()` on an `Err` value: Timeout(20)
+```
+
+**同一运行中的负载证据**：测试框架报告
+`fixture_allows_open_ssh_transport_roundtrip has been running for over 60 seconds`
+（该测试最终通过，但耗时 >60s）——说明失败当次整套件负载极重。
+
+**对照结果**：
+
+| 运行条件 | 结果 |
+|---|---|
+| 隔离，默认构建 | 通过（~0.74s） |
+| 隔离，native-ssh 构建 | 通过 |
+| 全量，ulimit 256 | 失败 `Timeout(20)` |
+| 全量，ulimit 4096，native-ssh | 通过（lib 31.78s） |
+| 全量，ulimit 4096，默认 | 失败 `Timeout(20)`（另见 >60s 测试） |
+
+**结论（暂定）**：20s 是死锁**检测**上限而非性能上限——真死锁无论预算多少
+都不会完成，超时会照常失败。失败当次存在"其他测试 >60s"的负载证据，且
+隔离/部分条件下通过，指向**机器负载 + fd 压力叠加的环境问题**，而非确定的
+代码并发缺陷。**不能据此宣称无并发缺陷，也未排除机器处于异常慢状态。**
+
+**新增负载证据（决定性）**：失败期间 `uptime` 报告
+`load averages: 29.40 33.69 44.26`（1/5/15 分钟），`6 users` 登录的共享机器，
+严重过载（远超本机核心数）。同时段简单 `grep`/`sed` 均出现 >15s 挂起。该证据
+支持"环境负载"而非代码缺陷的判断。
+
+**处置**：保留 5s→20s 作为测试容错调整（不构成修复）；是否再放宽待后续
+在负载正常时机重跑判定。
+
+## 2. 文件描述符上限
+
+- 当前 shell `ulimit -n` = **256**；内核上限 `kern.maxfilesperproc` = **122880**。
+- 提高至 4096 后 native-ssh 全量套件通过一次，但默认构建在 4096 下仍失败
+  （见上表）——**fd 上限是重要线索，但不是已被证实的唯一根因**。
+- **未修改 `~/.zshrc` 等全局配置**。测试/构建时以 `ulimit -n 4096` 前缀临时设置，
+  保留上述对照结果。
+
+## 3. `cargo fmt` 段错误（未解决）
+
+- 本机 `cargo fmt`（rustfmt 1.9.0-stable）**稳定段错误（exit 139）**，属工具链
+  问题，与文件内容无关；单文件 / 批量 rustfmt 均正常。
+- 临时替代：`rustfmt --edition 2021 $(find src tests -name '*.rs')`（应用与
+  `--check` 均可用）。
+- **等价性说明**：替代命令的 `--edition 2021`、文件集合 `src tests -name '*.rs'`、
+  默认 rustfmt 配置均与 `cargo fmt` 对齐，`--check` 通过。但 `cargo fmt` 崩溃
+  仍单列为**未解决项**，CI 若走 `cargo fmt --check` 需在工具链正常的环境执行，
+  不能以本机替代命令的通过宣称"全部标准门禁已通过"。
+
+## 4. 后续建议（不自动执行）
+
+- 在负载正常时段重跑全量套件，确认 streaming 测试通过率；
+- 若频繁复现，考虑给该测试标注 `#[ignore]` 并加独立说明，或在测试内用更长
+  检测上限（不影响真死锁检出）；
+- fd 上限与 rustfmt 崩溃是否修复，由用户在 shell 配置 / 工具链层面决定。

--- a/src/client/bridge.rs
+++ b/src/client/bridge.rs
@@ -100,12 +100,27 @@ impl VirtuosoClient {
     }
 
     fn from_config(cfg: Config, target_id: Option<String>) -> Result<Self> {
+        // One shared ownership-validation context (F05). A `CommandContext` is
+        // cheap (digest computation only); building it here keeps every check
+        // below on the same identity rule implemented in `context.rs`.
+        let ctx = crate::context::CommandContext::new(cfg.clone(), target_id)?;
+
         let tunnel = if cfg.is_remote() {
-            let state = crate::models::TunnelState::load().ok().flatten();
+            // Load tunnel state under the *config's* profile namespace, never the
+            // ambient `VB_PROFILE` — otherwise `--target prod` could reuse a
+            // tunnel recorded for `test`.
+            let state = crate::models::TunnelState::load_with_profile(cfg.profile.as_deref())
+                .ok()
+                .flatten();
             if let Some(ref s) = state {
+                // Validate the tunnel belongs to this target *before* reusing it.
+                // This is a tunnel-ownership check, not a substitute for the
+                // session check below — an existing tunnel bypasses session
+                // selection entirely.
+                ctx.validate_tunnel_ownership(s)?;
                 if is_port_open(s.port) {
                     tracing::info!("reusing existing tunnel on port {}", s.port);
-                    let client = SSHClient::from_env(cfg.keep_remote_files)?;
+                    let client = SSHClient::from_config(&cfg, cfg.keep_remote_files)?;
                     Some(client)
                 } else {
                     None
@@ -175,17 +190,11 @@ impl VirtuosoClient {
         }
 
         // P0-A ownership (F05): when a target is selected, a session recorded
-        // against a different host is an ownership violation — switching targets
-        // must not silently reuse the wrong session.
-        if let (Some(tid), Some(session)) = (target_id.as_deref(), resolved_session.as_ref()) {
-            let target_host = cfg.remote_host.as_deref().unwrap_or("");
-            if !target_host.is_empty() && session.host != target_host {
-                return Err(crate::error::VirtuosoError::Config(format!(
-                    "session '{}' belongs to host '{}' but target '{tid}' resolves to '{}'; \
-                     refusing to reuse the wrong session (run `vcli session list`)",
-                    session.id, session.host, target_host
-                )));
-            }
+        // against a different host or a different bridge port (same host, other
+        // target) is an ownership violation. Single rule lives in
+        // `CommandContext::validate_session_ownership`.
+        if let Some(session) = resolved_session.as_ref() {
+            ctx.validate_session_ownership(session)?;
         }
 
         Ok(Self {
@@ -1487,6 +1496,105 @@ mod client_id_tests {
         );
 
         std::env::remove_var("VB_PORT");
+        clear_env();
+    }
+
+    /// Real construction path (F05 regression): a session recorded on the SAME
+    /// compute host but a different bridge port belongs to another target and
+    /// must be rejected by `VirtuosoClient::from_context` — the actual path the
+    /// CLI takes, not just the unit-level `validate_session_ownership` check.
+    #[test]
+    #[serial]
+    fn from_context_rejects_session_on_same_host_but_other_target_bridge_port() {
+        clear_env();
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("cache");
+        let state = dir.path().join("state");
+        std::fs::create_dir_all(cache.join("virtuoso_bridge/sessions")).unwrap();
+        // A session that belongs to `test` (bridge port 30002), sharing the
+        // same compute node as `prod` (bridge port 30001).
+        let sess = serde_json::json!({
+            "id": "sess-wrong-port",
+            "port": 30002,
+            "pid": 42,
+            "host": "compute-eda-42",
+            "user": "user1",
+            "created": "2026-01-01T00:00:00Z",
+        });
+        std::fs::write(
+            cache.join("virtuoso_bridge/sessions/sess-wrong-port.json"),
+            serde_json::to_string(&sess).unwrap(),
+        )
+        .unwrap();
+
+        std::env::set_var("VB_CACHE_DIR", &cache);
+        std::env::set_var("VB_STATE_DIR", &state);
+        std::env::set_var("VB_SESSION", "sess-wrong-port");
+        std::env::set_var("VB_REMOTE_HOST_prodfix", "compute-eda-42");
+        std::env::set_var("VB_PORT_prodfix", "30001");
+
+        let mut cfg = Config::from_env_with_profile(Some("prodfix")).unwrap();
+        cfg.profile = None; // state/tunnel reads key on the target namespace
+        let ctx = crate::context::CommandContext::new(cfg.clone(), Some("prod".into())).unwrap();
+
+        let error = match VirtuosoClient::from_context(&ctx) {
+            Ok(_) => panic!("session on another target's bridge port must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            error.to_string().contains("is on bridge port 30002"),
+            "expected bridge-port ownership error, got: {error}"
+        );
+
+        std::env::remove_var("VB_REMOTE_HOST_prodfix");
+        std::env::remove_var("VB_PORT_prodfix");
+        std::env::remove_var("VB_CACHE_DIR");
+        std::env::remove_var("VB_STATE_DIR");
+        clear_env();
+    }
+
+    /// Positive control on the same construction path: a session matching the
+    /// target's host AND bridge port constructs a client successfully.
+    #[test]
+    #[serial]
+    fn from_context_accepts_session_matching_target_host_and_bridge_port() {
+        clear_env();
+        let dir = tempfile::tempdir().unwrap();
+        let cache = dir.path().join("cache");
+        let state = dir.path().join("state");
+        std::fs::create_dir_all(cache.join("virtuoso_bridge/sessions")).unwrap();
+        let sess = serde_json::json!({
+            "id": "sess-right-port",
+            "port": 30001,
+            "pid": 42,
+            "host": "compute-eda-42",
+            "user": "user1",
+            "created": "2026-01-01T00:00:00Z",
+        });
+        std::fs::write(
+            cache.join("virtuoso_bridge/sessions/sess-right-port.json"),
+            serde_json::to_string(&sess).unwrap(),
+        )
+        .unwrap();
+
+        std::env::set_var("VB_CACHE_DIR", &cache);
+        std::env::set_var("VB_STATE_DIR", &state);
+        std::env::set_var("VB_SESSION", "sess-right-port");
+        std::env::set_var("VB_REMOTE_HOST_prodfix", "compute-eda-42");
+        std::env::set_var("VB_PORT_prodfix", "30001");
+
+        let mut cfg = Config::from_env_with_profile(Some("prodfix")).unwrap();
+        cfg.profile = None;
+        let ctx = crate::context::CommandContext::new(cfg.clone(), Some("prod".into())).unwrap();
+
+        let client = VirtuosoClient::from_context(&ctx)
+            .expect("session matching target host+port must construct");
+        assert_eq!(client.port, 30001);
+
+        std::env::remove_var("VB_REMOTE_HOST_prodfix");
+        std::env::remove_var("VB_PORT_prodfix");
+        std::env::remove_var("VB_CACHE_DIR");
+        std::env::remove_var("VB_STATE_DIR");
         clear_env();
     }
 }

--- a/src/client/bridge.rs
+++ b/src/client/bridge.rs
@@ -4,6 +4,7 @@ use crate::client::maestro_ops::MaestroOps;
 use crate::client::schematic_ops::SchematicOps;
 use crate::client::whitelist::EvalstringWhitelist;
 use crate::client::window_ops::WindowOps;
+use crate::config::Config;
 use crate::error::{Result, VirtuosoError};
 use crate::models::{ExecutionStatus, SessionInfo, VirtuosoResult};
 use crate::transport::contract::CommandRequest;
@@ -87,7 +88,18 @@ impl VirtuosoClient {
 
     pub fn from_env() -> Result<Self> {
         let cfg = crate::config::Config::from_env()?;
+        Self::from_config(cfg, None)
+    }
 
+    /// Build a client from an already-resolved CommandContext (P0-A). The
+    /// config is parsed exactly once in `main()`; this path never re-reads the
+    /// environment for host/port/backend. Session selection still follows
+    /// `--session`/`VB_SESSION` and is validated against the context's target.
+    pub fn from_context(ctx: &crate::context::CommandContext) -> Result<Self> {
+        Self::from_config(ctx.config().clone(), ctx.target_id().map(str::to_string))
+    }
+
+    fn from_config(cfg: Config, target_id: Option<String>) -> Result<Self> {
         let tunnel = if cfg.is_remote() {
             let state = crate::models::TunnelState::load().ok().flatten();
             if let Some(ref s) = state {
@@ -160,6 +172,20 @@ impl VirtuosoClient {
         // Skipped if daemon_user is not yet known (populated lazily by `session show`).
         if let Some(ref session) = resolved_session {
             guard_cross_user(session)?;
+        }
+
+        // P0-A ownership (F05): when a target is selected, a session recorded
+        // against a different host is an ownership violation — switching targets
+        // must not silently reuse the wrong session.
+        if let (Some(tid), Some(session)) = (target_id.as_deref(), resolved_session.as_ref()) {
+            let target_host = cfg.remote_host.as_deref().unwrap_or("");
+            if !target_host.is_empty() && session.host != target_host {
+                return Err(crate::error::VirtuosoError::Config(format!(
+                    "session '{}' belongs to host '{}' but target '{tid}' resolves to '{}'; \
+                     refusing to reuse the wrong session (run `vcli session list`)",
+                    session.id, session.host, target_host
+                )));
+            }
         }
 
         Ok(Self {

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -9,7 +9,7 @@ use crate::transport::tunnel::SSHClient;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-pub fn start(ctx: &CommandContext, timeout: Option<u64>, dry_run: bool) -> Result<Value> {
+pub fn start(ctx: &CommandContext, _timeout: Option<u64>, dry_run: bool) -> Result<Value> {
     let cfg = ctx.config();
 
     if dry_run {
@@ -24,8 +24,13 @@ pub fn start(ctx: &CommandContext, timeout: Option<u64>, dry_run: bool) -> Resul
         }));
     }
 
-    let mut client = SSHClient::from_config(cfg, cfg.keep_remote_files)?;
-    client.warm(timeout)?;
+    // Deploy-only. The daemon is started by Virtuoso loading the deployed IL,
+    // at which point it binds an OS-assigned port — vcli does NOT start it and
+    // does NOT know the endpoint yet. Reporting "deployed, not ready" instead
+    // of a guessed port is what keeps the endpoint honest (the bridge's
+    // `RBStart` passes port=0; see resources/ramic_bridge.il).
+    let client = SSHClient::from_config(cfg, cfg.keep_remote_files)?;
+    let il_path = client.warm()?;
 
     // Auto-discover remote sessions and sync them to local cache.
     // This allows `vcli skill exec` to find the Virtuoso daemon port
@@ -33,15 +38,19 @@ pub fn start(ctx: &CommandContext, timeout: Option<u64>, dry_run: bool) -> Resul
     let transport = client.transport();
     let sessions_synced = SessionInfo::sync_from_remote(transport.as_ref()).unwrap_or(0);
 
-    let vc = VirtuosoClient::from_context(ctx)?;
-    let daemon_ok = matches!(vc.test_connection(Some(cfg.timeout)), Ok(true));
-
     Ok(json!({
-        "status": "started",
-        "port": client.port,
+        "status": "deployed",
+        "daemon_started": false,
+        "il_path": il_path,
         "remote_host": cfg.remote_host.as_deref().unwrap_or("local"),
-        "daemon_responsive": daemon_ok,
         "sessions_synced": sessions_synced,
+        "next": format!(
+            "load '{il_path}' in Virtuoso (or run RBStart() in CIW) to start the daemon, \
+             then `vcli tunnel attach{}` to open the tunnel to the daemon's port",
+            ctx.target_id()
+                .map(|t| format!(" --target {t}"))
+                .unwrap_or_default()
+        ),
     }))
 }
 
@@ -53,6 +62,75 @@ fn scoped_attach_sessions(sessions: Vec<SessionInfo>, target_port: u16) -> Vec<S
         .into_iter()
         .filter(|s| s.port == target_port)
         .collect()
+}
+
+/// Choose the candidate sessions for `tunnel attach`.
+///
+/// The bridge port is scoped ONLY when the target has an explicit port
+/// constraint (`port_explicit`). A default (hash-of-USER) port is not an
+/// endpoint constraint — the daemon binds an OS-assigned port — so it must
+/// never filter out discovered sessions. Target-less (legacy/profile) mode
+/// keeps full auto-discovery.
+fn attach_candidate_sessions(
+    sessions: Vec<SessionInfo>,
+    has_target: bool,
+    port: u16,
+    port_explicit: bool,
+) -> Vec<SessionInfo> {
+    if has_target && port_explicit {
+        scoped_attach_sessions(sessions, port)
+    } else {
+        sessions
+    }
+}
+
+/// Discover and validate a live daemon session for this target, without any
+/// side effects. Shared by [`attach`] and by `restart`'s pre-flight check, so
+/// restart refuses BEFORE disconnecting when there is nothing to re-attach to.
+///
+/// The bridge port is scoped only when the target's port is an explicit
+/// constraint (`port_explicit`); a default port never filters discoveries.
+/// Ownership is validated via [`CommandContext::validate_session_ownership`]
+/// (host always; bridge port only when explicit).
+fn discover_live_session(ctx: &CommandContext, client: &SSHClient) -> Result<SessionInfo> {
+    let cfg = ctx.config();
+    let transport = client.transport();
+
+    let sessions = SessionInfo::list_remote(transport.as_ref())?;
+    if sessions.is_empty() {
+        return Err(VirtuosoError::NotFound(
+            "no Virtuoso sessions found on remote; run `vcli tunnel start` to deploy a fresh daemon"
+                .into(),
+        ));
+    }
+
+    let scoped = attach_candidate_sessions(
+        sessions,
+        ctx.target_id().is_some(),
+        cfg.port,
+        cfg.port_explicit,
+    );
+    if scoped.is_empty() {
+        return Err(VirtuosoError::NotFound(format!(
+            "no session found on bridge port {} for target '{}'; \
+             run `vcli tunnel start` to deploy a fresh daemon on this target",
+            cfg.port,
+            ctx.target_id().unwrap_or("(selected)")
+        )));
+    }
+
+    let host_hint = cfg.remote_host.as_deref();
+    let live = pick_live_session(scoped, transport.as_ref(), host_hint)?.ok_or_else(|| {
+        VirtuosoError::NotFound(
+            "found session(s) on remote but no live daemons (port not listening); \
+                 check that Virtuoso is running and the daemon process is alive"
+                .into(),
+        )
+    })?;
+
+    // Final ownership guard (F05) before opening the tunnel / writing state.
+    ctx.validate_session_ownership(&live)?;
+    Ok(live)
 }
 
 /// Connect to a Virtuoso daemon that already exists on the remote host.
@@ -91,43 +169,7 @@ pub fn attach(ctx: &CommandContext, dry_run: bool) -> Result<Value> {
     // warm() (which would deploy a fresh daemon). The runner is configured
     // by from_config() but no remote command runs until we explicitly call one.
     let mut client = SSHClient::from_config(cfg, cfg.keep_remote_files)?;
-    let transport = client.transport();
-
-    let sessions = SessionInfo::list_remote(transport.as_ref())?;
-    if sessions.is_empty() {
-        return Err(VirtuosoError::NotFound(
-            "no Virtuoso sessions found on remote; run `vcli tunnel start` to deploy a fresh daemon".into()
-        ));
-    }
-
-    // Target-scoped selection (F05): only sessions whose bridge port matches
-    // this target's configured port may be attached. We must never fall back
-    // to a different-port daemon — that would record another target's tunnel
-    // into this target's namespace, which stop/detach would then reject (and
-    // which the ownership check below forbids anyway).
-    let target_port = cfg.port;
-    let scoped = scoped_attach_sessions(sessions, target_port);
-    if scoped.is_empty() {
-        return Err(VirtuosoError::NotFound(format!(
-            "no session found on bridge port {target_port} for target '{}'; \
-             run `vcli tunnel start` to deploy a fresh daemon on this target",
-            ctx.target_id().unwrap_or("(selected)")
-        )));
-    }
-
-    let host_hint = cfg.remote_host.as_deref();
-    let live = pick_live_session(scoped, transport.as_ref(), host_hint)?.ok_or_else(|| {
-        VirtuosoError::NotFound(
-            "found session(s) on remote but no live daemons (port not listening); \
-                 check that Virtuoso is running and the daemon process is alive"
-                .into(),
-        )
-    })?;
-
-    // Final ownership guard (F05) before opening the tunnel / writing state.
-    // Single rule in CommandContext::validate_session_ownership. For target
-    // selections this is defense-in-depth on top of the port filter above.
-    ctx.validate_session_ownership(&live)?;
+    let live = discover_live_session(ctx, &client)?;
 
     if dry_run {
         return Ok(json!({
@@ -148,9 +190,10 @@ pub fn attach(ctx: &CommandContext, dry_run: bool) -> Result<Value> {
     // forwarding keeps scripts that bind to the canonical daemon port
     // working without reconfiguration. `open_tunnel` runs `ssh -L
     // 127.0.0.1:<port>:127.0.0.1:<port>`, so this forwards to the
-    // discovered listener exactly.
+    // discovered listener exactly, and only reports success once the
+    // forward-holding ssh is verified alive.
     let local_port = live.port;
-    client.open_tunnel(local_port)?;
+    client.open_tunnel(local_port, live.port)?;
 
     let now_ms = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -167,7 +210,7 @@ pub fn attach(ctx: &CommandContext, dry_run: bool) -> Result<Value> {
         backend: Some("openssh".to_string()),
         daemon_nonce: None,
         executable_path: None,
-        start_identity: None,
+        start_identity: client.tunnel_identity(),
         ipc_endpoint: None,
         token_path: None,
         local_forward: Some(format!("L*:{local_port}")),
@@ -299,17 +342,23 @@ pub fn detach(ctx: &CommandContext) -> Result<Value> {
     }))
 }
 
-pub fn restart(ctx: &CommandContext, timeout: Option<u64>) -> Result<Value> {
+pub fn restart(ctx: &CommandContext, _timeout: Option<u64>) -> Result<Value> {
+    // Pre-flight BEFORE stopping: `start` is deploy-only and cannot restore a
+    // connection, so restart must refuse (without disconnecting the user) when
+    // there is no live daemon to re-attach to.
+    let client = SSHClient::from_config(ctx.config(), ctx.config().keep_remote_files)?;
+    discover_live_session(ctx, &client)?;
+
     let stop_result = match stop(ctx, false, false) {
         Ok(v) => Some(v),
         Err(VirtuosoError::NotFound(_)) => None,
         Err(e) => return Err(e),
     };
-    let start_result = start(ctx, timeout, false)?;
+    let attach_result = attach(ctx, false)?;
 
     Ok(json!({
         "stop": stop_result,
-        "start": start_result,
+        "attach": attach_result,
     }))
 }
 
@@ -842,6 +891,41 @@ mod tests {
         assert_eq!(scoped_attach_sessions(sessions, 30001).len(), 2);
     }
 
+    #[test]
+    fn attach_candidates_unfiltered_for_default_port() {
+        // A default (hash-of-USER) target port is NOT an endpoint constraint:
+        // the daemon binds an OS-assigned port, so sessions on other ports
+        // must stay discoverable.
+        let sessions = vec![
+            session("os-41234", 41234, "compute-eda-42"),
+            session("os-41235", 41235, "compute-eda-42"),
+        ];
+        let kept = attach_candidate_sessions(sessions, true, 65013, false);
+        assert_eq!(kept.len(), 2, "default port must not filter discoveries");
+    }
+
+    #[test]
+    fn attach_candidates_unfiltered_for_legacy_no_target() {
+        // Legacy/profile mode (no target) keeps full auto-discovery.
+        let sessions = vec![
+            session("os-41234", 41234, "compute-eda-42"),
+            session("os-41235", 41235, "compute-eda-42"),
+        ];
+        let kept = attach_candidate_sessions(sessions, false, 30001, true);
+        assert_eq!(kept.len(), 2, "target-less mode must not filter by port");
+    }
+
+    #[test]
+    fn attach_candidates_filtered_for_explicit_target_port() {
+        let sessions = vec![
+            session("prod-30001", 30001, "compute-eda-42"),
+            session("test-30002", 30002, "compute-eda-42"),
+        ];
+        let kept = attach_candidate_sessions(sessions, true, 30001, true);
+        assert_eq!(kept.len(), 1);
+        assert_eq!(kept[0].id, "prod-30001");
+    }
+
     // ─── Warning text + JSON shape (existing 4 tests) ────────────────────
 
     #[test]
@@ -1010,6 +1094,7 @@ mod backend_diagnostics_tests {
             remote_host: None,
             remote_user: None,
             port: 0,
+            port_explicit: false,
             jump_host: None,
             jump_user: None,
             ssh_port: None,

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -63,7 +63,8 @@ pub fn attach(ctx: &CommandContext, dry_run: bool) -> Result<Value> {
 
     // Refuse if a tunnel of any mode is already up. The user can pick the
     // matching verb to clean up (`detach` for attached, `stop` for deployed).
-    if let Some(existing) = TunnelState::load()? {
+    // Read under the config's profile namespace (same identity as the write).
+    if let Some(existing) = TunnelState::load_with_profile(cfg.profile.as_deref())? {
         let mode = existing.mode.as_deref().unwrap_or(TUNNEL_MODE_DEPLOYED);
         let verb = if mode == TUNNEL_MODE_ATTACHED {
             "detach"
@@ -142,13 +143,15 @@ pub fn attach(ctx: &CommandContext, dry_run: bool) -> Result<Value> {
         local_forward: Some(format!("L*:{local_port}")),
         start_time_unix_ms: Some(now_ms),
         health: None,
-        config_digest: None,
+        config_digest: Some(ctx.config_digest().to_string()),
         mode: Some(TUNNEL_MODE_ATTACHED.into()),
         attached_remote_port: Some(live.port),
         attached_session_id: Some(live.id.clone()),
     };
+    // Write under the config's profile namespace so later stop/detach/status
+    // reads (also profile-keyed) see this tunnel — never the ambient VB_PROFILE.
     state
-        .save()
+        .save_with_profile(cfg.profile.as_deref())
         .map_err(|e| VirtuosoError::Ssh(format!("save tunnel state: {e}")))?;
 
     // Mirror the remote session metadata into the local cache so subsequent
@@ -171,11 +174,19 @@ pub fn attach(ctx: &CommandContext, dry_run: bool) -> Result<Value> {
 pub fn stop(ctx: &CommandContext, force: bool, dry_run: bool) -> Result<Value> {
     let cfg = ctx.config();
 
-    let state = TunnelState::load()?;
+    // Read the tunnel state under the *config's* profile namespace, never the
+    // ambient `VB_PROFILE` — otherwise `--target prod` could stop a tunnel
+    // recorded for `test` and then clean up using prod's config (mixed
+    // identities). Read, write and cleanup all key on `cfg.profile`.
+    let state = TunnelState::load_with_profile(cfg.profile.as_deref())?;
     let state = match state {
         Some(s) => s,
         None => return Err(VirtuosoError::NotFound("no running tunnel found".into())),
     };
+
+    // Ownership (F05): never stop a tunnel that belongs to another target —
+    // including the same host with a different bridge port.
+    ctx.validate_tunnel_ownership(&state)?;
 
     let mode = state.mode.as_deref().unwrap_or(TUNNEL_MODE_DEPLOYED);
 
@@ -226,21 +237,14 @@ pub fn stop(ctx: &CommandContext, force: bool, dry_run: bool) -> Result<Value> {
 /// `tunnel stop` instead, since deployed tunnels own a setup dir that
 /// needs cleanup).
 pub fn detach(ctx: &CommandContext) -> Result<Value> {
-    let state = TunnelState::load()?
+    let cfg = ctx.config();
+    let state = TunnelState::load_with_profile(cfg.profile.as_deref())?
         .ok_or_else(|| VirtuosoError::NotFound("no attached tunnel found".into()))?;
 
     // P0-A ownership (F05): never detach a tunnel that belongs to another
-    // target's host.
-    if let Some(tid) = ctx.target_id() {
-        let target_host = ctx.config().remote_host.as_deref().unwrap_or("");
-        if !target_host.is_empty() && state.remote_host != target_host {
-            return Err(VirtuosoError::Config(format!(
-                "tunnel belongs to host '{}' but target '{tid}' resolves to '{}'; \
-                 refusing to touch another target's tunnel",
-                state.remote_host, target_host
-            )));
-        }
-    }
+    // target — single rule in `CommandContext::validate_tunnel_ownership`
+    // (host + remote bridge port).
+    ctx.validate_tunnel_ownership(&state)?;
 
     let mode = state.mode.as_deref().unwrap_or(TUNNEL_MODE_DEPLOYED);
     if mode != TUNNEL_MODE_ATTACHED {
@@ -251,7 +255,7 @@ pub fn detach(ctx: &CommandContext) -> Result<Value> {
 
     kill_tunnel_pid(state.pid, false);
 
-    TunnelState::clear()?;
+    TunnelState::clear_with_profile(cfg.profile.as_deref())?;
 
     Ok(json!({
         "status": "detached",
@@ -280,7 +284,9 @@ pub fn restart(ctx: &CommandContext, timeout: Option<u64>) -> Result<Value> {
 
 pub fn diagnose(ctx: &CommandContext) -> Result<Value> {
     let cfg = ctx.config();
-    let port = TunnelState::load()?.map(|s| s.port).unwrap_or(cfg.port);
+    let port = TunnelState::load_with_profile(cfg.profile.as_deref())?
+        .map(|s| s.port)
+        .unwrap_or(cfg.port);
 
     // TCP reachability
     let tcp_ok = std::net::TcpStream::connect_timeout(
@@ -403,7 +409,7 @@ pub fn status(ctx: &CommandContext, format: OutputFormat) -> Result<Value> {
         "scratch_root": cfg.roles.scratch_root(),
     });
 
-    let tunnel_info = if let Some(state) = TunnelState::load()? {
+    let tunnel_info = if let Some(state) = TunnelState::load_with_profile(cfg.profile.as_deref())? {
         let port_open = std::net::TcpStream::connect(format!("127.0.0.1:{}", state.port)).is_ok();
         let host_match = !cfg.is_remote() || Some(&state.remote_host) == cfg.remote_host.as_ref();
 
@@ -436,7 +442,9 @@ pub fn status(ctx: &CommandContext, format: OutputFormat) -> Result<Value> {
     };
     result["tunnel"] = tunnel_info;
 
-    let port = TunnelState::load()?.map(|s| s.port).unwrap_or(cfg.port);
+    let port = TunnelState::load_with_profile(cfg.profile.as_deref())?
+        .map(|s| s.port)
+        .unwrap_or(cfg.port);
 
     let mut daemon_info = if std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
         let vc = VirtuosoClient::new("127.0.0.1", port, cfg.timeout);

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -45,6 +45,16 @@ pub fn start(ctx: &CommandContext, timeout: Option<u64>, dry_run: bool) -> Resul
     }))
 }
 
+/// Filter remote sessions down to those belonging to `target_port` (the
+/// target's configured bridge port). Same-host, same-user sessions from a
+/// *different* target must never be attachable into this target's namespace.
+fn scoped_attach_sessions(sessions: Vec<SessionInfo>, target_port: u16) -> Vec<SessionInfo> {
+    sessions
+        .into_iter()
+        .filter(|s| s.port == target_port)
+        .collect()
+}
+
 /// Connect to a Virtuoso daemon that already exists on the remote host.
 ///
 /// This is the non-destructive counterpart to [`start`]: instead of deploying
@@ -90,14 +100,34 @@ pub fn attach(ctx: &CommandContext, dry_run: bool) -> Result<Value> {
         ));
     }
 
+    // Target-scoped selection (F05): only sessions whose bridge port matches
+    // this target's configured port may be attached. We must never fall back
+    // to a different-port daemon — that would record another target's tunnel
+    // into this target's namespace, which stop/detach would then reject (and
+    // which the ownership check below forbids anyway).
+    let target_port = cfg.port;
+    let scoped = scoped_attach_sessions(sessions, target_port);
+    if scoped.is_empty() {
+        return Err(VirtuosoError::NotFound(format!(
+            "no session found on bridge port {target_port} for target '{}'; \
+             run `vcli tunnel start` to deploy a fresh daemon on this target",
+            ctx.target_id().unwrap_or("(selected)")
+        )));
+    }
+
     let host_hint = cfg.remote_host.as_deref();
-    let live = pick_live_session(sessions, transport.as_ref(), host_hint)?.ok_or_else(|| {
+    let live = pick_live_session(scoped, transport.as_ref(), host_hint)?.ok_or_else(|| {
         VirtuosoError::NotFound(
             "found session(s) on remote but no live daemons (port not listening); \
                  check that Virtuoso is running and the daemon process is alive"
                 .into(),
         )
     })?;
+
+    // Final ownership guard (F05) before opening the tunnel / writing state.
+    // Single rule in CommandContext::validate_session_ownership. For target
+    // selections this is defense-in-depth on top of the port filter above.
+    ctx.validate_session_ownership(&live)?;
 
     if dry_run {
         return Ok(json!({
@@ -146,6 +176,7 @@ pub fn attach(ctx: &CommandContext, dry_run: bool) -> Result<Value> {
         config_digest: Some(ctx.config_digest().to_string()),
         mode: Some(TUNNEL_MODE_ATTACHED.into()),
         attached_remote_port: Some(live.port),
+        remote_bridge_port: Some(live.port),
         attached_session_id: Some(live.id.clone()),
     };
     // Write under the config's profile namespace so later stop/detach/status
@@ -427,6 +458,10 @@ pub fn status(ctx: &CommandContext, format: OutputFormat) -> Result<Value> {
         json!({
             "running": true,
             "port": state.port,
+            "remote_bridge_port": state
+                .remote_bridge_port
+                .or(state.attached_remote_port)
+                .unwrap_or(state.port),
             "pid": state.pid,
             "remote_host": state.remote_host,
             "port_reachable": port_open,
@@ -756,6 +791,55 @@ mod tests {
             actual: actual.into(),
             mismatch: actual != configured,
         }
+    }
+
+    fn session(id: &str, port: u16, host: &str) -> SessionInfo {
+        SessionInfo {
+            id: id.into(),
+            host: host.into(),
+            user: "user1".into(),
+            port,
+            pid: 0,
+            created: String::new(),
+            daemon_user: None,
+            daemon_version: None,
+        }
+    }
+
+    // ─── scoped_attach_sessions (F05) ────────────────────────────────────
+
+    #[test]
+    fn attach_scope_keeps_only_target_bridge_port() {
+        // Same host, two targets: prod=30001, test=30002. Only the prod
+        // session may be attachable for a prod target.
+        let sessions = vec![
+            session("prod-30001", 30001, "compute-eda-42"),
+            session("test-30002", 30002, "compute-eda-42"),
+            session("prod-30001-2", 30001, "compute-eda-42"),
+        ];
+        let scoped = scoped_attach_sessions(sessions, 30001);
+        assert_eq!(scoped.len(), 2);
+        assert!(scoped.iter().all(|s| s.port == 30001));
+    }
+
+    #[test]
+    fn attach_scope_empty_when_target_port_absent() {
+        let sessions = vec![
+            session("test-30002", 30002, "compute-eda-42"),
+            session("dev-30003", 30003, "compute-eda-42"),
+        ];
+        assert!(scoped_attach_sessions(sessions, 30001).is_empty());
+    }
+
+    #[test]
+    fn attach_scope_is_port_specific_not_host_specific() {
+        // Different hosts with the same bridge port still belong to the same
+        // target port; the scope is by port, host matching happens later.
+        let sessions = vec![
+            session("a-30001", 30001, "compute-a"),
+            session("b-30001", 30001, "compute-b"),
+        ];
+        assert_eq!(scoped_attach_sessions(sessions, 30001).len(), 2);
     }
 
     // ─── Warning text + JSON shape (existing 4 tests) ────────────────────

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -1,5 +1,6 @@
 use crate::client::bridge::VirtuosoClient;
 use crate::config::Config;
+use crate::context::CommandContext;
 use crate::error::{Result, VirtuosoError};
 use crate::models::{SessionInfo, TunnelState, TUNNEL_MODE_ATTACHED, TUNNEL_MODE_DEPLOYED};
 use crate::output::OutputFormat;
@@ -8,8 +9,8 @@ use crate::transport::tunnel::SSHClient;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-pub fn start(timeout: Option<u64>, dry_run: bool) -> Result<Value> {
-    let cfg = Config::from_env()?;
+pub fn start(ctx: &CommandContext, timeout: Option<u64>, dry_run: bool) -> Result<Value> {
+    let cfg = ctx.config();
 
     if dry_run {
         return Ok(json!({
@@ -23,7 +24,7 @@ pub fn start(timeout: Option<u64>, dry_run: bool) -> Result<Value> {
         }));
     }
 
-    let mut client = SSHClient::from_env(cfg.keep_remote_files)?;
+    let mut client = SSHClient::from_config(cfg, cfg.keep_remote_files)?;
     client.warm(timeout)?;
 
     // Auto-discover remote sessions and sync them to local cache.
@@ -32,7 +33,7 @@ pub fn start(timeout: Option<u64>, dry_run: bool) -> Result<Value> {
     let transport = client.transport();
     let sessions_synced = SessionInfo::sync_from_remote(transport.as_ref()).unwrap_or(0);
 
-    let vc = crate::client::bridge::VirtuosoClient::from_env()?;
+    let vc = VirtuosoClient::from_context(ctx)?;
     let daemon_ok = matches!(vc.test_connection(Some(cfg.timeout)), Ok(true));
 
     Ok(json!({
@@ -57,8 +58,8 @@ pub fn start(timeout: Option<u64>, dry_run: bool) -> Result<Value> {
 /// `tunnel detach` (which kills the tunnel SSH process and clears state).
 ///
 /// Returns `Err(NotFound)` if no live daemon can be discovered.
-pub fn attach(dry_run: bool) -> Result<Value> {
-    let cfg = Config::from_env()?;
+pub fn attach(ctx: &CommandContext, dry_run: bool) -> Result<Value> {
+    let cfg = ctx.config();
 
     // Refuse if a tunnel of any mode is already up. The user can pick the
     // matching verb to clean up (`detach` for attached, `stop` for deployed).
@@ -77,8 +78,8 @@ pub fn attach(dry_run: bool) -> Result<Value> {
 
     // SSHClient here is used purely as a transport wrapper — we don't call
     // warm() (which would deploy a fresh daemon). The runner is configured
-    // by from_env() but no remote command runs until we explicitly call one.
-    let mut client = SSHClient::from_env(cfg.keep_remote_files)?;
+    // by from_config() but no remote command runs until we explicitly call one.
+    let mut client = SSHClient::from_config(cfg, cfg.keep_remote_files)?;
     let transport = client.transport();
 
     let sessions = SessionInfo::list_remote(transport.as_ref())?;
@@ -167,8 +168,8 @@ pub fn attach(dry_run: bool) -> Result<Value> {
     }))
 }
 
-pub fn stop(force: bool, dry_run: bool) -> Result<Value> {
-    let cfg = Config::from_env()?;
+pub fn stop(ctx: &CommandContext, force: bool, dry_run: bool) -> Result<Value> {
+    let cfg = ctx.config();
 
     let state = TunnelState::load()?;
     let state = match state {
@@ -203,7 +204,7 @@ pub fn stop(force: bool, dry_run: bool) -> Result<Value> {
     //      tunnel is ours or proven gone (a live/unverifiable daemon is kept)
     //   2. ownership — only a `deployed` tunnel owns its remote setup dir; an
     //      `attached` daemon belongs to Virtuoso and is never rm -rf'd
-    crate::transport::tunnel::stop_saved_tunnel(&cfg, &state, force)?;
+    crate::transport::tunnel::stop_saved_tunnel(cfg, &state, force)?;
 
     Ok(json!({
         "status": "stopped",
@@ -224,9 +225,22 @@ pub fn stop(force: bool, dry_run: bool) -> Result<Value> {
 /// `Err(Execution)` when the recorded tunnel is in `deployed` mode (use
 /// `tunnel stop` instead, since deployed tunnels own a setup dir that
 /// needs cleanup).
-pub fn detach() -> Result<Value> {
+pub fn detach(ctx: &CommandContext) -> Result<Value> {
     let state = TunnelState::load()?
         .ok_or_else(|| VirtuosoError::NotFound("no attached tunnel found".into()))?;
+
+    // P0-A ownership (F05): never detach a tunnel that belongs to another
+    // target's host.
+    if let Some(tid) = ctx.target_id() {
+        let target_host = ctx.config().remote_host.as_deref().unwrap_or("");
+        if !target_host.is_empty() && state.remote_host != target_host {
+            return Err(VirtuosoError::Config(format!(
+                "tunnel belongs to host '{}' but target '{tid}' resolves to '{}'; \
+                 refusing to touch another target's tunnel",
+                state.remote_host, target_host
+            )));
+        }
+    }
 
     let mode = state.mode.as_deref().unwrap_or(TUNNEL_MODE_DEPLOYED);
     if mode != TUNNEL_MODE_ATTACHED {
@@ -250,13 +264,13 @@ pub fn detach() -> Result<Value> {
     }))
 }
 
-pub fn restart(timeout: Option<u64>) -> Result<Value> {
-    let stop_result = match stop(false, false) {
+pub fn restart(ctx: &CommandContext, timeout: Option<u64>) -> Result<Value> {
+    let stop_result = match stop(ctx, false, false) {
         Ok(v) => Some(v),
         Err(VirtuosoError::NotFound(_)) => None,
         Err(e) => return Err(e),
     };
-    let start_result = start(timeout, false)?;
+    let start_result = start(ctx, timeout, false)?;
 
     Ok(json!({
         "stop": stop_result,
@@ -264,8 +278,8 @@ pub fn restart(timeout: Option<u64>) -> Result<Value> {
     }))
 }
 
-pub fn diagnose() -> Result<Value> {
-    let cfg = Config::from_env()?;
+pub fn diagnose(ctx: &CommandContext) -> Result<Value> {
+    let cfg = ctx.config();
     let port = TunnelState::load()?.map(|s| s.port).unwrap_or(cfg.port);
 
     // TCP reachability
@@ -364,14 +378,16 @@ pub fn diagnose() -> Result<Value> {
     Ok(result)
 }
 
-pub fn status(format: OutputFormat) -> Result<Value> {
-    let cfg = Config::from_env()?;
+pub fn status(ctx: &CommandContext, format: OutputFormat) -> Result<Value> {
+    let cfg = ctx.config();
 
     let mut result = json!({
         "config": {
             "remote_host": cfg.remote_host.as_deref().unwrap_or("local"),
             "port": cfg.port,
             "timeout": cfg.timeout,
+            "target": ctx.target_id(),
+            "config_digest": ctx.config_digest(),
         }
     });
 
@@ -396,7 +412,7 @@ pub fn status(format: OutputFormat) -> Result<Value> {
         // ran a native daemon last, then re-launched with `VB_SSH_BACKEND=
         // openssh` and the legacy state file still says `native`).
         let (config_backend_value, tunnel_backend_value, drift_warning) =
-            backend_diagnostics(&cfg, Some(state.backend_or_openssh()));
+            backend_diagnostics(cfg, Some(state.backend_or_openssh()));
         result["config"]["backend"] = config_backend_value;
         if let Some(warning) = drift_warning {
             result["config"]["backend_warning"] = json!(warning);
@@ -414,7 +430,7 @@ pub fn status(format: OutputFormat) -> Result<Value> {
     } else {
         // No live tunnel — report the config-selected backend alone; the
         // recorded backend is irrelevant until a tunnel is actually running.
-        let (config_backend_value, _, _) = backend_diagnostics(&cfg, None);
+        let (config_backend_value, _, _) = backend_diagnostics(cfg, None);
         result["config"]["backend"] = config_backend_value;
         json!({ "running": false })
     };

--- a/src/config.rs
+++ b/src/config.rs
@@ -490,6 +490,29 @@ impl Config {
         })
     }
 
+    /// Deterministic SHA-256 over the non-secret identity fields of the
+    /// resolved config. Used for config identity (F05): `tunnel status` drift
+    /// detection and daemon Hello validation compare this digest instead of
+    /// trusting parsed values alone. Credentials (key paths, tokens) are
+    /// deliberately excluded.
+    pub fn digest(&self) -> String {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        for part in [
+            self.remote_host.as_deref().unwrap_or(""),
+            &self.port.to_string(),
+            self.remote_user.as_deref().unwrap_or(""),
+            self.jump_host.as_deref().unwrap_or(""),
+            self.jump_user.as_deref().unwrap_or(""),
+            self.profile.as_deref().unwrap_or(""),
+            self.ssh_backend.as_deref().unwrap_or(""),
+        ] {
+            hasher.update(part.as_bytes());
+            hasher.update([0u8]);
+        }
+        hex::encode(hasher.finalize())
+    }
+
     pub fn is_remote(&self) -> bool {
         self.remote_host.is_some()
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -293,7 +293,37 @@ impl Config {
     }
 
     pub fn from_env_with_profile(profile: Option<&str>) -> Result<Self> {
+        Self::from_env_resolve(profile, true)
+    }
+
+    /// Like [`from_env_with_profile`] but never honors the ambient `VB_TARGET`
+    /// bridge. Used by `target::resolve` for profile/legacy selections so a
+    /// leftover `VB_TARGET` cannot hijack the resolved configuration.
+    pub(crate) fn from_env_with_profile_no_target(profile: Option<&str>) -> Result<Self> {
+        Self::from_env_resolve(profile, false)
+    }
+
+    fn from_env_resolve(profile: Option<&str>, honor_vb_target: bool) -> Result<Self> {
         load_dotenv_upward();
+
+        if honor_vb_target {
+            // TEMPORARY bridge (P0-A): main() resolves the target/profile
+            // selection via target::resolve and syncs VB_TARGET here. This
+            // branch must be removed together with the env-var bridge when
+            // commands receive the resolved Config explicitly (CommandContext
+            // propagation).
+            if let Ok(target_name) = std::env::var("VB_TARGET") {
+                if !target_name.is_empty() {
+                    let manager = crate::target::TargetManager::load().map_err(|e| {
+                        VirtuosoError::Config(format!("failed to load targets: {e}"))
+                    })?;
+                    let target = manager.get(&target_name).ok_or_else(|| {
+                        VirtuosoError::Config(format!("target '{}' not found", target_name))
+                    })?;
+                    return Self::from_target(target, &target_name);
+                }
+            }
+        }
 
         let remote_host = Self::env_with_profile("VB_REMOTE_HOST", profile);
 
@@ -398,6 +428,66 @@ impl Config {
             .unwrap_or_default();
         let hash: u16 = user.bytes().map(|b| b as u16).sum::<u16>() % 500;
         65000 + hash
+    }
+
+    /// Create a Config from a TargetConfig (multi-target mode).
+    ///
+    /// TargetConfig fields override defaults; None fields fall back to
+    /// the same defaults as from_env().
+    pub fn from_target(target: &crate::target::TargetConfig, target_name: &str) -> Result<Self> {
+        let port = target.port.unwrap_or_else(Self::default_port);
+        if port == 0 {
+            return Err(VirtuosoError::Config(
+                "target port must be between 1 and 65535".into(),
+            ));
+        }
+
+        Ok(Self {
+            profile: Some(target_name.to_string()),
+            remote_host: target.remote_host.clone(),
+            remote_user: target.remote_user.clone(),
+            port,
+            jump_host: target.jump_host.clone(),
+            jump_user: target.jump_user.clone(),
+            ssh_port: target.ssh_port,
+            ssh_key: target.ssh_key.clone(),
+            ssh_config: target.ssh_config.clone(),
+            ssh_backend: target.ssh_backend.clone(),
+            disable_control_master: target.disable_control_master.unwrap_or(false),
+            timeout: target.timeout.unwrap_or(30),
+            read_timeout: target.read_timeout.unwrap_or(120),
+            keep_remote_files: target.keep_remote_files.unwrap_or(false),
+            spectre_cmd: target
+                .spectre_cmd
+                .clone()
+                .unwrap_or_else(|| "spectre".into()),
+            spectre_args: target.spectre_args.clone().unwrap_or_default(),
+            spectre_max_workers: target.spectre_max_workers.unwrap_or(8),
+            ssh_max_sessions: target
+                .ssh_max_sessions
+                .unwrap_or(crate::transport::scheduler::SchedulerLimits::DEFAULT_TOTAL),
+            ssh_max_bulk_sessions: target
+                .ssh_max_bulk_sessions
+                .unwrap_or(crate::transport::scheduler::SchedulerLimits::DEFAULT_BULK),
+            ssh_reconnect_max_attempts: target
+                .ssh_reconnect_max_attempts
+                .unwrap_or(crate::transport::lifecycle::ReconnectPolicy::DEFAULT_MAX_ATTEMPTS),
+            ssh_reconnect_max_delay: target
+                .ssh_reconnect_max_delay
+                .unwrap_or(crate::transport::lifecycle::ReconnectPolicy::DEFAULT_MAX_DELAY),
+            ssh_keepalive_interval: target
+                .ssh_keepalive_interval
+                .unwrap_or(crate::transport::lifecycle::KeepalivePolicy::DEFAULT_INTERVAL),
+            ssh_keepalive_failures: target
+                .ssh_keepalive_failures
+                .unwrap_or(crate::transport::lifecycle::KeepalivePolicy::DEFAULT_FAILURES),
+            transport_shutdown_grace: 10,
+            cadence_cshrc: target.cadence_cshrc.clone(),
+            spectre_bin: target.spectre_bin.clone(),
+            roles: RemoteRoles::default(),
+            transport_daemon_socket: target.transport_daemon_socket.clone(),
+            transport_daemon_token: target.transport_daemon_token.clone(),
+        })
     }
 
     pub fn is_remote(&self) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,12 @@ pub struct Config {
     pub remote_host: Option<String>,
     pub remote_user: Option<String>,
     pub port: u16,
+    /// Whether `port` is an explicit user constraint (VB_PORT set / target's
+    /// `port:` field present) rather than the hash-of-USER default. A default
+    /// port is NOT a bridge-endpoint constraint: daemons bind OS-assigned
+    /// ports, so a default `port` must never be used to filter or reject
+    /// discovered sessions (only an explicit port can be).
+    pub port_explicit: bool,
     pub jump_host: Option<String>,
     pub jump_user: Option<String>,
     pub ssh_port: Option<u16>,
@@ -330,6 +336,7 @@ impl Config {
         let port: u16 = Self::env_with_profile("VB_PORT", profile)
             .and_then(|v| v.parse().ok())
             .unwrap_or_else(Self::default_port);
+        let port_explicit = Self::env_with_profile("VB_PORT", profile).is_some();
 
         if port == 0 {
             return Err(VirtuosoError::Config(
@@ -347,6 +354,7 @@ impl Config {
             remote_host,
             remote_user: Self::env_with_profile("VB_REMOTE_USER", profile),
             port,
+            port_explicit,
             jump_host: Self::env_with_profile("VB_JUMP_HOST", profile),
             jump_user: Self::env_with_profile("VB_JUMP_USER", profile),
             ssh_port: Self::env_with_profile("VB_SSH_PORT", profile).and_then(|v| v.parse().ok()),
@@ -436,6 +444,7 @@ impl Config {
     /// the same defaults as from_env().
     pub fn from_target(target: &crate::target::TargetConfig, target_name: &str) -> Result<Self> {
         let port = target.port.unwrap_or_else(Self::default_port);
+        let port_explicit = target.port.is_some();
         if port == 0 {
             return Err(VirtuosoError::Config(
                 "target port must be between 1 and 65535".into(),
@@ -447,6 +456,7 @@ impl Config {
             remote_host: target.remote_host.clone(),
             remote_user: target.remote_user.clone(),
             port,
+            port_explicit,
             jump_host: target.jump_host.clone(),
             jump_user: target.jump_user.clone(),
             ssh_port: target.ssh_port,
@@ -495,15 +505,18 @@ impl Config {
     /// detection and daemon Hello validation compare this digest instead of
     /// trusting parsed values alone. Credentials are deliberately excluded,
     /// but all fields that shape the connection identity ARE included: host,
-    /// bridge port, SSH port, the *path* of the identity key / ssh_config
-    /// (paths, not key material), jump route, backend, timeouts and control
-    /// master behaviour.
+    /// bridge port AND whether that port is an explicit constraint
+    /// (`port_explicit` — the same port value with auto-discovery vs forced
+    /// port-matching must hash differently), SSH port, the *path* of the
+    /// identity key / ssh_config (paths, not key material), jump route,
+    /// backend, timeouts and control master behaviour.
     pub fn digest(&self) -> String {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
         for part in [
             self.remote_host.as_deref().unwrap_or(""),
             &self.port.to_string(),
+            &self.port_explicit.to_string(),
             self.remote_user.as_deref().unwrap_or(""),
             &self
                 .ssh_port

--- a/src/config.rs
+++ b/src/config.rs
@@ -493,8 +493,11 @@ impl Config {
     /// Deterministic SHA-256 over the non-secret identity fields of the
     /// resolved config. Used for config identity (F05): `tunnel status` drift
     /// detection and daemon Hello validation compare this digest instead of
-    /// trusting parsed values alone. Credentials (key paths, tokens) are
-    /// deliberately excluded.
+    /// trusting parsed values alone. Credentials are deliberately excluded,
+    /// but all fields that shape the connection identity ARE included: host,
+    /// bridge port, SSH port, the *path* of the identity key / ssh_config
+    /// (paths, not key material), jump route, backend, timeouts and control
+    /// master behaviour.
     pub fn digest(&self) -> String {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
@@ -502,10 +505,19 @@ impl Config {
             self.remote_host.as_deref().unwrap_or(""),
             &self.port.to_string(),
             self.remote_user.as_deref().unwrap_or(""),
+            &self
+                .ssh_port
+                .map(|p| p.to_string())
+                .unwrap_or_else(|| "22".into()),
+            self.ssh_key.as_deref().unwrap_or(""),
+            self.ssh_config.as_deref().unwrap_or(""),
             self.jump_host.as_deref().unwrap_or(""),
             self.jump_user.as_deref().unwrap_or(""),
             self.profile.as_deref().unwrap_or(""),
             self.ssh_backend.as_deref().unwrap_or(""),
+            &self.disable_control_master.to_string(),
+            &self.timeout.to_string(),
+            &self.read_timeout.to_string(),
         ] {
             hasher.update(part.as_bytes());
             hasher.update([0u8]);

--- a/src/context.rs
+++ b/src/context.rs
@@ -66,11 +66,11 @@ impl CommandContext {
     }
 
     /// Validate that a tunnel state belongs to this context's target.
-    /// `state.port` is the local forward port and may legitimately fall back
-    /// from the target's bridge port, so the ownership discriminator is the
-    /// *remote* bridge port: `remote_bridge_port` (deployed, fixed at
-    /// `cfg.port`) or `attached_remote_port` (attached), falling back to
-    /// `port` only for legacy state files.
+    /// `state.port` is the local forward port; the ownership discriminator is
+    /// the *remote* bridge port actually used: `remote_bridge_port` (the
+    /// discovered daemon port, recorded by attach) or `attached_remote_port`,
+    /// falling back to `port` only for legacy state files. The bridge-port arm
+    /// only fires when the target's port is an explicit constraint.
     pub fn validate_tunnel_ownership(&self, state: &crate::models::TunnelState) -> Result<()> {
         let remote_port = state
             .remote_bridge_port
@@ -85,6 +85,13 @@ impl CommandContext {
     }
 
     /// Shared host + bridge-port ownership rule.
+    ///
+    /// The bridge-port arm applies ONLY when the target's port is an explicit
+    /// user constraint (`Config::port_explicit`). A default (hash-of-USER)
+    /// port is not an endpoint constraint — daemons bind OS-assigned ports —
+    /// so it must never reject a discovered session or tunnel. Host identity is
+    /// always enforced in target mode; target-less (legacy env) selections
+    /// skip the whole check.
     fn validate_endpoint_ownership(
         &self,
         kind: &str,
@@ -104,9 +111,10 @@ impl CommandContext {
             )));
         }
         // Same-host discrimination: two targets on one compute node differ by
-        // their remote bridge port, so a port mismatch is an ownership
-        // violation even when the host matches.
-        if self.config.port != 0 && port != self.config.port {
+        // their remote bridge port, so an explicitly configured port mismatch
+        // is an ownership violation even when the host matches. A non-explicit
+        // (default) port is not a constraint and is never checked here.
+        if self.config.port_explicit && self.config.port != 0 && port != self.config.port {
             return Err(VirtuosoError::Config(format!(
                 "{kind} '{id}' is on bridge port {port} but target '{}' uses port {}; \
                  refusing to reuse the wrong {kind}",
@@ -339,5 +347,67 @@ mod tests {
         assert!(ctx
             .validate_session_ownership(&session_with("compute-eda-99", 30001))
             .is_ok());
+    }
+
+    /// A target config whose port is NOT an explicit constraint (mirrors a
+    /// target whose `port:` field is absent → hash-of-USER default). Built as
+    /// a literal rather than via env so ambient `VB_PORT` cannot leak in.
+    fn cfg_with_default_port(host: &str) -> Config {
+        let mut c = cfg_with(host, 65013);
+        c.port_explicit = false;
+        c
+    }
+
+    #[serial]
+    #[test]
+    fn ownership_default_port_is_not_a_constraint_same_host() {
+        // The daemon binds an OS-assigned port; a default cfg.port must never
+        // reject a discovered session that happens to differ from it.
+        let ctx = CommandContext::new(cfg_with_default_port("compute-eda-42"), Some("prod".into()))
+            .unwrap();
+        assert!(ctx
+            .validate_session_ownership(&session_with("compute-eda-42", 41234))
+            .is_ok());
+    }
+
+    #[serial]
+    #[test]
+    fn ownership_default_port_still_enforces_host() {
+        let ctx = CommandContext::new(cfg_with_default_port("compute-eda-42"), Some("prod".into()))
+            .unwrap();
+        let err = ctx
+            .validate_session_ownership(&session_with("compute-eda-99", 41234))
+            .unwrap_err();
+        assert!(err.to_string().contains("belongs to host 'compute-eda-99'"));
+    }
+
+    #[serial]
+    #[test]
+    fn tunnel_ownership_default_port_is_not_a_constraint() {
+        let ctx = CommandContext::new(cfg_with_default_port("compute-eda-42"), Some("prod".into()))
+            .unwrap();
+        let state = crate::models::TunnelState {
+            version: crate::models::CURRENT_STATE_VERSION,
+            port: 41234,
+            pid: 0,
+            remote_host: "compute-eda-42".into(),
+            setup_path: None,
+            profile: Some("prod".into()),
+            backend: Some("openssh".into()),
+            daemon_nonce: None,
+            executable_path: None,
+            start_identity: None,
+            ipc_endpoint: None,
+            token_path: None,
+            local_forward: None,
+            start_time_unix_ms: None,
+            health: None,
+            config_digest: None,
+            mode: Some(crate::models::TUNNEL_MODE_ATTACHED.into()),
+            attached_remote_port: Some(41234),
+            remote_bridge_port: Some(41234),
+            attached_session_id: None,
+        };
+        assert!(ctx.validate_tunnel_ownership(&state).is_ok());
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,152 @@
+//! CommandContext: the single resolved configuration for one invocation.
+//!
+//! P0-A: migrated command families receive their [`Config`] here instead of
+//! re-reading the environment (`Config::from_env()`). `main()` resolves the
+//! effective selection exactly once via `target::resolve`, builds a
+//! `CommandContext`, and hands the same immutable context to every migrated
+//! command — so host/port/backend/etc. are parsed once per process and there is
+//! no second, potentially divergent env re-read.
+//!
+//! The context also carries the target identity (`target_id`) and a
+//! deterministic [`Config::digest`] so downstream layers (tunnel status drift
+//! detection, daemon Hello validation, F05) can verify they are talking to the
+//! intended endpoint rather than trusting parsed values alone.
+
+use crate::config::Config;
+use crate::error::{Result, VirtuosoError};
+
+/// Immutable resolved configuration plus target identity for one invocation.
+#[derive(Debug, Clone)]
+pub struct CommandContext {
+    config: Config,
+    target_id: Option<String>,
+    config_digest: String,
+}
+
+impl CommandContext {
+    /// Build a context from a resolved target (name + config).
+    pub fn from_resolved(resolved: &crate::target::resolve::ResolvedTarget) -> Result<Self> {
+        Self::new(resolved.config.clone(), resolved.name.clone())
+    }
+
+    /// Build a context from a config and an optional target name.
+    pub fn new(config: Config, target_id: Option<String>) -> Result<Self> {
+        let config_digest = config.digest();
+        Ok(Self {
+            config,
+            target_id,
+            config_digest,
+        })
+    }
+
+    /// The resolved configuration. Migrated commands must use this instead of
+    /// `Config::from_env()`.
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// The selected target name, if the selection was target-backed.
+    pub fn target_id(&self) -> Option<&str> {
+        self.target_id.as_deref()
+    }
+
+    /// Deterministic digest of the resolved config (identity check, F05).
+    pub fn config_digest(&self) -> &str {
+        &self.config_digest
+    }
+
+    /// Validate that a session belongs to this context's target.
+    ///
+    /// When a target is selected, a session recorded against a different host
+    /// is an ownership violation — switching targets must not silently reuse
+    /// the wrong session (report F05: "切换目标不复用错误 session").
+    /// Target-less (legacy env) selections skip the check.
+    pub fn validate_session_ownership(&self, session: &crate::models::SessionInfo) -> Result<()> {
+        if self.target_id.is_none() {
+            return Ok(());
+        }
+        let target_host = self.config.remote_host.as_deref().unwrap_or("");
+        if !target_host.is_empty() && session.host != target_host {
+            return Err(VirtuosoError::Config(format!(
+                "session '{}' belongs to host '{}' but target '{}' resolves to '{}'; \
+                 refusing to reuse the wrong session (run `vcli session list`)",
+                session.id,
+                session.host,
+                self.target_id().unwrap_or("unknown"),
+                target_host
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::SessionInfo;
+    use serial_test::serial;
+
+    fn cfg_with_host(host: &str) -> Config {
+        // Build via env_with_profile with a scoped var, then strip profile.
+        std::env::set_var("VB_REMOTE_HOST_targettest", host);
+        let mut c = Config::from_env_with_profile(Some("targettest")).unwrap();
+        std::env::remove_var("VB_REMOTE_HOST_targettest");
+        c.profile = None;
+        c
+    }
+
+    fn session(host: &str) -> SessionInfo {
+        SessionInfo {
+            id: "sess-test".into(),
+            port: 30001,
+            pid: 42,
+            host: host.into(),
+            user: "user1".into(),
+            created: "2026-01-01T00:00:00Z".into(),
+            daemon_user: None,
+            daemon_version: None,
+        }
+    }
+
+    #[serial]
+    #[test]
+    fn digest_is_stable_and_identifies_host() {
+        let c1 = cfg_with_host("compute-a");
+        let c2 = cfg_with_host("compute-b");
+        let c1b = cfg_with_host("compute-a");
+        assert_eq!(c1.digest(), c1b.digest());
+        assert_ne!(c1.digest(), c2.digest());
+    }
+
+    #[serial]
+    #[test]
+    fn ownership_check_passes_on_matching_host() {
+        let ctx =
+            CommandContext::new(cfg_with_host("compute-eda-42"), Some("prod".into())).unwrap();
+        assert!(ctx
+            .validate_session_ownership(&session("compute-eda-42"))
+            .is_ok());
+    }
+
+    #[serial]
+    #[test]
+    fn ownership_check_rejects_wrong_host_session() {
+        let ctx =
+            CommandContext::new(cfg_with_host("compute-eda-42"), Some("prod".into())).unwrap();
+        let err = ctx
+            .validate_session_ownership(&session("compute-eda-99"))
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("refusing to reuse the wrong session"));
+    }
+
+    #[serial]
+    #[test]
+    fn ownership_check_skipped_without_target() {
+        let ctx = CommandContext::new(cfg_with_host("compute-eda-42"), None).unwrap();
+        assert!(ctx
+            .validate_session_ownership(&session("compute-eda-99"))
+            .is_ok());
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -57,23 +57,56 @@ impl CommandContext {
 
     /// Validate that a session belongs to this context's target.
     ///
-    /// When a target is selected, a session recorded against a different host
-    /// is an ownership violation — switching targets must not silently reuse
-    /// the wrong session (report F05: "切换目标不复用错误 session").
-    /// Target-less (legacy env) selections skip the check.
+    /// Single source of truth for target-ownership validation (report F05).
+    /// Distinguishes both the host and the remote bridge port, so two targets
+    /// on the same compute node with different bridge ports are not conflated.
+    /// Target-less (legacy env) selections skip the check entirely.
     pub fn validate_session_ownership(&self, session: &crate::models::SessionInfo) -> Result<()> {
+        self.validate_endpoint_ownership("session", &session.id, &session.host, session.port)
+    }
+
+    /// Validate that a tunnel state belongs to this context's target.
+    /// `state.port` is the local forward port; the discriminator against the
+    /// target is the *remote* bridge port (`attached_remote_port` when set,
+    /// otherwise the deployed tunnel's `port`).
+    pub fn validate_tunnel_ownership(&self, state: &crate::models::TunnelState) -> Result<()> {
+        let remote_port = state.attached_remote_port.unwrap_or(state.port);
+        self.validate_endpoint_ownership(
+            "tunnel",
+            &state.port.to_string(),
+            &state.remote_host,
+            remote_port,
+        )
+    }
+
+    /// Shared host + bridge-port ownership rule.
+    fn validate_endpoint_ownership(
+        &self,
+        kind: &str,
+        id: &str,
+        host: &str,
+        port: u16,
+    ) -> Result<()> {
         if self.target_id.is_none() {
             return Ok(());
         }
         let target_host = self.config.remote_host.as_deref().unwrap_or("");
-        if !target_host.is_empty() && session.host != target_host {
+        if !target_host.is_empty() && host != target_host {
             return Err(VirtuosoError::Config(format!(
-                "session '{}' belongs to host '{}' but target '{}' resolves to '{}'; \
-                 refusing to reuse the wrong session (run `vcli session list`)",
-                session.id,
-                session.host,
+                "{kind} '{id}' belongs to host '{host}' but target '{}' resolves to '{target_host}'; \
+                 refusing to reuse the wrong {kind} (run `vcli session list`)",
+                self.target_id().unwrap_or("unknown")
+            )));
+        }
+        // Same-host discrimination: two targets on one compute node differ by
+        // their remote bridge port, so a port mismatch is an ownership
+        // violation even when the host matches.
+        if self.config.port != 0 && port != self.config.port {
+            return Err(VirtuosoError::Config(format!(
+                "{kind} '{id}' is on bridge port {port} but target '{}' uses port {}; \
+                 refusing to reuse the wrong {kind}",
                 self.target_id().unwrap_or("unknown"),
-                target_host
+                self.config.port
             )));
         }
         Ok(())
@@ -86,19 +119,21 @@ mod tests {
     use crate::models::SessionInfo;
     use serial_test::serial;
 
-    fn cfg_with_host(host: &str) -> Config {
-        // Build via env_with_profile with a scoped var, then strip profile.
+    fn cfg_with(host: &str, port: u16) -> Config {
+        // Build via env_with_profile with scoped vars, then strip profile.
         std::env::set_var("VB_REMOTE_HOST_targettest", host);
+        std::env::set_var("VB_PORT_targettest", port.to_string());
         let mut c = Config::from_env_with_profile(Some("targettest")).unwrap();
         std::env::remove_var("VB_REMOTE_HOST_targettest");
+        std::env::remove_var("VB_PORT_targettest");
         c.profile = None;
         c
     }
 
-    fn session(host: &str) -> SessionInfo {
+    fn session_with(host: &str, port: u16) -> SessionInfo {
         SessionInfo {
             id: "sess-test".into(),
-            port: 30001,
+            port,
             pid: 42,
             host: host.into(),
             user: "user1".into(),
@@ -111,20 +146,28 @@ mod tests {
     #[serial]
     #[test]
     fn digest_is_stable_and_identifies_host() {
-        let c1 = cfg_with_host("compute-a");
-        let c2 = cfg_with_host("compute-b");
-        let c1b = cfg_with_host("compute-a");
+        let c1 = cfg_with("compute-a", 30001);
+        let c2 = cfg_with("compute-b", 30001);
+        let c1b = cfg_with("compute-a", 30001);
         assert_eq!(c1.digest(), c1b.digest());
         assert_ne!(c1.digest(), c2.digest());
     }
 
     #[serial]
     #[test]
-    fn ownership_check_passes_on_matching_host() {
+    fn digest_changes_when_bridge_port_changes() {
+        let c1 = cfg_with("compute-eda-42", 30001);
+        let c2 = cfg_with("compute-eda-42", 30002);
+        assert_ne!(c1.digest(), c2.digest());
+    }
+
+    #[serial]
+    #[test]
+    fn ownership_check_passes_on_matching_host_and_port() {
         let ctx =
-            CommandContext::new(cfg_with_host("compute-eda-42"), Some("prod".into())).unwrap();
+            CommandContext::new(cfg_with("compute-eda-42", 30001), Some("prod".into())).unwrap();
         assert!(ctx
-            .validate_session_ownership(&session("compute-eda-42"))
+            .validate_session_ownership(&session_with("compute-eda-42", 30001))
             .is_ok());
     }
 
@@ -132,9 +175,9 @@ mod tests {
     #[test]
     fn ownership_check_rejects_wrong_host_session() {
         let ctx =
-            CommandContext::new(cfg_with_host("compute-eda-42"), Some("prod".into())).unwrap();
+            CommandContext::new(cfg_with("compute-eda-42", 30001), Some("prod".into())).unwrap();
         let err = ctx
-            .validate_session_ownership(&session("compute-eda-99"))
+            .validate_session_ownership(&session_with("compute-eda-99", 30001))
             .unwrap_err();
         assert!(err
             .to_string()
@@ -143,10 +186,52 @@ mod tests {
 
     #[serial]
     #[test]
+    fn ownership_check_rejects_same_host_different_bridge_port() {
+        // prod/test share a compute node; only the bridge port distinguishes them.
+        let ctx =
+            CommandContext::new(cfg_with("compute-eda-42", 30001), Some("prod".into())).unwrap();
+        let err = ctx
+            .validate_session_ownership(&session_with("compute-eda-42", 30002))
+            .unwrap_err();
+        assert!(err.to_string().contains("is on bridge port 30002"));
+    }
+
+    #[serial]
+    #[test]
+    fn tunnel_ownership_check_rejects_same_host_different_bridge_port() {
+        let ctx =
+            CommandContext::new(cfg_with("compute-eda-42", 30001), Some("prod".into())).unwrap();
+        let state = crate::models::TunnelState {
+            version: crate::models::CURRENT_STATE_VERSION,
+            port: 40001,
+            pid: 0,
+            remote_host: "compute-eda-42".into(),
+            setup_path: None,
+            profile: Some("prod".into()),
+            backend: Some("openssh".into()),
+            daemon_nonce: None,
+            executable_path: None,
+            start_identity: None,
+            ipc_endpoint: None,
+            token_path: None,
+            local_forward: None,
+            start_time_unix_ms: None,
+            health: None,
+            config_digest: None,
+            mode: Some(crate::models::TUNNEL_MODE_ATTACHED.into()),
+            attached_remote_port: Some(30002),
+            attached_session_id: None,
+        };
+        let err = ctx.validate_tunnel_ownership(&state).unwrap_err();
+        assert!(err.to_string().contains("is on bridge port 30002"));
+    }
+
+    #[serial]
+    #[test]
     fn ownership_check_skipped_without_target() {
-        let ctx = CommandContext::new(cfg_with_host("compute-eda-42"), None).unwrap();
+        let ctx = CommandContext::new(cfg_with("compute-eda-42", 30001), None).unwrap();
         assert!(ctx
-            .validate_session_ownership(&session("compute-eda-99"))
+            .validate_session_ownership(&session_with("compute-eda-99", 30001))
             .is_ok());
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -66,11 +66,16 @@ impl CommandContext {
     }
 
     /// Validate that a tunnel state belongs to this context's target.
-    /// `state.port` is the local forward port; the discriminator against the
-    /// target is the *remote* bridge port (`attached_remote_port` when set,
-    /// otherwise the deployed tunnel's `port`).
+    /// `state.port` is the local forward port and may legitimately fall back
+    /// from the target's bridge port, so the ownership discriminator is the
+    /// *remote* bridge port: `remote_bridge_port` (deployed, fixed at
+    /// `cfg.port`) or `attached_remote_port` (attached), falling back to
+    /// `port` only for legacy state files.
     pub fn validate_tunnel_ownership(&self, state: &crate::models::TunnelState) -> Result<()> {
-        let remote_port = state.attached_remote_port.unwrap_or(state.port);
+        let remote_port = state
+            .remote_bridge_port
+            .or(state.attached_remote_port)
+            .unwrap_or(state.port);
         self.validate_endpoint_ownership(
             "tunnel",
             &state.port.to_string(),
@@ -220,10 +225,111 @@ mod tests {
             config_digest: None,
             mode: Some(crate::models::TUNNEL_MODE_ATTACHED.into()),
             attached_remote_port: Some(30002),
+            remote_bridge_port: Some(30002),
             attached_session_id: None,
         };
         let err = ctx.validate_tunnel_ownership(&state).unwrap_err();
         assert!(err.to_string().contains("is on bridge port 30002"));
+    }
+
+    #[serial]
+    #[test]
+    fn tunnel_ownership_pass_with_local_port_fallback_remote_fixed() {
+        // `tunnel start` may fall back to a *local* forward port when the
+        // configured bridge port is taken locally, while the remote endpoint
+        // stays fixed at the target's bridge port. Ownership must be judged on
+        // the remote port, so this freshly-created state is NOT self-rejected.
+        let ctx =
+            CommandContext::new(cfg_with("compute-eda-42", 30001), Some("prod".into())).unwrap();
+        let state = crate::models::TunnelState {
+            version: crate::models::CURRENT_STATE_VERSION,
+            port: 40001, // local fallback — differs from the bridge port
+            pid: 0,
+            remote_host: "compute-eda-42".into(),
+            setup_path: None,
+            profile: Some("prod".into()),
+            backend: Some("openssh".into()),
+            daemon_nonce: None,
+            executable_path: None,
+            start_identity: None,
+            ipc_endpoint: None,
+            token_path: None,
+            local_forward: None,
+            start_time_unix_ms: None,
+            health: None,
+            config_digest: None,
+            mode: Some(crate::models::TUNNEL_MODE_DEPLOYED.into()),
+            attached_remote_port: None,
+            remote_bridge_port: Some(30001), // fixed remote bridge port
+            attached_session_id: None,
+        };
+        assert!(ctx.validate_tunnel_ownership(&state).is_ok());
+    }
+
+    #[serial]
+    #[test]
+    fn tunnel_ownership_rejects_local_fallback_on_wrong_remote_port() {
+        // Same as above but the recorded remote bridge port belongs to another
+        // target — must be rejected even though the local port matches nothing
+        // meaningful.
+        let ctx =
+            CommandContext::new(cfg_with("compute-eda-42", 30001), Some("prod".into())).unwrap();
+        let state = crate::models::TunnelState {
+            version: crate::models::CURRENT_STATE_VERSION,
+            port: 30001,
+            pid: 0,
+            remote_host: "compute-eda-42".into(),
+            setup_path: None,
+            profile: Some("prod".into()),
+            backend: Some("openssh".into()),
+            daemon_nonce: None,
+            executable_path: None,
+            start_identity: None,
+            ipc_endpoint: None,
+            token_path: None,
+            local_forward: None,
+            start_time_unix_ms: None,
+            health: None,
+            config_digest: None,
+            mode: Some(crate::models::TUNNEL_MODE_DEPLOYED.into()),
+            attached_remote_port: None,
+            remote_bridge_port: Some(30002),
+            attached_session_id: None,
+        };
+        let err = ctx.validate_tunnel_ownership(&state).unwrap_err();
+        assert!(err.to_string().contains("is on bridge port 30002"));
+    }
+
+    #[serial]
+    #[test]
+    fn tunnel_ownership_legacy_state_uses_port_when_no_remote_port() {
+        // v1/v2 legacy state files have neither remote_bridge_port nor
+        // attached_remote_port; the remote port is then identical to `port`.
+        let ctx =
+            CommandContext::new(cfg_with("compute-eda-42", 30001), Some("prod".into())).unwrap();
+        let state = crate::models::TunnelState {
+            version: crate::models::CURRENT_STATE_VERSION,
+            port: 30001,
+            pid: 0,
+            remote_host: "compute-eda-42".into(),
+            setup_path: None,
+            profile: Some("prod".into()),
+            backend: None,
+            daemon_nonce: None,
+            executable_path: None,
+            start_identity: None,
+            ipc_endpoint: None,
+            token_path: None,
+            local_forward: None,
+            start_time_unix_ms: None,
+            health: None,
+            config_digest: None,
+            mode: None,
+            attached_remote_port: None,
+            remote_bridge_port: None,
+            attached_session_id: None,
+        };
+        assert!(ctx.validate_tunnel_ownership(&state).is_ok());
     }
 
     #[serial]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod client;
 pub mod command_log;
 pub mod commands;
 pub mod config;
+pub mod context;
 pub mod error;
 pub mod exit_codes;
 pub mod history;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod spectre;
 pub mod streaming;
 #[cfg(target_os = "linux")]
 pub mod sys;
+pub mod target;
 #[cfg(test)]
 pub mod test_env;
 pub mod transaction;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ mod skill_finder;
 mod spectre;
 mod streaming;
 mod sys;
+mod target;
 #[cfg(test)]
 mod test_env;
 #[cfg(test)]
@@ -79,6 +80,11 @@ struct Cli {
     /// Connection profile name (reads VB_REMOTE_HOST_<profile> etc.)
     #[arg(long, short, global = true)]
     profile: Option<String>,
+
+    /// Target name from ~/.vcli/targets.yaml (multi-target mode).
+    /// Overrides --profile and environment variables when specified.
+    #[arg(long, global = true)]
+    target: Option<String>,
 }
 
 #[derive(Clone, ValueEnum)]
@@ -101,6 +107,10 @@ enum Commands {
         #[arg(long)]
         if_not_exists: bool,
     },
+
+    /// Manage multiple Virtuoso targets (multi-host connection pools)
+    #[command(subcommand)]
+    Target(TargetCmd),
 
     /// Manage SSH tunnel to remote Virtuoso host
     #[command(subcommand)]
@@ -325,6 +335,69 @@ impl McpCmd {
             McpCmd::Serve => crate::mcp::server::run().map(|_| serde_json::json!({})),
         }
     }
+}
+
+#[derive(Subcommand)]
+enum TargetCmd {
+    /// List all configured targets
+    #[command(long_about = "List all targets from ~/.vcli/targets.yaml.\n\n\
+            Examples:\n  \
+            vcli target list\n  \
+            vcli target list --format json")]
+    List,
+
+    /// Show configuration for a specific target
+    #[command(long_about = "Show detailed configuration for a target.\n\n\
+            Examples:\n  \
+            vcli target show prod\n  \
+            vcli target show")]
+    Show {
+        /// Target name (defaults to active target)
+        name: Option<String>,
+    },
+
+    /// Switch the active target
+    #[command(long_about = "Set the active target in ~/.vcli/targets.yaml.\n\n\
+            Examples:\n  \
+            vcli target switch prod")]
+    Switch {
+        /// Target name to activate
+        name: String,
+    },
+
+    /// Add a new target
+    #[command(long_about = "Add a new target to ~/.vcli/targets.yaml.\n\n\
+            Examples:\n  \
+            vcli target add prod --host compute-eda-42 --port 30001\n  \
+            vcli target add test --host compute-eda-99 --port 30002 --ssh-backend native")]
+    Add {
+        /// Target name
+        name: String,
+        /// Remote host running Virtuoso
+        #[arg(long)]
+        host: String,
+        /// Bridge port (default: username-derived)
+        #[arg(long)]
+        port: Option<u16>,
+        /// SSH backend (openssh or native)
+        #[arg(long)]
+        ssh_backend: Option<String>,
+        /// Jump host (bastion)
+        #[arg(long)]
+        jump_host: Option<String>,
+        /// Description
+        #[arg(long)]
+        description: Option<String>,
+    },
+
+    /// Remove a target
+    #[command(long_about = "Remove a target from ~/.vcli/targets.yaml.\n\n\
+            Examples:\n  \
+            vcli target remove old-prod")]
+    Remove {
+        /// Target name to remove
+        name: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -1755,6 +1828,201 @@ fn dispatch_profile(cmd: ProfileCmd) -> error::Result<serde_json::Value> {
     }
 }
 
+fn dispatch_target(cmd: TargetCmd, format: OutputFormat) -> error::Result<serde_json::Value> {
+    use crate::target::{TargetConfig, TargetManager};
+
+    match cmd {
+        TargetCmd::List => {
+            let manager =
+                TargetManager::load().map_err(|e| error::VirtuosoError::Config(e.to_string()))?;
+
+            if manager.is_empty() && matches!(format, OutputFormat::Table) {
+                println!(
+                    "No targets configured yet. Add one with: vcli target add <name> --host <host>"
+                );
+            }
+
+            let targets: Vec<serde_json::Value> = manager
+                .list_names()
+                .iter()
+                .map(|name| {
+                    let cfg = manager.get(name).unwrap();
+                    serde_json::json!({
+                        "name": name,
+                        "active": *name == manager.active_target_name(),
+                        "remote_host": cfg.remote_host,
+                        "port": cfg.port,
+                        "description": cfg.description,
+                    })
+                })
+                .collect();
+
+            if matches!(format, OutputFormat::Table) && !targets.is_empty() {
+                println!(
+                    "\n{:<15} {:<8} {:<25} {:<10}",
+                    "NAME", "ACTIVE", "REMOTE_HOST", "PORT"
+                );
+                println!("{:-<15} {:-<8} {:-<25} {:-<10}", "", "", "", "");
+                for t in &targets {
+                    println!(
+                        "{:<15} {:<8} {:<25} {:<10}",
+                        t["name"].as_str().unwrap_or(""),
+                        if t["active"].as_bool().unwrap_or(false) {
+                            "*"
+                        } else {
+                            ""
+                        },
+                        t["remote_host"].as_str().unwrap_or("-"),
+                        t["port"]
+                            .as_u64()
+                            .map(|p| p.to_string())
+                            .unwrap_or_else(|| "-".to_string()),
+                    );
+                }
+                println!();
+            }
+
+            Ok(serde_json::json!({
+                "targets": targets,
+                "count": targets.len(),
+                "active": manager.active_target_name(),
+                "config_path": manager.config_path().to_string_lossy().to_string(),
+            }))
+        }
+
+        TargetCmd::Show { name } => {
+            let manager =
+                TargetManager::load().map_err(|e| error::VirtuosoError::Config(e.to_string()))?;
+
+            let target_name = name
+                .as_deref()
+                .unwrap_or_else(|| manager.active_target_name());
+            let cfg = manager.get(target_name).ok_or_else(|| {
+                error::VirtuosoError::NotFound(format!("target '{}' not found", target_name))
+            })?;
+
+            if matches!(format, OutputFormat::Table) {
+                println!("\nTarget: {}", target_name);
+                println!(
+                    "  remote_host:    {}",
+                    cfg.remote_host.as_deref().unwrap_or("-")
+                );
+                println!(
+                    "  port:           {}",
+                    cfg.port
+                        .map(|p| p.to_string())
+                        .unwrap_or_else(|| "default".to_string())
+                );
+                println!(
+                    "  remote_user:    {}",
+                    cfg.remote_user.as_deref().unwrap_or("-")
+                );
+                println!(
+                    "  jump_host:      {}",
+                    cfg.jump_host.as_deref().unwrap_or("-")
+                );
+                println!(
+                    "  ssh_backend:    {}",
+                    cfg.ssh_backend.as_deref().unwrap_or("openssh")
+                );
+                println!("  timeout:        {}s", cfg.timeout.unwrap_or(30));
+                println!("  read_timeout:   {}s", cfg.read_timeout.unwrap_or(120));
+                if let Some(desc) = &cfg.description {
+                    println!("  description:    {}", desc);
+                }
+                println!();
+            }
+
+            Ok(serde_json::json!({
+                "name": target_name,
+                "config": cfg,
+            }))
+        }
+
+        TargetCmd::Switch { name } => {
+            let mut manager =
+                TargetManager::load().map_err(|e| error::VirtuosoError::Config(e.to_string()))?;
+
+            manager
+                .set_active(&name)
+                .map_err(|e| error::VirtuosoError::NotFound(e.to_string()))?;
+            manager
+                .save()
+                .map_err(|e| error::VirtuosoError::Config(e.to_string()))?;
+
+            println!("Switched active target to: {}", name);
+            Ok(serde_json::json!({
+                "action": "switch",
+                "active_target": name,
+            }))
+        }
+
+        TargetCmd::Add {
+            name,
+            host,
+            port,
+            ssh_backend,
+            jump_host,
+            description,
+        } => {
+            let mut manager =
+                TargetManager::load().map_err(|e| error::VirtuosoError::Config(e.to_string()))?;
+
+            let cfg = TargetConfig {
+                remote_host: Some(host),
+                port,
+                ssh_backend,
+                jump_host,
+                description,
+                ..Default::default()
+            };
+
+            manager.set(&name, cfg);
+            if manager.active_target().is_none() {
+                manager
+                    .set_active(&name)
+                    .map_err(|e| error::VirtuosoError::Config(e.to_string()))?;
+            }
+            manager
+                .save()
+                .map_err(|e| error::VirtuosoError::Config(e.to_string()))?;
+
+            println!("Added target: {}", name);
+            Ok(serde_json::json!({
+                "action": "add",
+                "name": name,
+            }))
+        }
+
+        TargetCmd::Remove { name } => {
+            let mut manager =
+                TargetManager::load().map_err(|e| error::VirtuosoError::Config(e.to_string()))?;
+
+            if !manager.remove(&name) {
+                return Err(error::VirtuosoError::NotFound(format!(
+                    "target '{}' not found",
+                    name
+                )));
+            }
+
+            // If we removed the active target, clear active_target
+            if manager.active_target_name() == name {
+                manager.clear_active();
+            }
+
+            manager
+                .save()
+                .map_err(|e| error::VirtuosoError::Config(e.to_string()))?;
+
+            println!("Removed target: {}", name);
+            Ok(serde_json::json!({
+                "action": "remove",
+                "name": name,
+            }))
+        }
+    }
+}
+
 fn parse_bind_scope(
     venv: bool,
     user: bool,
@@ -2284,9 +2552,66 @@ fn dispatch_rpc(cmd: RpcCmd) -> error::Result<serde_json::Value> {
 fn main() {
     let cli = Cli::parse();
 
-    // Propagate profile to config layer via env var
-    if let Some(ref profile) = cli.profile {
-        std::env::set_var("VB_PROFILE", profile);
+    // Target/profile selection: resolve the precedence once here so the rest
+    // of the process sees a single, consistent selection. `--target` and
+    // `--profile` are mutually exclusive (see target::resolve).
+    //
+    // NOTE: the effective Config is still read back from env by the command
+    // layer (Config::from_env()/VirtuosoClient::from_env()). Until CommandContext
+    // propagation lands (P0-A next step), we bridge the resolved selection via
+    // VB_TARGET/VB_PROFILE so those paths observe the same choice.
+    use crate::target::resolve::{resolve_selection, Selection};
+    match resolve_selection(cli.target.as_deref(), cli.profile.as_deref()) {
+        Ok(selection) => match selection {
+            Selection::CliTarget(name) => {
+                let manager = match crate::target::TargetManager::load() {
+                    Ok(m) => m,
+                    Err(e) => {
+                        eprintln!("Error loading targets: {}", e);
+                        std::process::exit(exit_codes::USAGE_ERROR);
+                    }
+                };
+                if manager.get(&name).is_none() {
+                    eprintln!(
+                        "Error: target '{}' not found in {}",
+                        name,
+                        manager.config_path().display()
+                    );
+                    std::process::exit(exit_codes::NOT_FOUND);
+                }
+                tracing::info!(
+                    "Target '{}' selected from {}",
+                    name,
+                    manager.config_path().display()
+                );
+                std::env::set_var("VB_TARGET", &name);
+            }
+            Selection::ActiveTarget(name) => {
+                // Bridge the active target through the same env path so
+                // Config::from_env() resolves it. Resolve_selection already
+                // verified the target exists.
+                std::env::set_var("VB_TARGET", &name);
+            }
+            Selection::EnvTarget(_) => {
+                // Already in the environment; Config::from_env() picks it up.
+            }
+            Selection::CliProfile(profile) => {
+                // An explicit profile beats a stale ambient VB_TARGET: the
+                // resolver already decided this is a profile selection, so
+                // clear the bridge variable to keep Config::from_env() in sync.
+                std::env::remove_var("VB_TARGET");
+                std::env::set_var("VB_PROFILE", &profile);
+            }
+            Selection::LegacyEnv => {
+                // No target selected; clear any stale bridge variable so a
+                // leftover VB_TARGET cannot hijack legacy env resolution.
+                std::env::remove_var("VB_TARGET");
+            }
+        },
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(exit_codes::USAGE_ERROR);
+        }
     }
 
     let log_level = if cli.verbose {
@@ -2334,6 +2659,7 @@ fn main() {
 
     let result = match cli.command {
         Commands::Init { if_not_exists } => commands::init::run(if_not_exists),
+        Commands::Target(cmd) => dispatch_target(cmd, format),
         // Compiled only with `native-ssh`; other builds have no such subcommand
         // at all, so there is nothing to dispatch. `run_with` blocks forever
         // (it is the daemon process); returning here is fine because nothing

--- a/src/main.rs
+++ b/src/main.rs
@@ -1744,11 +1744,18 @@ fn dispatch_tunnel(
     }
 }
 
-fn dispatch_profile(cmd: ProfileCmd) -> error::Result<serde_json::Value> {
+fn dispatch_profile(
+    cmd: ProfileCmd,
+    cli_profile: Option<String>,
+) -> error::Result<serde_json::Value> {
     use virtuoso_cli::profile::{BindScope, ProfileResolution};
     match cmd {
         ProfileCmd::Show => {
-            let info: ProfileResolution = virtuoso_cli::profile::resolve_profile_info(None);
+            // `--profile`/`-p` must win over the ambient VB_PROFILE. Config
+            // management skips full connection-target resolution, so the CLI
+            // profile is threaded here explicitly.
+            let info: ProfileResolution =
+                virtuoso_cli::profile::resolve_profile_info(cli_profile.as_deref());
             Ok(serde_json::json!({
                 "profile": info.profile,
                 "source": info.source,
@@ -2695,7 +2702,17 @@ fn main() {
             cmd,
             format,
         ),
-        Commands::Profile(cmd) => dispatch_profile(cmd),
+        Commands::Profile(cmd) => {
+            // Config management skips full target resolution, but the
+            // `--target`/`--profile` exclusivity contract still holds.
+            if cli.target.is_some() {
+                Err(error::VirtuosoError::Config(
+                    "--target and --profile are mutually exclusive".into(),
+                ))
+            } else {
+                dispatch_profile(cmd, cli.profile.clone())
+            }
+        }
         Commands::Skill(cmd) => dispatch_skill(cmd),
         Commands::Cell(cmd) => dispatch_cell(cmd),
         Commands::Sim(cmd) => dispatch_sim(cmd),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2568,56 +2568,69 @@ fn main() {
     // families still call Config::from_env(), so they are driven through the
     // VB_TARGET/VB_PROFILE bridge — set from the SAME single selection to keep
     // every path consistent until their migration lands.
+    //
+    // Config-management commands (target/profile/init) must keep working even
+    // when the current active target is stale or missing — they do not need a
+    // connection target, so they skip the whole resolution entirely. Only
+    // connection commands perform full selection + resolve.
     use crate::target::resolve::{resolve_from_selection, resolve_selection, Selection};
-    let selection = match resolve_selection(cli.target.as_deref(), cli.profile.as_deref()) {
-        Ok(s) => s,
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(exit_codes::USAGE_ERROR);
+    let needs_config = !matches!(
+        &cli.command,
+        Commands::Target(_) | Commands::Profile(_) | Commands::Init { .. }
+    );
+    let ctx: Option<crate::context::CommandContext> = if needs_config {
+        let selection = match resolve_selection(cli.target.as_deref(), cli.profile.as_deref()) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("Error: {e}");
+                std::process::exit(exit_codes::USAGE_ERROR);
+            }
+        };
+        match &selection {
+            Selection::CliTarget(name) => {
+                // Existence is validated below by resolve_from_selection.
+                std::env::set_var("VB_TARGET", name);
+            }
+            Selection::ActiveTarget(name) => {
+                // resolve_selection already verified the target exists.
+                std::env::set_var("VB_TARGET", name);
+            }
+            Selection::EnvTarget(_) => {
+                // Already in the environment; Config::from_env() picks it up.
+            }
+            Selection::CliProfile(profile) => {
+                // An explicit profile beats a stale ambient VB_TARGET: clear the
+                // bridge variable so legacy Config::from_env() stays in sync.
+                std::env::remove_var("VB_TARGET");
+                std::env::set_var("VB_PROFILE", profile);
+            }
+            Selection::LegacyEnv => {
+                // No target selected; clear any stale bridge variable so a
+                // leftover VB_TARGET cannot hijack legacy env resolution.
+                std::env::remove_var("VB_TARGET");
+            }
         }
-    };
-    match &selection {
-        Selection::CliTarget(name) => {
-            // Existence is validated below by resolve_from_selection.
-            std::env::set_var("VB_TARGET", name);
+        // P0-A: single immutable Config for this invocation. Migrated commands
+        // receive it through CommandContext and must not re-read env.
+        let resolved = match resolve_from_selection(selection) {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("Error: {e}");
+                std::process::exit(match e {
+                    crate::error::VirtuosoError::NotFound(_) => exit_codes::NOT_FOUND,
+                    _ => exit_codes::USAGE_ERROR,
+                });
+            }
+        };
+        match crate::context::CommandContext::from_resolved(&resolved) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                eprintln!("Error: {e}");
+                std::process::exit(exit_codes::USAGE_ERROR);
+            }
         }
-        Selection::ActiveTarget(name) => {
-            // resolve_selection already verified the target exists.
-            std::env::set_var("VB_TARGET", name);
-        }
-        Selection::EnvTarget(_) => {
-            // Already in the environment; Config::from_env() picks it up.
-        }
-        Selection::CliProfile(profile) => {
-            // An explicit profile beats a stale ambient VB_TARGET: clear the
-            // bridge variable so legacy Config::from_env() stays in sync.
-            std::env::remove_var("VB_TARGET");
-            std::env::set_var("VB_PROFILE", profile);
-        }
-        Selection::LegacyEnv => {
-            // No target selected; clear any stale bridge variable so a
-            // leftover VB_TARGET cannot hijack legacy env resolution.
-            std::env::remove_var("VB_TARGET");
-        }
-    }
-    // P0-A: single immutable Config for this invocation. Migrated commands
-    // receive it through CommandContext and must not re-read env.
-    let resolved = match resolve_from_selection(selection) {
-        Ok(r) => r,
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(match e {
-                crate::error::VirtuosoError::NotFound(_) => exit_codes::NOT_FOUND,
-                _ => exit_codes::USAGE_ERROR,
-            });
-        }
-    };
-    let ctx = match crate::context::CommandContext::from_resolved(&resolved) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("Error: {e}");
-            std::process::exit(exit_codes::USAGE_ERROR);
-        }
+    } else {
+        None
     };
 
     let log_level = if cli.verbose {
@@ -2676,7 +2689,12 @@ fn main() {
             token_path,
             daemon_nonce,
         } => commands::transport_daemon::run_with(&ipc_endpoint, &token_path, &daemon_nonce),
-        Commands::Tunnel(cmd) => dispatch_tunnel(&ctx, cmd, format),
+        Commands::Tunnel(cmd) => dispatch_tunnel(
+            ctx.as_ref()
+                .expect("tunnel commands always resolve a config"),
+            cmd,
+            format,
+        ),
         Commands::Profile(cmd) => dispatch_profile(cmd),
         Commands::Skill(cmd) => dispatch_skill(cmd),
         Commands::Cell(cmd) => dispatch_cell(cmd),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod client;
 mod command_log;
 mod commands;
 mod config;
+mod context;
 mod error;
 mod exit_codes;
 mod history;
@@ -1725,15 +1726,21 @@ fn parse_key_val(s: &str) -> std::result::Result<(String, String), String> {
 
 // ── Per-group dispatch helpers ───────────────────────────────────────
 
-fn dispatch_tunnel(cmd: TunnelCmd, format: OutputFormat) -> error::Result<serde_json::Value> {
+fn dispatch_tunnel(
+    ctx: &crate::context::CommandContext,
+    cmd: TunnelCmd,
+    format: OutputFormat,
+) -> error::Result<serde_json::Value> {
     match cmd {
-        TunnelCmd::Start { timeout, dry_run } => commands::tunnel::start(Some(timeout), dry_run),
-        TunnelCmd::Stop { force, dry_run } => commands::tunnel::stop(force, dry_run),
-        TunnelCmd::Restart { timeout } => commands::tunnel::restart(Some(timeout)),
-        TunnelCmd::Status => commands::tunnel::status(format),
-        TunnelCmd::Diagnose => commands::tunnel::diagnose(),
-        TunnelCmd::Attach { dry_run } => commands::tunnel::attach(dry_run),
-        TunnelCmd::Detach => commands::tunnel::detach(),
+        TunnelCmd::Start { timeout, dry_run } => {
+            commands::tunnel::start(ctx, Some(timeout), dry_run)
+        }
+        TunnelCmd::Stop { force, dry_run } => commands::tunnel::stop(ctx, force, dry_run),
+        TunnelCmd::Restart { timeout } => commands::tunnel::restart(ctx, Some(timeout)),
+        TunnelCmd::Status => commands::tunnel::status(ctx, format),
+        TunnelCmd::Diagnose => commands::tunnel::diagnose(ctx),
+        TunnelCmd::Attach { dry_run } => commands::tunnel::attach(ctx, dry_run),
+        TunnelCmd::Detach => commands::tunnel::detach(ctx),
     }
 }
 
@@ -2556,63 +2563,62 @@ fn main() {
     // of the process sees a single, consistent selection. `--target` and
     // `--profile` are mutually exclusive (see target::resolve).
     //
-    // NOTE: the effective Config is still read back from env by the command
-    // layer (Config::from_env()/VirtuosoClient::from_env()). Until CommandContext
-    // propagation lands (P0-A next step), we bridge the resolved selection via
-    // VB_TARGET/VB_PROFILE so those paths observe the same choice.
-    use crate::target::resolve::{resolve_selection, Selection};
-    match resolve_selection(cli.target.as_deref(), cli.profile.as_deref()) {
-        Ok(selection) => match selection {
-            Selection::CliTarget(name) => {
-                let manager = match crate::target::TargetManager::load() {
-                    Ok(m) => m,
-                    Err(e) => {
-                        eprintln!("Error loading targets: {}", e);
-                        std::process::exit(exit_codes::USAGE_ERROR);
-                    }
-                };
-                if manager.get(&name).is_none() {
-                    eprintln!(
-                        "Error: target '{}' not found in {}",
-                        name,
-                        manager.config_path().display()
-                    );
-                    std::process::exit(exit_codes::NOT_FOUND);
-                }
-                tracing::info!(
-                    "Target '{}' selected from {}",
-                    name,
-                    manager.config_path().display()
-                );
-                std::env::set_var("VB_TARGET", &name);
-            }
-            Selection::ActiveTarget(name) => {
-                // Bridge the active target through the same env path so
-                // Config::from_env() resolves it. Resolve_selection already
-                // verified the target exists.
-                std::env::set_var("VB_TARGET", &name);
-            }
-            Selection::EnvTarget(_) => {
-                // Already in the environment; Config::from_env() picks it up.
-            }
-            Selection::CliProfile(profile) => {
-                // An explicit profile beats a stale ambient VB_TARGET: the
-                // resolver already decided this is a profile selection, so
-                // clear the bridge variable to keep Config::from_env() in sync.
-                std::env::remove_var("VB_TARGET");
-                std::env::set_var("VB_PROFILE", &profile);
-            }
-            Selection::LegacyEnv => {
-                // No target selected; clear any stale bridge variable so a
-                // leftover VB_TARGET cannot hijack legacy env resolution.
-                std::env::remove_var("VB_TARGET");
-            }
-        },
+    // P0-A: the effective Config is resolved exactly once and handed to
+    // migrated command families (tunnel) via CommandContext. Not-yet-migrated
+    // families still call Config::from_env(), so they are driven through the
+    // VB_TARGET/VB_PROFILE bridge — set from the SAME single selection to keep
+    // every path consistent until their migration lands.
+    use crate::target::resolve::{resolve_from_selection, resolve_selection, Selection};
+    let selection = match resolve_selection(cli.target.as_deref(), cli.profile.as_deref()) {
+        Ok(s) => s,
         Err(e) => {
             eprintln!("Error: {e}");
             std::process::exit(exit_codes::USAGE_ERROR);
         }
+    };
+    match &selection {
+        Selection::CliTarget(name) => {
+            // Existence is validated below by resolve_from_selection.
+            std::env::set_var("VB_TARGET", name);
+        }
+        Selection::ActiveTarget(name) => {
+            // resolve_selection already verified the target exists.
+            std::env::set_var("VB_TARGET", name);
+        }
+        Selection::EnvTarget(_) => {
+            // Already in the environment; Config::from_env() picks it up.
+        }
+        Selection::CliProfile(profile) => {
+            // An explicit profile beats a stale ambient VB_TARGET: clear the
+            // bridge variable so legacy Config::from_env() stays in sync.
+            std::env::remove_var("VB_TARGET");
+            std::env::set_var("VB_PROFILE", profile);
+        }
+        Selection::LegacyEnv => {
+            // No target selected; clear any stale bridge variable so a
+            // leftover VB_TARGET cannot hijack legacy env resolution.
+            std::env::remove_var("VB_TARGET");
+        }
     }
+    // P0-A: single immutable Config for this invocation. Migrated commands
+    // receive it through CommandContext and must not re-read env.
+    let resolved = match resolve_from_selection(selection) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(match e {
+                crate::error::VirtuosoError::NotFound(_) => exit_codes::NOT_FOUND,
+                _ => exit_codes::USAGE_ERROR,
+            });
+        }
+    };
+    let ctx = match crate::context::CommandContext::from_resolved(&resolved) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            std::process::exit(exit_codes::USAGE_ERROR);
+        }
+    };
 
     let log_level = if cli.verbose {
         "debug"
@@ -2670,7 +2676,7 @@ fn main() {
             token_path,
             daemon_nonce,
         } => commands::transport_daemon::run_with(&ipc_endpoint, &token_path, &daemon_nonce),
-        Commands::Tunnel(cmd) => dispatch_tunnel(cmd, format),
+        Commands::Tunnel(cmd) => dispatch_tunnel(&ctx, cmd, format),
         Commands::Profile(cmd) => dispatch_profile(cmd),
         Commands::Skill(cmd) => dispatch_skill(cmd),
         Commands::Cell(cmd) => dispatch_cell(cmd),

--- a/src/models.rs
+++ b/src/models.rs
@@ -417,6 +417,14 @@ pub struct TunnelState {
     /// the daemon's own listening port, identical to `port`).
     #[serde(default)]
     pub attached_remote_port: Option<u16>,
+    /// Remote bridge port this tunnel forwards to, recorded separately from
+    /// the *local* forward port (`port`) so a local port fallback never
+    /// changes the remote endpoint identity. For `deployed` tunnels this is
+    /// the target's fixed bridge port (`cfg.port`); for `attached` tunnels it
+    /// equals `attached_remote_port`. `None` on legacy files means the remote
+    /// port was identical to `port`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remote_bridge_port: Option<u16>,
     /// Bridge session id this attach resolved to. Mirrors
     /// `SessionInfo::id` for the daemon we discovered via
     /// `~/.cache/virtuoso_bridge/sessions/*.json`.
@@ -569,6 +577,7 @@ mod tests {
             config_digest: Some("deadbeef".into()),
             mode: None,
             attached_remote_port: None,
+            remote_bridge_port: None,
             attached_session_id: None,
         };
         let json = serde_json::to_string(&s).unwrap();
@@ -612,6 +621,7 @@ mod tests {
             config_digest: None,
             mode: None,
             attached_remote_port: None,
+            remote_bridge_port: None,
             attached_session_id: None,
         };
         let json = serde_json::to_string(&s).unwrap();

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -1,0 +1,323 @@
+//! Multi-target connection pool management.
+//!
+//! Allows vcli to manage multiple Virtuoso targets (host+port combinations)
+//! via a YAML configuration file, instead of relying solely on environment
+//! variables. Each target has its own connection pool.
+
+pub mod resolve;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Configuration for a single Virtuoso target.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TargetConfig {
+    /// Remote host running Virtuoso (compute host, not jump host)
+    pub remote_host: Option<String>,
+    /// SSH username for remote host
+    pub remote_user: Option<String>,
+    /// Bridge port on the remote host
+    pub port: Option<u16>,
+    /// Jump host (bastion) for SSH tunneling
+    pub jump_host: Option<String>,
+    /// SSH username for jump host
+    pub jump_user: Option<String>,
+    /// SSH port (default 22)
+    pub ssh_port: Option<u16>,
+    /// Path to SSH private key
+    pub ssh_key: Option<String>,
+    /// Path to custom SSH config file
+    pub ssh_config: Option<String>,
+    /// SSH backend: "openssh" (default) or "native"
+    pub ssh_backend: Option<String>,
+    /// Disable SSH ControlMaster multiplexing
+    pub disable_control_master: Option<bool>,
+    /// Timeout for write operations in seconds (default 30)
+    pub timeout: Option<u64>,
+    /// Timeout for read operations in seconds (default 120)
+    pub read_timeout: Option<u64>,
+    /// Keep remote files after operation
+    pub keep_remote_files: Option<bool>,
+    /// Spectre command (default "spectre")
+    pub spectre_cmd: Option<String>,
+    /// Additional Spectre arguments
+    pub spectre_args: Option<Vec<String>>,
+    /// Maximum parallel Spectre workers (default 8)
+    pub spectre_max_workers: Option<u32>,
+    /// Path to Cadence environment setup file
+    pub cadence_cshrc: Option<String>,
+    /// Absolute path to Spectre binary
+    pub spectre_bin: Option<String>,
+    /// Native SSH: max concurrent sessions (default 10)
+    pub ssh_max_sessions: Option<usize>,
+    /// Native SSH: max bulk transfer sessions (default 2)
+    pub ssh_max_bulk_sessions: Option<usize>,
+    /// Native SSH: reconnect attempts before degraded (default 8)
+    pub ssh_reconnect_max_attempts: Option<u32>,
+    /// Native SSH: max reconnect delay in seconds (default 30)
+    pub ssh_reconnect_max_delay: Option<u64>,
+    /// Native SSH: keepalive interval in seconds (default 30)
+    pub ssh_keepalive_interval: Option<u64>,
+    /// Native SSH: missed keepalives before dead (default 3)
+    pub ssh_keepalive_failures: Option<u32>,
+    /// Transport daemon IPC socket path
+    pub transport_daemon_socket: Option<String>,
+    /// Transport daemon auth token
+    pub transport_daemon_token: Option<String>,
+    /// Human-readable description
+    pub description: Option<String>,
+}
+
+/// Top-level targets configuration file structure.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TargetsConfig {
+    /// Map of target name → configuration
+    pub targets: HashMap<String, TargetConfig>,
+    /// Name of the currently active target (used when --target is not specified)
+    #[serde(default)]
+    pub active_target: Option<String>,
+}
+
+/// Manages multiple Virtuoso targets and their connection pools.
+pub struct TargetManager {
+    config: TargetsConfig,
+    config_path: PathBuf,
+}
+
+impl TargetManager {
+    /// Default config file path: ~/.vcli/targets.yaml
+    pub fn default_config_path() -> PathBuf {
+        dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".vcli")
+            .join("targets.yaml")
+    }
+
+    /// Load targets from the default config path.
+    /// Returns an empty manager if the file doesn't exist.
+    pub fn load() -> Result<Self, TargetError> {
+        Self::load_from(&Self::default_config_path())
+    }
+
+    /// Load targets from a specific config file path.
+    pub fn load_from(path: &std::path::Path) -> Result<Self, TargetError> {
+        if !path.exists() {
+            return Ok(Self {
+                config: TargetsConfig::default(),
+                config_path: path.to_path_buf(),
+            });
+        }
+
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| TargetError::Io(format!("failed to read {}: {e}", path.display())))?;
+
+        let config: TargetsConfig = serde_yaml::from_str(&content)
+            .map_err(|e| TargetError::Parse(format!("failed to parse {}: {e}", path.display())))?;
+
+        Ok(Self {
+            config,
+            config_path: path.to_path_buf(),
+        })
+    }
+
+    /// Get a target by name.
+    pub fn get(&self, name: &str) -> Option<&TargetConfig> {
+        self.config.targets.get(name)
+    }
+
+    /// Get the active target (or "default" if no active is set).
+    pub fn active_target_name(&self) -> &str {
+        self.config.active_target.as_deref().unwrap_or("default")
+    }
+
+    /// Get the active target configuration.
+    pub fn active_target(&self) -> Option<&TargetConfig> {
+        self.get(self.active_target_name())
+    }
+
+    /// The raw `active_target` field value, if explicitly set (no "default"
+    /// fallback). Lets the resolver distinguish "unset" from "set but the
+    /// target definition is missing" so the latter can be reported as an error.
+    pub fn active_target_raw(&self) -> Option<&str> {
+        self.config.active_target.as_deref()
+    }
+
+    /// List all target names.
+    pub fn list_names(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self.config.targets.keys().map(|s| s.as_str()).collect();
+        names.sort();
+        names
+    }
+
+    /// Add or update a target.
+    pub fn set(&mut self, name: &str, config: TargetConfig) {
+        self.config.targets.insert(name.to_string(), config);
+    }
+
+    /// Remove a target. Returns true if it existed.
+    pub fn remove(&mut self, name: &str) -> bool {
+        self.config.targets.remove(name).is_some()
+    }
+
+    /// Set the active target. Returns error if the target doesn't exist.
+    pub fn set_active(&mut self, name: &str) -> Result<(), TargetError> {
+        if !self.config.targets.contains_key(name) {
+            return Err(TargetError::NotFound(name.to_string()));
+        }
+        self.config.active_target = Some(name.to_string());
+        Ok(())
+    }
+
+    /// Clear the active target (e.g. after the active target is removed).
+    pub fn clear_active(&mut self) {
+        self.config.active_target = None;
+    }
+
+    /// Save configuration to disk.
+    pub fn save(&self) -> Result<(), TargetError> {
+        if let Some(parent) = self.config_path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                TargetError::Io(format!("failed to create {}: {e}", parent.display()))
+            })?;
+        }
+
+        let yaml = serde_yaml::to_string(&self.config)
+            .map_err(|e| TargetError::Parse(format!("failed to serialize config: {e}")))?;
+
+        std::fs::write(&self.config_path, yaml).map_err(|e| {
+            TargetError::Io(format!(
+                "failed to write {}: {e}",
+                self.config_path.display()
+            ))
+        })?;
+
+        Ok(())
+    }
+
+    /// Get the config file path.
+    pub fn config_path(&self) -> &std::path::Path {
+        &self.config_path
+    }
+
+    /// Check if the manager has any targets configured.
+    pub fn is_empty(&self) -> bool {
+        self.config.targets.is_empty()
+    }
+}
+
+/// Errors for target management.
+#[derive(Debug, thiserror::Error)]
+pub enum TargetError {
+    #[error("IO error: {0}")]
+    Io(String),
+    #[error("Parse error: {0}")]
+    Parse(String),
+    #[error("Target not found: {0}")]
+    NotFound(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_target_config_serialization() {
+        let config = TargetConfig {
+            remote_host: Some("compute-eda-42".to_string()),
+            port: Some(30001),
+            ssh_backend: Some("native".to_string()),
+            ..Default::default()
+        };
+
+        let yaml = serde_yaml::to_string(&config).unwrap();
+        let parsed: TargetConfig = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed.remote_host, Some("compute-eda-42".to_string()));
+        assert_eq!(parsed.port, Some(30001));
+        assert_eq!(parsed.ssh_backend, Some("native".to_string()));
+    }
+
+    #[test]
+    fn test_targets_config_serialization() {
+        let mut targets = HashMap::new();
+        targets.insert(
+            "prod".to_string(),
+            TargetConfig {
+                remote_host: Some("compute-eda-42".to_string()),
+                port: Some(30001),
+                ..Default::default()
+            },
+        );
+        targets.insert(
+            "test".to_string(),
+            TargetConfig {
+                remote_host: Some("compute-eda-99".to_string()),
+                port: Some(30002),
+                ..Default::default()
+            },
+        );
+
+        let config = TargetsConfig {
+            targets,
+            active_target: Some("prod".to_string()),
+        };
+
+        let yaml = serde_yaml::to_string(&config).unwrap();
+        let parsed: TargetsConfig = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed.targets.len(), 2);
+        assert_eq!(parsed.active_target, Some("prod".to_string()));
+        assert!(parsed.targets.contains_key("prod"));
+        assert!(parsed.targets.contains_key("test"));
+    }
+
+    #[test]
+    fn test_target_manager_get_and_set() {
+        let mut manager = TargetManager {
+            config: TargetsConfig::default(),
+            config_path: PathBuf::from("/tmp/test_targets.yaml"),
+        };
+
+        assert!(manager.is_empty());
+
+        manager.set(
+            "prod",
+            TargetConfig {
+                remote_host: Some("host1".to_string()),
+                port: Some(1000),
+                ..Default::default()
+            },
+        );
+
+        assert!(!manager.is_empty());
+        assert!(manager.get("prod").is_some());
+        assert_eq!(manager.get("prod").unwrap().port, Some(1000));
+        assert_eq!(manager.list_names(), vec!["prod"]);
+    }
+
+    #[test]
+    fn test_target_manager_set_active() {
+        let mut manager = TargetManager {
+            config: TargetsConfig::default(),
+            config_path: PathBuf::from("/tmp/test_targets.yaml"),
+        };
+
+        manager.set("prod", TargetConfig::default());
+        assert!(manager.set_active("prod").is_ok());
+        assert_eq!(manager.active_target_name(), "prod");
+        assert!(manager.set_active("nonexistent").is_err());
+    }
+
+    #[test]
+    fn test_target_manager_remove() {
+        let mut manager = TargetManager {
+            config: TargetsConfig::default(),
+            config_path: PathBuf::from("/tmp/test_targets.yaml"),
+        };
+
+        manager.set("prod", TargetConfig::default());
+        assert!(manager.remove("prod"));
+        assert!(!manager.remove("prod"));
+        assert!(manager.is_empty());
+    }
+}

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -87,8 +87,21 @@ pub struct TargetManager {
 }
 
 impl TargetManager {
-    /// Default config file path: ~/.vcli/targets.yaml
+    /// Default config file path: `$VB_TARGETS_FILE` when set, otherwise
+    /// `~/.vcli/targets.yaml`.
+    ///
+    /// The env override is not a convenience — it is the only way to relocate
+    /// this file on Windows. `dirs::home_dir()` there resolves to
+    /// `FOLDERID_Profile` (via `SHGetKnownFolderPath`) and ignores `HOME`
+    /// entirely, so anything that tried to redirect the lookup through `HOME`
+    /// silently read the real user profile instead. Non-Windows platforms
+    /// honour the same variable, so behaviour stays identical everywhere.
     pub fn default_config_path() -> PathBuf {
+        if let Some(raw) = std::env::var_os("VB_TARGETS_FILE") {
+            if !raw.is_empty() {
+                return PathBuf::from(raw);
+            }
+        }
         dirs::home_dir()
             .unwrap_or_else(|| PathBuf::from("."))
             .join(".vcli")
@@ -221,6 +234,48 @@ pub enum TargetError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
+
+    /// `VB_TARGETS_FILE` must win over the home-dir default on every platform.
+    ///
+    /// Regression: the lookup used to be `dirs::home_dir()/.vcli/targets.yaml`
+    /// with no override. On Windows `dirs::home_dir()` resolves to
+    /// `FOLDERID_Profile` and ignores `HOME`, so nothing could redirect it —
+    /// the target tests silently exercised the real user profile there.
+    #[serial]
+    #[test]
+    fn default_config_path_honours_vb_targets_file() {
+        let original = std::env::var_os("VB_TARGETS_FILE");
+        let expected = if cfg!(windows) {
+            PathBuf::from(r"C:\tmp\targets.yaml")
+        } else {
+            PathBuf::from("/tmp/targets.yaml")
+        };
+        std::env::set_var("VB_TARGETS_FILE", &expected);
+        assert_eq!(TargetManager::default_config_path(), expected);
+        match original {
+            Some(v) => std::env::set_var("VB_TARGETS_FILE", v),
+            None => std::env::remove_var("VB_TARGETS_FILE"),
+        }
+    }
+
+    /// An empty `VB_TARGETS_FILE` must be treated as unset, not as `""`.
+    #[serial]
+    #[test]
+    fn default_config_path_ignores_empty_vb_targets_file() {
+        let original = std::env::var_os("VB_TARGETS_FILE");
+        std::env::set_var("VB_TARGETS_FILE", "");
+        let path = TargetManager::default_config_path();
+        assert!(
+            path.ends_with("targets.yaml"),
+            "must fall back to the home-dir default, got: {}",
+            path.display()
+        );
+        match original {
+            Some(v) => std::env::set_var("VB_TARGETS_FILE", v),
+            None => std::env::remove_var("VB_TARGETS_FILE"),
+        }
+    }
 
     #[test]
     fn test_target_config_serialization() {

--- a/src/target/resolve.rs
+++ b/src/target/resolve.rs
@@ -1,0 +1,390 @@
+//! Target selection and resolution.
+//!
+//! Owns the precedence rules that pick the effective configuration for one
+//! invocation:
+//!
+//! 1. explicit `--target` and `--profile` are mutually exclusive (error);
+//! 2. explicit `--target` wins over everything;
+//! 3. explicit `--profile` beats an ambient `VB_TARGET`;
+//! 4. a non-empty ambient `VB_TARGET` is treated as a target selection;
+//! 5. otherwise the `active_target` from `targets.yaml`;
+//! 6. otherwise fall back to legacy profile/env defaults.
+//!
+//! The resolver never starts a daemon and never reads tokens: it only turns a
+//! name into an immutable [`Config`]. Connection lifecycle and identity
+//! validation (config digest, nonce) live in the daemon layer.
+
+use crate::config::Config;
+use crate::error::VirtuosoError;
+use crate::target::TargetManager;
+
+/// A concrete selection and where it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Selection {
+    /// Explicit `--target NAME`.
+    CliTarget(String),
+    /// Explicit `--profile NAME`.
+    CliProfile(String),
+    /// Ambient `VB_TARGET` env var.
+    EnvTarget(String),
+    /// `active_target` from `targets.yaml`.
+    ActiveTarget(String),
+    /// No explicit selection: legacy profile/env defaults.
+    LegacyEnv,
+}
+
+/// The resolved, immutable configuration for one invocation.
+// TODO(P0-A CommandContext): remove `allow(dead_code)` once commands receive
+// the resolved Config explicitly instead of re-reading env.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub struct ResolvedTarget {
+    /// Target name for target-backed selections; `None` for legacy paths.
+    pub name: Option<String>,
+    pub config: Config,
+}
+
+/// Decide which selection applies from explicit CLI flags plus ambient
+/// configuration. Pure selection: never starts a daemon, never reads tokens,
+/// and never resolves the selected target itself.
+pub fn resolve_selection(
+    cli_target: Option<&str>,
+    cli_profile: Option<&str>,
+) -> Result<Selection, VirtuosoError> {
+    match (cli_target, cli_profile) {
+        (Some(_), Some(_)) => Err(VirtuosoError::Config(
+            "--target and --profile are mutually exclusive; pass exactly one".into(),
+        )),
+        (Some(name), None) => Ok(Selection::CliTarget(name.to_string())),
+        (None, Some(profile)) => Ok(Selection::CliProfile(profile.to_string())),
+        (None, None) => {
+            if let Ok(value) = std::env::var("VB_TARGET") {
+                if !value.trim().is_empty() {
+                    return Ok(Selection::EnvTarget(value));
+                }
+            }
+            // With no explicit flags we implicitly rely on the active target, so
+            // a missing/corrupt targets.yaml is a real error here (the report's
+            // rule: only report corrupt config on paths that actually need it —
+            // explicit --profile never reaches this branch).
+            let manager = TargetManager::load()
+                .map_err(|e| VirtuosoError::Config(format!("failed to load targets: {e}")))?;
+            // Distinguish "active_target unset" (fall back to legacy) from
+            // "active_target set but its definition is missing" (error). The
+            // latter is an inconsistent config and must not silently degrade.
+            if let Some(name) = manager.active_target_raw() {
+                if manager.get(name).is_none() {
+                    return Err(VirtuosoError::Config(format!(
+                        "active_target '{name}' is set but not defined in targets"
+                    )));
+                }
+                return Ok(Selection::ActiveTarget(name.to_string()));
+            }
+            Ok(Selection::LegacyEnv)
+        }
+    }
+}
+
+/// Resolve a target name into its immutable configuration. Errors if the
+/// target does not exist or its configuration is invalid; never silently
+/// falls back.
+// TODO(P0-A CommandContext): remove `allow(dead_code)` once commands receive
+// the resolved Config explicitly instead of re-reading env.
+#[allow(dead_code)]
+pub fn resolve_target(name: &str) -> Result<ResolvedTarget, VirtuosoError> {
+    let manager = TargetManager::load()
+        .map_err(|e| VirtuosoError::Config(format!("failed to load targets: {e}")))?;
+    let target = manager
+        .get(name)
+        .ok_or_else(|| VirtuosoError::NotFound(format!("target '{name}' not found")))?;
+    let config = Config::from_target(target, name)?;
+    Ok(ResolvedTarget {
+        name: Some(name.to_string()),
+        config,
+    })
+}
+
+/// Resolve the effective configuration for an invocation from CLI flags and
+/// ambient configuration.
+// TODO(P0-A CommandContext): remove `allow(dead_code)` once commands receive
+// the resolved Config explicitly instead of re-reading env.
+#[allow(dead_code)]
+pub fn resolve(
+    cli_target: Option<&str>,
+    cli_profile: Option<&str>,
+) -> Result<ResolvedTarget, VirtuosoError> {
+    match resolve_selection(cli_target, cli_profile)? {
+        Selection::CliTarget(name) | Selection::EnvTarget(name) | Selection::ActiveTarget(name) => {
+            resolve_target(&name)
+        }
+        Selection::CliProfile(profile) => Ok(ResolvedTarget {
+            name: None,
+            config: Config::from_env_with_profile_no_target(Some(&profile))?,
+        }),
+        Selection::LegacyEnv => Ok(ResolvedTarget {
+            name: None,
+            config: Config::from_env()?,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    fn conflict_errors() {
+        let err = resolve_selection(Some("prod"), Some("analog")).unwrap_err();
+        assert!(err.to_string().contains("mutually exclusive"));
+    }
+
+    #[test]
+    fn cli_target_wins() {
+        assert_eq!(
+            resolve_selection(Some("prod"), None).unwrap(),
+            Selection::CliTarget("prod".to_string())
+        );
+    }
+
+    #[test]
+    fn cli_profile_wins() {
+        assert_eq!(
+            resolve_selection(None, Some("analog")).unwrap(),
+            Selection::CliProfile("analog".to_string())
+        );
+    }
+
+    #[serial]
+    #[test]
+    fn env_target_used_when_no_cli_flags() {
+        std::env::set_var("VB_TARGET", "prod");
+        let sel = resolve_selection(None, None).unwrap();
+        std::env::remove_var("VB_TARGET");
+        assert_eq!(sel, Selection::EnvTarget("prod".to_string()));
+    }
+
+    #[serial]
+    #[test]
+    fn cli_profile_overrides_env_target() {
+        std::env::set_var("VB_TARGET", "prod");
+        let sel = resolve_selection(None, Some("analog")).unwrap();
+        std::env::remove_var("VB_TARGET");
+        assert_eq!(sel, Selection::CliProfile("analog".to_string()));
+    }
+
+    /// Write a targets.yaml under the given (temp) home directory.
+    fn write_targets(home: &std::path::Path, yaml: &str) {
+        let vcli = home.join(".vcli");
+        std::fs::create_dir_all(&vcli).unwrap();
+        std::fs::write(vcli.join("targets.yaml"), yaml).unwrap();
+    }
+
+    /// Run `body` with HOME pointed at a temp dir (used to isolate
+    /// `TargetManager::load()`), then restore the original HOME.
+    fn with_home<T>(body: impl FnOnce(&std::path::Path) -> T) -> T {
+        let original_home = std::env::var_os("HOME");
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", temp.path());
+        let result = body(temp.path());
+        match original_home {
+            Some(h) => std::env::set_var("HOME", h),
+            None => std::env::remove_var("HOME"),
+        }
+        result
+    }
+
+    #[serial]
+    #[test]
+    fn active_target_used_when_no_cli_or_env() {
+        std::env::remove_var("VB_TARGET");
+        let sel = with_home(|home| {
+            write_targets(
+                home,
+                "active_target: prod\ntargets:\n  prod:\n    remote_host: compute-eda-42\n",
+            );
+            resolve_selection(None, None).unwrap()
+        });
+        assert_eq!(sel, Selection::ActiveTarget("prod".to_string()));
+    }
+
+    #[serial]
+    #[test]
+    fn legacy_env_when_nothing_selected() {
+        std::env::remove_var("VB_TARGET");
+        let sel = with_home(|_home| resolve_selection(None, None).unwrap());
+        assert_eq!(sel, Selection::LegacyEnv);
+    }
+
+    #[serial]
+    #[test]
+    fn corrupt_targets_errors_when_needed() {
+        std::env::remove_var("VB_TARGET");
+        let err = with_home(|home| {
+            write_targets(home, "active_target: prod\ntargets: [not valid");
+            resolve_selection(None, None).unwrap_err()
+        });
+        assert!(err.to_string().contains("failed to load targets"));
+    }
+
+    #[serial]
+    #[test]
+    fn resolve_target_builds_config() {
+        let resolved = with_home(|home| {
+            write_targets(
+                home,
+                "targets:\n  prod:\n    remote_host: compute-eda-42\n    port: 30001\n",
+            );
+            resolve_target("prod").unwrap()
+        });
+        assert_eq!(resolved.name.as_deref(), Some("prod"));
+        assert_eq!(
+            resolved.config.remote_host.as_deref(),
+            Some("compute-eda-42")
+        );
+        assert_eq!(resolved.config.port, 30001);
+    }
+
+    #[serial]
+    #[test]
+    fn resolve_target_not_found_errors() {
+        let err = with_home(|_home| resolve_target("nope").unwrap_err());
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[serial]
+    #[test]
+    fn invalid_active_target_errors() {
+        // active_target is set to a name whose definition was deleted: this is
+        // an inconsistent config and must error, not silently fall back.
+        std::env::remove_var("VB_TARGET");
+        let err = with_home(|home| {
+            write_targets(
+                home,
+                "active_target: prod\ntargets:\n  test:\n    remote_host: compute-eda-99\n",
+            );
+            resolve_selection(None, None).unwrap_err()
+        });
+        assert!(err
+            .to_string()
+            .contains("active_target 'prod' is set but not defined"));
+    }
+
+    #[serial]
+    #[test]
+    fn resolve_invalid_active_target_errors() {
+        std::env::remove_var("VB_TARGET");
+        let err = with_home(|home| {
+            write_targets(
+                home,
+                "active_target: prod\ntargets:\n  test:\n    remote_host: compute-eda-99\n",
+            );
+            resolve(None, None).unwrap_err()
+        });
+        assert!(err
+            .to_string()
+            .contains("active_target 'prod' is set but not defined"));
+    }
+
+    #[serial]
+    #[test]
+    fn unset_active_target_does_not_implicitly_select_default() {
+        // An unset active_target must fall back to legacy env even when a
+        // target literally named "default" exists — no implicit default pick.
+        std::env::remove_var("VB_TARGET");
+        let sel = with_home(|home| {
+            write_targets(
+                home,
+                "targets:\n  default:\n    remote_host: compute-eda-default\n",
+            );
+            resolve_selection(None, None).unwrap()
+        });
+        assert_eq!(sel, Selection::LegacyEnv);
+    }
+
+    #[serial]
+    #[test]
+    fn resolve_target_flow_uses_target_config() {
+        let resolved = with_home(|home| {
+            write_targets(
+                home,
+                "targets:\n  prod:\n    remote_host: compute-eda-42\n    port: 30001\n",
+            );
+            resolve(Some("prod"), None).unwrap()
+        });
+        assert_eq!(resolved.name.as_deref(), Some("prod"));
+        assert_eq!(
+            resolved.config.remote_host.as_deref(),
+            Some("compute-eda-42")
+        );
+        assert_eq!(resolved.config.port, 30001);
+    }
+
+    #[serial]
+    #[test]
+    fn resolve_env_target_flow_uses_target_config() {
+        std::env::set_var("VB_TARGET", "test");
+        let resolved = with_home(|home| {
+            write_targets(
+                home,
+                "targets:\n  test:\n    remote_host: compute-eda-99\n    port: 30002\n",
+            );
+            resolve(None, None).unwrap()
+        });
+        std::env::remove_var("VB_TARGET");
+        assert_eq!(resolved.name.as_deref(), Some("test"));
+        assert_eq!(
+            resolved.config.remote_host.as_deref(),
+            Some("compute-eda-99")
+        );
+        assert_eq!(resolved.config.port, 30002);
+    }
+
+    #[serial]
+    #[test]
+    fn resolve_active_target_flow_uses_target_config() {
+        std::env::remove_var("VB_TARGET");
+        let resolved = with_home(|home| {
+            write_targets(
+                home,
+                "active_target: prod\ntargets:\n  prod:\n    remote_host: compute-eda-42\n    port: 30001\n",
+            );
+            resolve(None, None).unwrap()
+        });
+        assert_eq!(resolved.name.as_deref(), Some("prod"));
+        assert_eq!(
+            resolved.config.remote_host.as_deref(),
+            Some("compute-eda-42")
+        );
+        assert_eq!(resolved.config.port, 30001);
+    }
+
+    #[serial]
+    #[test]
+    fn resolve_profile_flow_ignores_vb_target() {
+        // Regression: resolve(None, Some(profile)) must NOT be hijacked by a
+        // leftover ambient VB_TARGET. The old from_env_with_profile read
+        // VB_TARGET first and would have resolved to the "test" target here.
+        // Assert the final config comes from the profile/legacy path.
+        std::env::set_var("VB_TARGET", "test");
+        std::env::set_var("VB_REMOTE_HOST", "sentinel-host");
+        std::env::set_var("VB_PORT", "65432");
+        let resolved = with_home(|home| {
+            write_targets(
+                home,
+                "targets:\n  test:\n    remote_host: compute-eda-99\n    port: 30002\n",
+            );
+            resolve(None, Some("analog")).unwrap()
+        });
+        std::env::remove_var("VB_TARGET");
+        std::env::remove_var("VB_REMOTE_HOST");
+        std::env::remove_var("VB_PORT");
+        assert_eq!(resolved.name, None);
+        assert_eq!(
+            resolved.config.remote_host.as_deref(),
+            Some("sentinel-host")
+        );
+        assert_eq!(resolved.config.port, 65432);
+        assert_eq!(resolved.config.profile.as_deref(), Some("analog"));
+    }
+}

--- a/src/target/resolve.rs
+++ b/src/target/resolve.rs
@@ -104,16 +104,15 @@ pub fn resolve_target(name: &str) -> Result<ResolvedTarget, VirtuosoError> {
     })
 }
 
-/// Resolve the effective configuration for an invocation from CLI flags and
-/// ambient configuration.
+/// Resolve a concrete [`Selection`] into the effective, immutable config for
+/// one invocation. This is the single resolution point: callers (main) build a
+/// [`crate::context::CommandContext`] from the result and pass it to migrated
+/// commands, which must not re-read env.
 // TODO(P0-A CommandContext): remove `allow(dead_code)` once commands receive
 // the resolved Config explicitly instead of re-reading env.
 #[allow(dead_code)]
-pub fn resolve(
-    cli_target: Option<&str>,
-    cli_profile: Option<&str>,
-) -> Result<ResolvedTarget, VirtuosoError> {
-    match resolve_selection(cli_target, cli_profile)? {
+pub fn resolve_from_selection(selection: Selection) -> Result<ResolvedTarget, VirtuosoError> {
+    match selection {
         Selection::CliTarget(name) | Selection::EnvTarget(name) | Selection::ActiveTarget(name) => {
             resolve_target(&name)
         }
@@ -126,6 +125,18 @@ pub fn resolve(
             config: Config::from_env()?,
         }),
     }
+}
+
+/// Resolve the effective configuration for an invocation from CLI flags and
+/// ambient configuration.
+// TODO(P0-A CommandContext): remove `allow(dead_code)` once commands receive
+// the resolved Config explicitly instead of re-reading env.
+#[allow(dead_code)]
+pub fn resolve(
+    cli_target: Option<&str>,
+    cli_profile: Option<&str>,
+) -> Result<ResolvedTarget, VirtuosoError> {
+    resolve_from_selection(resolve_selection(cli_target, cli_profile)?)
 }
 
 #[cfg(test)]

--- a/src/target/resolve.rs
+++ b/src/target/resolve.rs
@@ -184,23 +184,30 @@ mod tests {
         assert_eq!(sel, Selection::CliProfile("analog".to_string()));
     }
 
-    /// Write a targets.yaml under the given (temp) home directory.
-    fn write_targets(home: &std::path::Path, yaml: &str) {
-        let vcli = home.join(".vcli");
-        std::fs::create_dir_all(&vcli).unwrap();
-        std::fs::write(vcli.join("targets.yaml"), yaml).unwrap();
+    /// Write a targets.yaml into the given (temp) config directory.
+    fn write_targets(dir: &std::path::Path, yaml: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join("targets.yaml"), yaml).unwrap();
     }
 
-    /// Run `body` with HOME pointed at a temp dir (used to isolate
-    /// `TargetManager::load()`), then restore the original HOME.
-    fn with_home<T>(body: impl FnOnce(&std::path::Path) -> T) -> T {
-        let original_home = std::env::var_os("HOME");
+    /// Run `body` with `VB_TARGETS_FILE` pointed at a temp targets.yaml, then
+    /// restore the previous value.
+    ///
+    /// Pointing `HOME` at a temp dir does **not** isolate
+    /// `TargetManager::load()`: on Windows `dirs::home_dir()` resolves to
+    /// `FOLDERID_Profile` and ignores `HOME` entirely, so a HOME-based helper
+    /// silently loads the real user profile there and every "config exists"
+    /// assertion degrades to the empty-config path. `VB_TARGETS_FILE` is
+    /// honoured identically on every platform, so these tests assert the same
+    /// behaviour everywhere.
+    fn with_targets_dir<T>(body: impl FnOnce(&std::path::Path) -> T) -> T {
+        let original = std::env::var_os("VB_TARGETS_FILE");
         let temp = tempfile::tempdir().unwrap();
-        std::env::set_var("HOME", temp.path());
+        std::env::set_var("VB_TARGETS_FILE", temp.path().join("targets.yaml"));
         let result = body(temp.path());
-        match original_home {
-            Some(h) => std::env::set_var("HOME", h),
-            None => std::env::remove_var("HOME"),
+        match original {
+            Some(v) => std::env::set_var("VB_TARGETS_FILE", v),
+            None => std::env::remove_var("VB_TARGETS_FILE"),
         }
         result
     }
@@ -209,7 +216,7 @@ mod tests {
     #[test]
     fn active_target_used_when_no_cli_or_env() {
         std::env::remove_var("VB_TARGET");
-        let sel = with_home(|home| {
+        let sel = with_targets_dir(|home| {
             write_targets(
                 home,
                 "active_target: prod\ntargets:\n  prod:\n    remote_host: compute-eda-42\n",
@@ -223,7 +230,7 @@ mod tests {
     #[test]
     fn legacy_env_when_nothing_selected() {
         std::env::remove_var("VB_TARGET");
-        let sel = with_home(|_home| resolve_selection(None, None).unwrap());
+        let sel = with_targets_dir(|_home| resolve_selection(None, None).unwrap());
         assert_eq!(sel, Selection::LegacyEnv);
     }
 
@@ -231,7 +238,7 @@ mod tests {
     #[test]
     fn corrupt_targets_errors_when_needed() {
         std::env::remove_var("VB_TARGET");
-        let err = with_home(|home| {
+        let err = with_targets_dir(|home| {
             write_targets(home, "active_target: prod\ntargets: [not valid");
             resolve_selection(None, None).unwrap_err()
         });
@@ -241,7 +248,7 @@ mod tests {
     #[serial]
     #[test]
     fn resolve_target_builds_config() {
-        let resolved = with_home(|home| {
+        let resolved = with_targets_dir(|home| {
             write_targets(
                 home,
                 "targets:\n  prod:\n    remote_host: compute-eda-42\n    port: 30001\n",
@@ -259,7 +266,7 @@ mod tests {
     #[serial]
     #[test]
     fn resolve_target_not_found_errors() {
-        let err = with_home(|_home| resolve_target("nope").unwrap_err());
+        let err = with_targets_dir(|_home| resolve_target("nope").unwrap_err());
         assert!(err.to_string().contains("not found"));
     }
 
@@ -269,7 +276,7 @@ mod tests {
         // active_target is set to a name whose definition was deleted: this is
         // an inconsistent config and must error, not silently fall back.
         std::env::remove_var("VB_TARGET");
-        let err = with_home(|home| {
+        let err = with_targets_dir(|home| {
             write_targets(
                 home,
                 "active_target: prod\ntargets:\n  test:\n    remote_host: compute-eda-99\n",
@@ -285,7 +292,7 @@ mod tests {
     #[test]
     fn resolve_invalid_active_target_errors() {
         std::env::remove_var("VB_TARGET");
-        let err = with_home(|home| {
+        let err = with_targets_dir(|home| {
             write_targets(
                 home,
                 "active_target: prod\ntargets:\n  test:\n    remote_host: compute-eda-99\n",
@@ -303,7 +310,7 @@ mod tests {
         // An unset active_target must fall back to legacy env even when a
         // target literally named "default" exists — no implicit default pick.
         std::env::remove_var("VB_TARGET");
-        let sel = with_home(|home| {
+        let sel = with_targets_dir(|home| {
             write_targets(
                 home,
                 "targets:\n  default:\n    remote_host: compute-eda-default\n",
@@ -316,7 +323,7 @@ mod tests {
     #[serial]
     #[test]
     fn resolve_target_flow_uses_target_config() {
-        let resolved = with_home(|home| {
+        let resolved = with_targets_dir(|home| {
             write_targets(
                 home,
                 "targets:\n  prod:\n    remote_host: compute-eda-42\n    port: 30001\n",
@@ -335,7 +342,7 @@ mod tests {
     #[test]
     fn resolve_env_target_flow_uses_target_config() {
         std::env::set_var("VB_TARGET", "test");
-        let resolved = with_home(|home| {
+        let resolved = with_targets_dir(|home| {
             write_targets(
                 home,
                 "targets:\n  test:\n    remote_host: compute-eda-99\n    port: 30002\n",
@@ -355,7 +362,7 @@ mod tests {
     #[test]
     fn resolve_active_target_flow_uses_target_config() {
         std::env::remove_var("VB_TARGET");
-        let resolved = with_home(|home| {
+        let resolved = with_targets_dir(|home| {
             write_targets(
                 home,
                 "active_target: prod\ntargets:\n  prod:\n    remote_host: compute-eda-42\n    port: 30001\n",
@@ -380,7 +387,7 @@ mod tests {
         std::env::set_var("VB_TARGET", "test");
         std::env::set_var("VB_REMOTE_HOST", "sentinel-host");
         std::env::set_var("VB_PORT", "65432");
-        let resolved = with_home(|home| {
+        let resolved = with_targets_dir(|home| {
             write_targets(
                 home,
                 "targets:\n  test:\n    remote_host: compute-eda-99\n    port: 30002\n",

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -27,6 +27,7 @@ mod config_tests {
             remote_host: remote_host.map(String::from),
             remote_user: remote_user.map(String::from),
             port: 65432,
+            port_explicit: true,
             jump_host: jump_host.map(String::from),
             jump_user: jump_user.map(String::from),
             ssh_port: None,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2188,3 +2188,56 @@ END"#;
         assert!(sweep_data.contains_key(&1));
     }
 }
+
+#[cfg(test)]
+mod profile_dispatch_tests {
+    use serial_test::serial;
+    use std::env;
+
+    /// RAII guard restoring a set of env vars to their previous values.
+    struct EnvGuard(Vec<(String, Option<String>)>);
+    impl EnvGuard {
+        fn set(entries: &[(&str, &str)]) -> Self {
+            let mut prev = Vec::new();
+            for (k, v) in entries {
+                prev.push((k.to_string(), env::var(k).ok()));
+                env::set_var(k, v);
+            }
+            Self(prev)
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.0 {
+                match v {
+                    Some(prev) => env::set_var(k, prev),
+                    None => env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn profile_show_explicit_wins_over_ambient_vb_profile() {
+        // Regression: `VB_PROFILE=review_ambient vcli --profile review_explicit
+        // profile show` returned the ambient profile because the config
+        // management branch skipped resolution and dispatch_profile did not
+        // receive the CLI --profile. The explicit arg must win.
+        let _g = EnvGuard::set(&[("VB_PROFILE", "review_ambient")]);
+        let out = crate::dispatch_profile(crate::ProfileCmd::Show, Some("review_explicit".into()))
+            .expect("dispatch should succeed");
+        assert_eq!(out["profile"], "review_explicit");
+        assert_eq!(out["source"], "explicit");
+    }
+
+    #[test]
+    #[serial]
+    fn profile_show_falls_back_to_ambient_without_explicit() {
+        let _g = EnvGuard::set(&[("VB_PROFILE", "review_ambient")]);
+        let out = crate::dispatch_profile(crate::ProfileCmd::Show, None)
+            .expect("dispatch should succeed");
+        assert_eq!(out["profile"], "review_ambient");
+        assert_eq!(out["source"], "environment");
+    }
+}

--- a/src/transport/backend.rs
+++ b/src/transport/backend.rs
@@ -197,6 +197,7 @@ mod tests {
             remote_host: Some("compute-eda-42".into()),
             remote_user: None,
             port: 65432,
+            port_explicit: false,
             jump_host: None,
             jump_user: None,
             ssh_port: None,

--- a/src/transport/daemon_lifecycle.rs
+++ b/src/transport/daemon_lifecycle.rs
@@ -243,6 +243,7 @@ mod tests {
             config_digest: None,
             mode: None,
             attached_remote_port: None,
+            remote_bridge_port: None,
             attached_session_id: None,
         }
     }
@@ -456,6 +457,7 @@ mod challenge_tests {
             config_digest: None,
             mode: None,
             attached_remote_port: None,
+            remote_bridge_port: None,
             attached_session_id: None,
         }
     }

--- a/src/transport/lifecycle.rs
+++ b/src/transport/lifecycle.rs
@@ -391,6 +391,7 @@ mod tests {
             remote_host: None,
             remote_user: None,
             port: 22,
+            port_explicit: false,
             jump_host: None,
             jump_user: None,
             ssh_port: None,

--- a/src/transport/native.rs
+++ b/src/transport/native.rs
@@ -983,6 +983,7 @@ mod tests {
             remote_host: Some(host.into()),
             remote_user: None,
             port: 65432,
+            port_explicit: true,
             jump_host: jump.map(String::from),
             jump_user: None,
             ssh_port: Some(22),

--- a/src/transport/pool.rs
+++ b/src/transport/pool.rs
@@ -332,6 +332,7 @@ mod tests {
             remote_host: Some(host.into()),
             remote_user: None,
             port: 65432,
+            port_explicit: false,
             jump_host: None,
             jump_user: None,
             ssh_port: Some(22),

--- a/src/transport/scheduler.rs
+++ b/src/transport/scheduler.rs
@@ -663,6 +663,7 @@ mod tests {
             remote_host: Some("compute-eda-42".into()),
             remote_user: None,
             port: 65432,
+            port_explicit: false,
             jump_host: None,
             jump_user: None,
             ssh_port: Some(22),

--- a/src/transport/ssh.rs
+++ b/src/transport/ssh.rs
@@ -853,7 +853,10 @@ mod tests {
             .arg("-C")
             .arg(destination.path());
 
-        let output = run_streaming_pipeline(producer, consumer, Duration::from_secs(5)).unwrap();
+        // 20s is a deadlock-detection bound, not a performance bound: a real
+        // deadlock never completes regardless of the budget. 5s was too tight
+        // and flaky on loaded machines.
+        let output = run_streaming_pipeline(producer, consumer, Duration::from_secs(20)).unwrap();
         assert!(output.producer_status.success());
         assert!(output.consumer_status.success());
         assert!(output.producer_stderr.len() >= 262144);

--- a/src/transport/tunnel.rs
+++ b/src/transport/tunnel.rs
@@ -534,23 +534,18 @@ pub struct SSHClient {
     /// re-reading the environment — combining env hosts with context dirs is
     /// exactly the cross-identity bug target isolation must prevent.
     config: Config,
-    /// Local forward port the client connects to. For `deployed` tunnels this
-    /// may fall back to a free port when `cfg.port` is taken locally; the
-    /// remote endpoint stays at [`Self::remote_bridge_port`].
+    /// Local forward port the client connects to.
     pub port: u16,
-    /// Fixed remote bridge port (= `cfg.port`) this tunnel forwards to.
-    /// Never incremented together with the local port.
-    pub remote_bridge_port: u16,
     pub keep_remote_files: bool,
     pub profile: Option<String>,
-    /// Config identity digest (F05). Recorded into `TunnelState` so `status`
-    /// can detect drift between the resolved config and the running tunnel.
-    pub config_digest: Option<String>,
-    /// Set by [`Self::warm`] once the tunnel child is spawned; carried so
-    /// liveness probes and state saving agree on the target. `stop` prefers
-    /// the recorded `TunnelState` pid as the sole target (see
-    /// [`stop_saved_tunnel`]).
+    /// PID of the SSH tunnel process spawned by [`Self::open_tunnel`]. The
+    /// process is spawned WITHOUT `-f`, so this is the real forward-holding
+    /// process (verifiable via [`Self::is_tunnel_alive`]).
     tunnel_pid: Option<u32>,
+    /// Start-identity of the tunnel process, captured at spawn (best-effort).
+    /// Recorded into `TunnelState::start_identity` so `stop` can distinguish
+    /// the process we spawned from an unrelated PID-reuse.
+    tunnel_identity: Option<u64>,
 }
 
 impl SSHClient {
@@ -600,20 +595,22 @@ impl SSHClient {
             transport: Arc::new(OpenSshTransport::new(runner)),
             config: cfg.clone(),
             port: cfg.port,
-            remote_bridge_port: cfg.port,
             keep_remote_files,
             profile: cfg.profile.clone(),
-            config_digest: Some(cfg.digest()),
             tunnel_pid: None,
+            tunnel_identity: None,
         })
     }
 
-    pub fn warm(&mut self, _timeout: Option<u64>) -> Result<()> {
-        self.ensure_remote_setup()?;
-        self.ensure_tunnel()?;
-        self.save_state()?;
-        tracing::info!("tunnel established on port {}", self.port);
-        Ok(())
+    /// Deploy the remote setup files (daemon binary + bridge IL) for this
+    /// profile. This does NOT open a tunnel and does NOT claim a daemon
+    /// endpoint: the daemon is started by Virtuoso loading the IL, at which
+    /// point it binds an OS-assigned port that is discovered and validated by
+    /// `vcli tunnel attach`. Returns the deployed IL path.
+    pub fn warm(&self) -> Result<String> {
+        let il_path = self.ensure_remote_setup()?;
+        tracing::info!("remote setup deployed: profile={:?}", self.profile);
+        Ok(il_path)
     }
 
     pub fn stop(&self) -> Result<()> {
@@ -641,11 +638,18 @@ impl SSHClient {
             .map(|s| s.port)
     }
 
-    /// OS PID of the SSH tunnel process spawned by [`Self::open_tunnel`]
-    /// (or by `warm()`), if any. Used by `tunnel attach` to record the
-    /// tunnel pid into `TunnelState` so `tunnel detach` / `stop` can signal it.
+    /// OS PID of the SSH tunnel process spawned by [`Self::open_tunnel`].
+    /// Used by `tunnel attach` to record the tunnel pid into `TunnelState` so
+    /// `tunnel detach` / `stop` can signal it.
     pub fn tunnel_pid(&self) -> Option<u32> {
         self.tunnel_pid
+    }
+
+    /// Start-identity of the tunnel process (best-effort), recorded into
+    /// `TunnelState::start_identity` so `stop` can tell the process we spawned
+    /// apart from an unrelated PID reuse.
+    pub fn tunnel_identity(&self) -> Option<u64> {
+        self.tunnel_identity
     }
 
     pub fn is_tunnel_alive(&self) -> bool {
@@ -710,35 +714,15 @@ impl SSHClient {
         Ok(il_path)
     }
 
-    fn ensure_tunnel(&mut self) -> Result<()> {
-        // The REMOTE bridge port is fixed (= cfg.port); only the local forward
-        // port may fall back when `cfg.port` is already taken locally. The two
-        // are never incremented together, so a fallback can't change the
-        // tunnel's remote endpoint identity.
-        let remote = self.remote_bridge_port;
-        for local in self.port..(self.port + 10) {
-            if self.try_ssh_tunnel(local, remote).is_ok() {
-                self.port = local;
-                return Ok(());
-            }
-        }
-        // All candidate local ports failed — clean up the resources this
-        // creation deployed (the remote setup dir) rather than leaking them.
-        let _ = self.cleanup_remote();
-        Err(VirtuosoError::Ssh(format!(
-            "failed to establish tunnel on any port; verify SSH: `{}`",
-            self.runner().verify_cmd_hint()
-        )))
-    }
-
-    /// Open an SSH tunnel forwarding the local port to the remote host.
+    /// Open an SSH tunnel forwarding `local_port` to `remote_port` on the
+    /// remote host.
     ///
-    /// Used by `tunnel attach` to plug into a pre-existing daemon at a port
-    /// discovered from session metadata — no port walk, since the OS-assigned
-    /// port we want to reach is known up front. Local and remote coincide here
-    /// (attach forwards to the discovered daemon port).
-    pub fn open_tunnel(&mut self, port: u16) -> Result<()> {
-        self.try_ssh_tunnel(port, port)
+    /// Used by `tunnel attach` to plug into a pre-existing daemon whose real
+    /// (OS-assigned) port was discovered and validated from session metadata.
+    /// No port walk: the endpoint is known up front, so a local-port conflict
+    /// is reported as a failure, not silently shifted.
+    pub fn open_tunnel(&mut self, local_port: u16, remote_port: u16) -> Result<()> {
+        self.try_ssh_tunnel(local_port, remote_port)
     }
 
     fn try_ssh_tunnel(&mut self, local_port: u16, remote_port: u16) -> Result<()> {
@@ -753,27 +737,30 @@ impl SSHClient {
             "ServerAliveInterval=30",
             "-o",
             "ServerAliveCountMax=3",
-            "-f",
+            // The spawned process MUST be the sole forward holder, so
+            // connection reuse is explicitly disabled here — even a user's
+            // `~/.ssh/config` cannot turn this tunnel into a ControlMaster
+            // slave whose recorded PID is not the process owning the forward.
+            "-o",
+            "ControlMaster=no",
+            // -v logs the `Local forwarding listening on …` line to stderr;
+            // `wait_for_forward` uses it to prove THIS ssh actually bound the
+            // port (a pre-existing service can never produce it). `LogLevel`
+            // is pinned explicitly because `-v` only raises the level when the
+            // user config left it unset: a `LogLevel QUIET` in ~/.ssh/config
+            // would otherwise silence the marker and make every attach time
+            // out. Command-line `-o` wins over the config file.
+            "-v",
+            "-o",
+            "LogLevel=DEBUG1",
             "-N",
             "-L",
             &format!("127.0.0.1:{local_port}:127.0.0.1:{remote_port}"),
         ]);
-
-        // Conditionally add ControlMaster options — disabled when CM has been
-        // found to fail at runtime (WSL2/Windows named pipe issues).
-        if *self.runner().use_control_master.lock().unwrap() {
-            let control_dir = crate::runtime_paths::cache_subdir(&["ssh"]);
-            let _ = std::fs::create_dir_all(&control_dir);
-            let control_path = control_dir.join("%h-%p-%r");
-            cmd.args([
-                "-o",
-                "ControlMaster=auto",
-                "-o",
-                &format!("ControlPath={}", control_path.display()),
-                "-o",
-                "ControlPersist=600",
-            ]);
-        }
+        // No `-f`: the spawned process IS the forward-holding ssh, so its pid
+        // and start identity are verifiable and `stop` can signal it directly.
+        // Without `-f`, ssh keeps forwarding after this CLI process exits, so
+        // the tunnel lifetime is unchanged from the old backgrounded form.
 
         if let Some(p) = self.runner().ssh_port {
             cmd.arg("-p").arg(p.to_string());
@@ -789,58 +776,31 @@ impl SSHClient {
         }
         cmd.arg(&target);
 
-        let output = cmd
+        let mut child = cmd
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()
             .map_err(|e| VirtuosoError::Ssh(format!("failed to start tunnel: {e}")))?;
 
-        let pid = output.id();
-        self.tunnel_pid = Some(pid);
+        // Only THIS ssh's forward counts as success. `wait_for_forward` needs
+        // the ssh child alive AND a reachable port AND its stderr showing it
+        // bound the local port — a pre-existing service can never satisfy the
+        // stderr marker, so it cannot masquerade as our tunnel. Any failure
+        // reaps the child so the caller can try another local port without
+        // leaking a process.
+        //
+        // The budget covers the full SSH handshake + auth, which can be slow
+        // through a jump host; failures (`ExitOnForwardFailure`) are detected
+        // immediately by the child exiting, not by the budget running out.
+        wait_for_forward(&mut child, local_port, TUNNEL_FORWARD_BUDGET)?;
 
-        use std::net::TcpStream;
-        for _ in 0..10 {
-            std::thread::sleep(std::time::Duration::from_millis(50));
-            if TcpStream::connect(format!("127.0.0.1:{local_port}")).is_ok() {
-                return Ok(());
-            }
-        }
-        Err(VirtuosoError::Ssh("tunnel port not reachable".into()))
-    }
-
-    fn save_state(&self) -> Result<()> {
-        let state = TunnelState {
-            version: crate::models::CURRENT_STATE_VERSION,
-            port: self.port,
-            pid: self.tunnel_pid.unwrap_or(0),
-            remote_host: self.runner().host.clone(),
-            setup_path: Some(setup_dir_for_profile(self.profile.as_deref())),
-            // v2 fields: the OpenSSH backend records its backend + profile; the
-            // remaining v2 fields (daemon nonce, IPC endpoint, executable path,
-            // start identity, …) are populated by the native daemon when it ships.
-            profile: self.profile.clone(),
-            backend: Some("openssh".to_string()),
-            daemon_nonce: None,
-            executable_path: None,
-            start_identity: None,
-            ipc_endpoint: None,
-            token_path: None,
-            local_forward: None,
-            start_time_unix_ms: None,
-            health: None,
-            config_digest: self.config_digest.clone(),
-            mode: Some(crate::models::TUNNEL_MODE_DEPLOYED.into()),
-            attached_remote_port: None,
-            remote_bridge_port: Some(self.remote_bridge_port),
-            attached_session_id: None,
-        };
-        // Write under the *config's* profile namespace. Using `save()` (which
-        // keys on ambient `VB_PROFILE`) here would record the tunnel under the
-        // wrong namespace whenever the process env profile differs from the
-        // resolved config (e.g. `--target prod` with `VB_PROFILE=test`).
-        state
-            .save_with_profile(self.profile.as_deref())
-            .map_err(|e| VirtuosoError::Ssh(e.to_string()))
+        self.tunnel_pid = Some(child.id());
+        self.tunnel_identity = crate::transport::identity::ProcessIdentity::of_pid(child.id())
+            .ok()
+            .map(|p| p.start_identity);
+        // The child is intentionally not waited on: it keeps forwarding after
+        // this process exits (same lifetime as the old `-f` behaviour).
+        Ok(())
     }
 
     fn deploy_daemon_3(&self, setup_dir: &str) -> Result<String> {
@@ -922,17 +882,143 @@ impl SSHClient {
         self.runner().upload_text(&il_content, &path)?;
         Ok(path)
     }
+}
 
-    fn cleanup_remote(&self) -> Result<()> {
-        // Cleanup is scoped to the active profile's setup dir so that
-        // stopping profile A does not wipe profile B's bridge files.
-        // This was the bug upstream PR #86 fixed in the Python bridge
-        // and that we mirror here.
-        let setup_dir = setup_dir_for_profile(self.profile.as_deref());
-        self.runner()
-            .run_command(&format!("rm -rf {setup_dir}"), None)?;
-        Ok(())
+/// How long `wait_for_forward` waits for the ssh child to report its bind.
+///
+/// This must cover a full SSH handshake + auth, which can take several seconds
+/// through a jump host or a loaded bastion. It is NOT the failure path: with
+/// `ExitOnForwardFailure=yes` a bind failure (or any connection error) makes
+/// ssh exit, and the child-exit branch returns immediately.
+const TUNNEL_FORWARD_BUDGET: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Wait until the spawned ssh process has established its local forward.
+///
+/// The ONLY proof that THIS ssh's forward is up is ssh's own stderr: with
+/// `-v` and `ExitOnForwardFailure=yes`, OpenSSH prints `Local forwarding
+/// listening on 127.0.0.1 port <n>` once it has bound the local port and set
+/// up the forwarding. A pre-existing service on the port can satisfy a bare
+/// TCP probe but can never produce that line — and during the ssh handshake
+/// (before it has tried to bind) a naive "child alive + port reachable" test
+/// would falsely report success. So we require the stderr bind marker AND a
+/// reachable port AND a live child. On any failure the child is killed and
+/// reaped so the caller can try another local port without leaking a process.
+fn wait_for_forward(
+    child: &mut std::process::Child,
+    local_port: u16,
+    budget: std::time::Duration,
+) -> Result<()> {
+    use std::io::Read;
+    use std::net::TcpStream;
+    use std::sync::{Arc, Mutex};
+
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| VirtuosoError::Ssh("tunnel stderr unavailable".into()))?;
+    // Drain stderr on a background thread so ssh's debug output can never fill
+    // the pipe and block the child while we poll liveness + the port below.
+    let log: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(Vec::new()));
+    let log_reader = Arc::clone(&log);
+    let reader = std::thread::spawn(move || {
+        let mut buf = [0u8; 2048];
+        let mut s = stderr;
+        loop {
+            match s.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(n) => log_reader.lock().unwrap().extend_from_slice(&buf[..n]),
+            }
+        }
+    });
+
+    // Snapshot the bytes captured so far. The mutex guard must be dropped
+    // before the value is used, so this returns an owned, lowercased String
+    // rather than a `Cow` borrowed from the guard.
+    fn snapshot(log: &std::sync::Arc<std::sync::Mutex<Vec<u8>>>) -> String {
+        let guard = match log.lock() {
+            Ok(g) => g,
+            // A poisoned mutex only means the reader thread panicked; the
+            // captured bytes are still safe to read for a diagnostic.
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        String::from_utf8_lossy(&guard).to_lowercase()
     }
+
+    // The marker must be followed by a NON-digit: with a plain substring
+    // match, ssh binding port 30001 would satisfy the marker for port 3000.
+    fn bind_marker_present(log: &str, local_port: u16) -> bool {
+        let marker = format!("local forwarding listening on 127.0.0.1 port {local_port}");
+        let mut rest = log;
+        while let Some(idx) = rest.find(&marker) {
+            let after = &rest[idx + marker.len()..];
+            if !after.starts_with(|c: char| c.is_ascii_digit()) {
+                return true;
+            }
+            rest = after;
+        }
+        false
+    }
+
+    let deadline = std::time::Instant::now() + budget;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let _ = child.wait();
+                let tail = snapshot(&log);
+                let _ = reader.join();
+                return Err(VirtuosoError::Ssh(format!(
+                    "ssh exited before forward was established ({status}); stderr tail: {}",
+                    tail.trim_end()
+                )));
+            }
+            Ok(None) => {}
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = reader.join();
+                return Err(VirtuosoError::Ssh(format!("tunnel wait failed: {e}")));
+            }
+        }
+
+        let log_snapshot = snapshot(&log);
+        if bind_marker_present(&log_snapshot, local_port)
+            && TcpStream::connect(("127.0.0.1", local_port)).is_ok()
+        {
+            // ssh logged that IT bound the port; confirm it did not die right
+            // after (e.g. the remote end tore the connection down).
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    let _ = child.wait();
+                    let _ = reader.join();
+                    return Err(VirtuosoError::Ssh(format!(
+                        "ssh exited right after reporting the forward: {status}"
+                    )));
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    let _ = reader.join();
+                    return Err(VirtuosoError::Ssh(format!("tunnel wait failed: {e}")));
+                }
+            }
+            // Detach the reader: it blocks on the pipe until ssh exits (i.e.
+            // the tunnel is torn down), which is fine for a short-lived CLI.
+            return Ok(());
+        }
+
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = reader.join();
+    Err(VirtuosoError::Ssh(
+        "tunnel forward never established in time".into(),
+    ))
 }
 
 pub fn file_md5(path: &str) -> Result<String> {
@@ -955,8 +1041,8 @@ mod tests {
     use super::is_ssh_executable;
     use super::{
         classify_ssh_pid, daemon_lifecycle, decide_stop, profiled_bridge_leaf, profiled_env_key,
-        setup_dir_for_profile, stop_saved_tunnel, verdict_to_decision, verify_ssh_pid, PidVerdict,
-        StopDecision, TunnelState, Verdict,
+        setup_dir_for_profile, stop_saved_tunnel, verdict_to_decision, verify_ssh_pid,
+        wait_for_forward, PidVerdict, StopDecision, TunnelState, Verdict,
     };
     use crate::config::Config;
     use serial_test::serial;
@@ -1529,5 +1615,151 @@ mod tests {
         let k_a = profiled_env_key("VB_LOCAL_PORT", Some("analog"));
         let k_b = profiled_env_key("VB_LOCAL_PORT", Some("digital"));
         assert_ne!(k_a, k_b);
+    }
+
+    // ---- wait_for_forward -------------------------------------------------
+    //
+    // The regression these guard against: the old success check probed only
+    // the local TCP port, so when the port was already served by another
+    // process (and ssh exited on bind failure) the tunnel was reported as
+    // established. `wait_for_forward` now requires ssh's own stderr bind
+    // marker (`Local forwarding listening on 127.0.0.1 port <n>`) — only that
+    // proves THIS ssh bound the port; a foreign listener can never produce it.
+    //
+    // Budgets here are deliberately short: production uses
+    // `TUNNEL_FORWARD_BUDGET`, but every failure mode these tests exercise is
+    // detected without waiting it out, so the whole group runs in ~3 s.
+
+    fn free_port() -> u16 {
+        std::net::TcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    fn shell_child(script: &str) -> std::process::Child {
+        std::process::Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .unwrap()
+    }
+
+    const TEST_BUDGET: std::time::Duration = std::time::Duration::from_secs(5);
+
+    /// A port that has a listener but whose child exited immediately: must
+    /// fail, even though the port is reachable. The child never emitted a
+    /// bind marker, so the foreign listener cannot be mistaken for our tunnel.
+    #[test]
+    fn wait_for_forward_fails_when_child_dies_despite_port_open() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let mut child = shell_child("exit 7");
+        let err = wait_for_forward(&mut child, port, TEST_BUDGET).unwrap_err();
+        assert!(
+            err.to_string().contains("exited before forward"),
+            "must not claim success on a pre-existing service, got: {err}"
+        );
+        // child is reaped by wait_for_forward.
+    }
+
+    /// The false-success window: an unrelated service holds the port while
+    /// our "ssh" is still handshaking (alive) and then fails LATE. A naive
+    /// "child alive + port reachable" probe would return Ok during the alive
+    /// window; the bind-marker requirement means we never do — we wait out the
+    /// delay and reject on exit.
+    #[test]
+    fn wait_for_forward_rejects_unrelated_listener_when_ssh_fails_late() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let mut child = shell_child("sleep 2; exit 7");
+        let err = wait_for_forward(&mut child, port, TEST_BUDGET).unwrap_err();
+        assert!(
+            err.to_string().contains("exited before forward"),
+            "foreign listener must never be accepted as our forward, got: {err}"
+        );
+    }
+
+    /// A live child that reports the OpenSSH `-v` bind line on stderr (i.e.
+    /// THIS ssh bound the port) plus a reachable port → success. The marker is
+    /// matched case-insensitively and irrespective of the `debug1: ` prefix
+    /// OpenSSH adds, so the check survives cosmetic log-format changes.
+    #[test]
+    fn wait_for_forward_succeeds_when_ssh_reports_the_bind() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let script = format!(
+            "echo 'debug1: Local forwarding listening on 127.0.0.1 port {port}.' >&2; sleep 30"
+        );
+        let mut child = shell_child(&script);
+        assert!(
+            wait_for_forward(&mut child, port, TEST_BUDGET).is_ok(),
+            "the stderr bind marker must be accepted as proof of the forward"
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// The bind marker is port-scoped: ssh reporting a bind on a DIFFERENT
+    /// port must not be accepted as proof for the port we asked for.
+    #[test]
+    fn wait_for_forward_ignores_bind_marker_for_another_port() {
+        let port = free_port();
+        let other = port.wrapping_add(1);
+        let script = format!(
+            "echo 'debug1: Local forwarding listening on 127.0.0.1 port {other}.' >&2; sleep 30"
+        );
+        let mut child = shell_child(&script);
+        let err =
+            wait_for_forward(&mut child, port, std::time::Duration::from_millis(500)).unwrap_err();
+        assert!(
+            err.to_string().contains("never established"),
+            "a bind marker for another port must not satisfy the check, got: {err}"
+        );
+        assert!(
+            child.try_wait().unwrap().is_some(),
+            "child must be reclaimed after a timeout"
+        );
+    }
+
+    /// The marker must be digit-boundary-scoped: a bind on `30001` is not a
+    /// bind on `3000`. (The TCP probe is irrelevant here — no listener is
+    /// bound by the test — so the outcome must be a timeout either way.)
+    #[test]
+    fn wait_for_forward_ignores_bind_marker_that_extends_the_port() {
+        let child_port = 30_001;
+        let mut child = shell_child(&format!(
+            "echo 'debug1: Local forwarding listening on 127.0.0.1 port {child_port}.' >&2; sleep 30"
+        ));
+        let err =
+            wait_for_forward(&mut child, 3_000, std::time::Duration::from_millis(500)).unwrap_err();
+        assert!(
+            err.to_string().contains("never established"),
+            "'port 30001' must not satisfy the marker for port 3000, got: {err}"
+        );
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// Live child but NO listener on the port (and no bind marker) → times
+    /// out, and the child is reclaimed (killed + reaped) so the caller can try
+    /// the next port.
+    #[test]
+    fn wait_for_forward_times_out_and_reclaims_child() {
+        let mut child = shell_child("sleep 30");
+        let err = wait_for_forward(
+            &mut child,
+            free_port(),
+            std::time::Duration::from_millis(500),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("never established"), "err: {err}");
+        assert!(
+            child.try_wait().unwrap().is_some(),
+            "child must be killed + reaped after a timeout"
+        );
     }
 }

--- a/src/transport/tunnel.rs
+++ b/src/transport/tunnel.rs
@@ -553,9 +553,14 @@ impl SSHClient {
 
     pub fn from_env(keep_remote_files: bool) -> Result<Self> {
         let cfg = Config::from_env()?;
-        // The tunnel child is a dedicated OpenSSH-only lifecycle. An explicit
-        // `native` request must fail here rather than be silently ignored.
-        crate::transport::backend::require_openssh(&cfg)?;
+        Self::from_config(&cfg, keep_remote_files)
+    }
+
+    /// Build from an already-resolved config (P0-A). The tunnel child is a
+    /// dedicated OpenSSH-only lifecycle; an explicit `native` request must
+    /// fail here rather than be silently ignored.
+    pub fn from_config(cfg: &Config, keep_remote_files: bool) -> Result<Self> {
+        crate::transport::backend::require_openssh(cfg)?;
         let mut runner = SSHRunner::new(cfg.remote_host.as_deref().unwrap_or(""));
         if let Some(ref user) = cfg.remote_user {
             runner = runner.with_user(user);
@@ -578,7 +583,7 @@ impl SSHClient {
             transport: Arc::new(OpenSshTransport::new(runner)),
             port: cfg.port,
             keep_remote_files,
-            profile: cfg.profile,
+            profile: cfg.profile.clone(),
             tunnel_pid: None,
         })
     }

--- a/src/transport/tunnel.rs
+++ b/src/transport/tunnel.rs
@@ -453,7 +453,10 @@ pub(crate) fn stop_saved_tunnel(cfg: &Config, state: &TunnelState, force: bool) 
              use `vcli tunnel detach` if you only want to disconnect)"
         );
     } else if !cfg.keep_remote_files {
-        match SSHClient::from_env(cfg.keep_remote_files) {
+        // Remote cleanup must run against the SAME config that describes the
+        // tunnel being stopped — never re-read the environment (that could
+        // combine an ambient host with this cfg's setup dir).
+        match SSHClient::from_config(cfg, cfg.keep_remote_files) {
             Ok(client) => {
                 let setup_dir = setup_dir_for_profile(cfg.profile.as_deref());
                 if let Err(e) = client.run_command(&format!("rm -rf {setup_dir}")) {
@@ -526,7 +529,18 @@ pub struct SSHClient {
     /// `SSHRunner::clone` snapshots its ControlMaster flag instead of sharing
     /// it, so handing out a second runner would silently break the fallback.
     transport: Arc<OpenSshTransport>,
+    /// The resolved config this client was built from. Held so lifecycle
+    /// operations (`stop`, remote cleanup) reuse the SAME identity instead of
+    /// re-reading the environment — combining env hosts with context dirs is
+    /// exactly the cross-identity bug target isolation must prevent.
+    config: Config,
+    /// Local forward port the client connects to. For `deployed` tunnels this
+    /// may fall back to a free port when `cfg.port` is taken locally; the
+    /// remote endpoint stays at [`Self::remote_bridge_port`].
     pub port: u16,
+    /// Fixed remote bridge port (= `cfg.port`) this tunnel forwards to.
+    /// Never incremented together with the local port.
+    pub remote_bridge_port: u16,
     pub keep_remote_files: bool,
     pub profile: Option<String>,
     /// Config identity digest (F05). Recorded into `TunnelState` so `status`
@@ -584,7 +598,9 @@ impl SSHClient {
 
         Ok(Self {
             transport: Arc::new(OpenSshTransport::new(runner)),
+            config: cfg.clone(),
             port: cfg.port,
+            remote_bridge_port: cfg.port,
             keep_remote_files,
             profile: cfg.profile.clone(),
             config_digest: Some(cfg.digest()),
@@ -603,13 +619,14 @@ impl SSHClient {
     pub fn stop(&self) -> Result<()> {
         // Delegate to the single stop path so the CLI and the programmatic API
         // never diverge. `force` is not exposed here: identity verification is
-        // mandatory for an in-process client.
-        let cfg = Config::from_env()?;
+        // mandatory for an in-process client. Uses the config this client was
+        // built from — never re-reads the environment, so cleanup cannot
+        // combine env hosts with the client's own profile.
         let state = TunnelState::load_with_profile(self.profile.as_deref())
             .ok()
             .flatten();
         match state {
-            Some(s) => stop_saved_tunnel(&cfg, &s, false),
+            Some(s) => stop_saved_tunnel(&self.config, &s, false),
             None => Err(VirtuosoError::NotFound("no running tunnel found".into())),
         }
     }
@@ -694,12 +711,20 @@ impl SSHClient {
     }
 
     fn ensure_tunnel(&mut self) -> Result<()> {
-        for port in self.port..(self.port + 10) {
-            if self.try_ssh_tunnel(port).is_ok() {
-                self.port = port;
+        // The REMOTE bridge port is fixed (= cfg.port); only the local forward
+        // port may fall back when `cfg.port` is already taken locally. The two
+        // are never incremented together, so a fallback can't change the
+        // tunnel's remote endpoint identity.
+        let remote = self.remote_bridge_port;
+        for local in self.port..(self.port + 10) {
+            if self.try_ssh_tunnel(local, remote).is_ok() {
+                self.port = local;
                 return Ok(());
             }
         }
+        // All candidate local ports failed — clean up the resources this
+        // creation deployed (the remote setup dir) rather than leaking them.
+        let _ = self.cleanup_remote();
         Err(VirtuosoError::Ssh(format!(
             "failed to establish tunnel on any port; verify SSH: `{}`",
             self.runner().verify_cmd_hint()
@@ -710,12 +735,13 @@ impl SSHClient {
     ///
     /// Used by `tunnel attach` to plug into a pre-existing daemon at a port
     /// discovered from session metadata — no port walk, since the OS-assigned
-    /// port we want to reach is known up front.
+    /// port we want to reach is known up front. Local and remote coincide here
+    /// (attach forwards to the discovered daemon port).
     pub fn open_tunnel(&mut self, port: u16) -> Result<()> {
-        self.try_ssh_tunnel(port)
+        self.try_ssh_tunnel(port, port)
     }
 
-    fn try_ssh_tunnel(&mut self, port: u16) -> Result<()> {
+    fn try_ssh_tunnel(&mut self, local_port: u16, remote_port: u16) -> Result<()> {
         let target = self.runner().remote_target();
         let mut cmd = Command::new("ssh");
         cmd.args([
@@ -730,7 +756,7 @@ impl SSHClient {
             "-f",
             "-N",
             "-L",
-            &format!("127.0.0.1:{port}:127.0.0.1:{port}"),
+            &format!("127.0.0.1:{local_port}:127.0.0.1:{remote_port}"),
         ]);
 
         // Conditionally add ControlMaster options — disabled when CM has been
@@ -775,7 +801,7 @@ impl SSHClient {
         use std::net::TcpStream;
         for _ in 0..10 {
             std::thread::sleep(std::time::Duration::from_millis(50));
-            if TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            if TcpStream::connect(format!("127.0.0.1:{local_port}")).is_ok() {
                 return Ok(());
             }
         }
@@ -805,6 +831,7 @@ impl SSHClient {
             config_digest: self.config_digest.clone(),
             mode: Some(crate::models::TUNNEL_MODE_DEPLOYED.into()),
             attached_remote_port: None,
+            remote_bridge_port: Some(self.remote_bridge_port),
             attached_session_id: None,
         };
         // Write under the *config's* profile namespace. Using `save()` (which
@@ -983,6 +1010,7 @@ mod tests {
             config_digest: None,
             mode: None,
             attached_remote_port: None,
+            remote_bridge_port: None,
             attached_session_id: None,
         }
     }

--- a/src/transport/tunnel.rs
+++ b/src/transport/tunnel.rs
@@ -529,6 +529,9 @@ pub struct SSHClient {
     pub port: u16,
     pub keep_remote_files: bool,
     pub profile: Option<String>,
+    /// Config identity digest (F05). Recorded into `TunnelState` so `status`
+    /// can detect drift between the resolved config and the running tunnel.
+    pub config_digest: Option<String>,
     /// Set by [`Self::warm`] once the tunnel child is spawned; carried so
     /// liveness probes and state saving agree on the target. `stop` prefers
     /// the recorded `TunnelState` pid as the sole target (see
@@ -584,6 +587,7 @@ impl SSHClient {
             port: cfg.port,
             keep_remote_files,
             profile: cfg.profile.clone(),
+            config_digest: Some(cfg.digest()),
             tunnel_pid: None,
         })
     }
@@ -611,7 +615,13 @@ impl SSHClient {
     }
 
     pub fn saved_port(&self) -> Option<u16> {
-        TunnelState::load().ok().flatten().map(|s| s.port)
+        // Read under the *config's* profile namespace, never the ambient
+        // `VB_PROFILE` — the caller (VirtuosoClient) resolves the tunnel for a
+        // specific target and must not pick up another target's state file.
+        TunnelState::load_with_profile(self.profile.as_deref())
+            .ok()
+            .flatten()
+            .map(|s| s.port)
     }
 
     /// OS PID of the SSH tunnel process spawned by [`Self::open_tunnel`]
@@ -792,12 +802,18 @@ impl SSHClient {
             local_forward: None,
             start_time_unix_ms: None,
             health: None,
-            config_digest: None,
+            config_digest: self.config_digest.clone(),
             mode: Some(crate::models::TUNNEL_MODE_DEPLOYED.into()),
             attached_remote_port: None,
             attached_session_id: None,
         };
-        state.save().map_err(|e| VirtuosoError::Ssh(e.to_string()))
+        // Write under the *config's* profile namespace. Using `save()` (which
+        // keys on ambient `VB_PROFILE`) here would record the tunnel under the
+        // wrong namespace whenever the process env profile differs from the
+        // resolved config (e.g. `--target prod` with `VB_PROFILE=test`).
+        state
+            .save_with_profile(self.profile.as_deref())
+            .map_err(|e| VirtuosoError::Ssh(e.to_string()))
     }
 
     fn deploy_daemon_3(&self, setup_dir: &str) -> Result<String> {

--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -5475,6 +5475,7 @@ mod tests {
             remote_host: None,
             remote_user: None,
             port: 5555,
+            port_explicit: false,
             jump_host: None,
             jump_user: None,
             ssh_port: None,

--- a/src/vtui.rs
+++ b/src/vtui.rs
@@ -21,6 +21,7 @@ mod skill_finder;
 mod spectre;
 mod streaming;
 mod sys;
+mod target;
 #[cfg(test)]
 mod test_env;
 mod transaction;

--- a/src/vtui.rs
+++ b/src/vtui.rs
@@ -7,6 +7,7 @@ mod client;
 mod command_log;
 mod commands;
 mod config;
+mod context;
 mod error;
 mod exit_codes;
 mod history;

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -110,3 +110,56 @@ fn test_config_timeout_env_override_wins() {
     let config = virtuoso_cli::config::Config::from_env_with_profile(None).unwrap();
     assert_eq!(config.timeout, 45);
 }
+
+/// `port_explicit` is part of the connection identity: the same numeric port
+/// with "allow auto-discovery" vs "force port matching" must produce
+/// different digests, otherwise `tunnel status` drift detection / daemon Hello
+/// cannot tell the two constraints apart. Pure struct literal — no env, no
+/// filesystem — so it needs no serialisation or guards.
+#[test]
+fn test_config_digest_distinguishes_port_explicit() {
+    let base = virtuoso_cli::config::Config {
+        profile: None,
+        remote_host: Some("compute-eda-42".into()),
+        remote_user: None,
+        port: 30001,
+        port_explicit: false,
+        jump_host: None,
+        jump_user: None,
+        ssh_port: None,
+        ssh_key: None,
+        ssh_config: None,
+        ssh_backend: None,
+        disable_control_master: false,
+        timeout: 30,
+        read_timeout: 120,
+        keep_remote_files: false,
+        spectre_cmd: "spectre".into(),
+        spectre_args: vec![],
+        spectre_max_workers: 8,
+        ssh_max_sessions: 10,
+        ssh_max_bulk_sessions: 2,
+        ssh_reconnect_max_attempts: 8,
+        ssh_reconnect_max_delay: 30,
+        ssh_keepalive_interval: 30,
+        ssh_keepalive_failures: 3,
+        transport_shutdown_grace: 5,
+        cadence_cshrc: None,
+        spectre_bin: None,
+        roles: Default::default(),
+        transport_daemon_socket: None,
+        transport_daemon_token: None,
+    };
+    let mut explicit = base.clone();
+    explicit.port_explicit = true;
+    assert_ne!(
+        base.digest(),
+        explicit.digest(),
+        "port constraint mode must change the config digest"
+    );
+    assert_eq!(
+        base.digest(),
+        base.clone().digest(),
+        "digest must be deterministic for identical configs"
+    );
+}

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,9 +1,10 @@
 //! Integration tests for Config parsing.
 //!
-//! Note: These tests are limited because Config::from_env_with_profile() loads
-//! .env files from the current directory upward, which can override test values.
-//! Only tests that don't depend on specific env values or are resilient to .env
-//! overrides are included here.
+//! `Config::from_env_with_profile()` loads `.env` files from the current
+//! directory upward (so `~/.env` can leak values here). dotenvy's `load()`
+//! never overrides an already-set env var, so tests that must see a specific
+//! value set that var explicitly in the process first — that shields them from
+//! `.env`. Env-mutating tests are marked `#[serial]`.
 
 /// Test that Config can be created without panicking.
 #[test]
@@ -24,10 +25,29 @@ fn test_config_spectre_max_workers_default() {
     assert_eq!(config.spectre_max_workers, 8);
 }
 
-/// Test that timeout has a reasonable default.
+/// The default timeout is 30, verified in isolation.
+///
+/// An empty `VB_TIMEOUT` is set first so the upward `.env` (which on this
+/// machine sets `VB_TIMEOUT=60`) cannot leak in: dotenvy skips already-set
+/// vars, and `Config` treats an empty value as absent, so the parser falls
+/// back to the built-in default.
+#[serial_test::serial]
 #[test]
-fn test_config_timeout_default() {
+fn test_config_timeout_default_isolated() {
+    std::env::set_var("VB_TIMEOUT", "");
     let config = virtuoso_cli::config::Config::from_env_with_profile(None).unwrap();
-    // Should be 30 by default
+    std::env::remove_var("VB_TIMEOUT");
     assert_eq!(config.timeout, 30);
+}
+
+/// An explicit ambient `VB_TIMEOUT` overrides both the default and any `.env`
+/// value. `45` differs from the default (30) and from this machine's `~/.env`
+/// (60), so a pass proves the process env var wins.
+#[serial_test::serial]
+#[test]
+fn test_config_timeout_env_override_wins() {
+    std::env::set_var("VB_TIMEOUT", "45");
+    let config = virtuoso_cli::config::Config::from_env_with_profile(None).unwrap();
+    std::env::remove_var("VB_TIMEOUT");
+    assert_eq!(config.timeout, 45);
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,14 +1,69 @@
 //! Integration tests for Config parsing.
 //!
-//! `Config::from_env_with_profile()` loads `.env` files from the current
-//! directory upward (so `~/.env` can leak values here). dotenvy's `load()`
-//! never overrides an already-set env var, so tests that must see a specific
-//! value set that var explicitly in the process first — that shields them from
-//! `.env`. Env-mutating tests are marked `#[serial]`.
+//! Isolation contract: `Config::from_env_with_profile()` loads `.env` files
+//! from the current directory upward (so `~/.env` can leak values here), and
+//! honours the ambient `VB_TARGET` bridge (which can jump the parse into a
+//! target file). dotenvy's `load()` never overrides an already-set env var, so
+//! a test that must see a specific value sets that var explicitly first, using
+//! [`EnvGuard`] so the original value is restored on drop (RAII).
+//!
+//! Every env-reading/writing test is `#[serial]`: mutating the process
+//! environment is shared state, so these tests must never run concurrently
+//! with each other, and each must shield every variable its assertion depends
+//! on — the mechanism is shared, not per-test.
+
+/// RAII guard that sets an env var for the scope of the test and restores the
+/// original value (or removes it if it was absent) on drop.
+struct EnvGuard {
+    restored: Vec<(String, Option<std::ffi::OsString>)>,
+}
+
+impl EnvGuard {
+    /// Set `key` to `val` for the rest of this scope, restoring the prior
+    /// value on drop.
+    fn set(key: &str, val: &str) -> Self {
+        let old = std::env::var_os(key);
+        std::env::set_var(key, val);
+        Self {
+            restored: vec![(key.to_string(), old)],
+        }
+    }
+
+    /// Shield a variable from both the process env and any upward `.env`:
+    /// dotenvy skips already-set vars, and `Config` treats an empty value as
+    /// absent, so the parser falls back to its default. The original value is
+    /// restored on drop.
+    fn shield(key: &str) -> Self {
+        Self::set(key, "")
+    }
+
+    fn restore(&mut self) {
+        for (key, val) in self.restored.drain(..) {
+            match val {
+                Some(v) => std::env::set_var(&key, v),
+                None => std::env::remove_var(&key),
+            }
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        self.restore();
+    }
+}
+
+/// Shield `VB_TARGET` so `from_env_with_profile` cannot jump the parse into a
+/// target file. Used by every test below.
+fn shield_target() -> EnvGuard {
+    EnvGuard::shield("VB_TARGET")
+}
 
 /// Test that Config can be created without panicking.
+#[serial_test::serial]
 #[test]
 fn test_config_from_env_works() {
+    let _g = shield_target();
     let result = virtuoso_cli::config::Config::from_env_with_profile(None);
     assert!(result.is_ok());
     // Should have a valid config with reasonable defaults
@@ -17,9 +72,13 @@ fn test_config_from_env_works() {
     assert!(config.timeout > 0);
 }
 
-/// Test that spectre_max_workers has a reasonable default.
+/// Test that spectre_max_workers has a reasonable default, verified in
+/// isolation (no ambient `VB_SPECTRE_MAX_WORKERS`, no target file).
+#[serial_test::serial]
 #[test]
 fn test_config_spectre_max_workers_default() {
+    let _g = EnvGuard::shield("VB_SPECTRE_MAX_WORKERS");
+    let _t = shield_target();
     let config = virtuoso_cli::config::Config::from_env_with_profile(None).unwrap();
     // Should be 8 by default
     assert_eq!(config.spectre_max_workers, 8);
@@ -27,27 +86,27 @@ fn test_config_spectre_max_workers_default() {
 
 /// The default timeout is 30, verified in isolation.
 ///
-/// An empty `VB_TIMEOUT` is set first so the upward `.env` (which on this
-/// machine sets `VB_TIMEOUT=60`) cannot leak in: dotenvy skips already-set
-/// vars, and `Config` treats an empty value as absent, so the parser falls
-/// back to the built-in default.
+/// Both `VB_TIMEOUT` and `VB_TARGET` are shielded: the upward `.env` (which on
+/// this machine sets `VB_TIMEOUT=60`) and any ambient target selection cannot
+/// leak in. The prior values are restored on drop.
 #[serial_test::serial]
 #[test]
 fn test_config_timeout_default_isolated() {
-    std::env::set_var("VB_TIMEOUT", "");
+    let _g = EnvGuard::shield("VB_TIMEOUT");
+    let _t = shield_target();
     let config = virtuoso_cli::config::Config::from_env_with_profile(None).unwrap();
-    std::env::remove_var("VB_TIMEOUT");
     assert_eq!(config.timeout, 30);
 }
 
 /// An explicit ambient `VB_TIMEOUT` overrides both the default and any `.env`
 /// value. `45` differs from the default (30) and from this machine's `~/.env`
-/// (60), so a pass proves the process env var wins.
+/// (60), so a pass proves the process env var wins. `VB_TARGET` is shielded so
+/// the parse stays on the legacy path.
 #[serial_test::serial]
 #[test]
 fn test_config_timeout_env_override_wins() {
-    std::env::set_var("VB_TIMEOUT", "45");
+    let _g = EnvGuard::set("VB_TIMEOUT", "45");
+    let _t = shield_target();
     let config = virtuoso_cli::config::Config::from_env_with_profile(None).unwrap();
-    std::env::remove_var("VB_TIMEOUT");
     assert_eq!(config.timeout, 45);
 }


### PR DESCRIPTION
feat(target/context): target 选择与 CommandContext 单解析 + tunnel 所有权/转发验证修复

> 本 PR 原与 gui-debug 工作流（PR #74）被误堆在同一本地分支上。两者文件完全不重叠（gui-debug 仅 `.claude/skills/virtuoso-gui-debug/**`，本 PR 仅 Rust 源码 + docs），故拆分为独立分支提交，内容与原分支逐字节一致（`git diff` 指纹校验通过）。

## 变更内容（5 commits）

1. `feat(target)` target 选择基础 + 编译基线修复
2. `feat(context)` CommandContext 单解析 + tunnel 命令族迁移
3. `fix(target)` tunnel state profile 隔离 + 统一所有权判定（review P1/P2）
4. `fix(target)` tunnel attach 端口作用域 + local/remote 端口拆分（review round 2）
5. `fix(tunnel)` 转发持有者证明 / ControlMaster 禁用 / restart 语义 / digest 补字段

## 核心修复

### 默认端口不是端点约束
`Config` 新增 `port_explicit`（`from_env` 按 `VB_PORT` 是否存在、`from_target` 按 `target.port.is_some()`）。
daemon 绑定 OS 分配端口，因此默认（hash-of-USER）端口**不得**过滤发现结果：
`attach_candidate_sessions` 与 `validate_endpoint_ownership` 的端口臂仅在显式约束时生效，host 恒校验。

### 转发成功判定不再被已有服务骗过
- `try_ssh_tunnel` 加 `-v` 与 `-o LogLevel=DEBUG1`：OpenSSH 绑定成功后在 stderr 打印
  `Local forwarding listening on 127.0.0.1 port <n>`。`LogLevel` 必须显式钉死——`-v` 只在用户
  配置未设 `LogLevel` 时才抬高等级，`~/.ssh/config` 里的 `LogLevel QUIET` 会静默掉该标记。
  `ExitOnForwardFailure=yes` 保证绑定失败即退出。
- `wait_for_forward` 三条件判定：ssh 自身 stderr 绑定标记 + 端口可达 + 子进程存活；
  后台线程持续排空 stderr 防管道填满；失败一律 kill+reap。
- 绑定标记按端口全串匹配且要求后接非数字（`port 30001` 不满足 `port 3000`）。
- 轮询预算参数化：生产 `TUNNEL_FORWARD_BUDGET = 20s`（失败由子进程退出立即返回），单测短预算。

### 记录的 PID 必须是转发持有者
`try_ssh_tunnel` 去掉 `-f` 并显式 `-o ControlMaster=no`，即使 `~/.ssh/config` 开启复用也不影响：
spawn 出的 ssh 即唯一转发持有者，其 PID 与 `start_identity` 可验证（stop 据此精确信令）。
无 `-f` 时 ssh 在本 CLI 退出后继续转发，隧道生命周期不变。

### restart 不再「断开后不恢复」
抽 `discover_live_session()`（attach 同款发现 + 归属校验，无副作用）供 attach/restart 共用。
restart 先在停止前预检：无存活 daemon 可重连即拒绝（不先断开）；通过后 stop → attach，
JSON 返回 `{stop, attach}`。

### digest 补身份约束
`Config::digest()` 哈希输入补入 `port_explicit`：同一端口数值下「允许自动发现」与
「强制端口匹配」必须产生不同摘要，否则 status 漂移检测与 daemon Hello 无法区分两种约束。

## 测试
新增 13 例：`wait_for_forward` 6（子进程立即退出→拒绝 / 延迟失败→拒绝 / 绑定标记→通过 /
他端口标记→拒绝 / 端口数字边界→拒绝 / 超时→回收子进程）、`attach_candidates` 3、
`context` 默认端口非约束 3、`config digest` 1。

## 门禁
`cargo fmt --check` ✅ / `clippy --all-targets -D warnings` ✅ / `cargo test` 全绿 ✅ /
`cargo build --features daemon` ✅
