### PR TITLE
fix(bridge): support shared daemon installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,58 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.4] - 2026-09-06
+
+Multi-user / shared deployment. Previously each user on a shared host had to
+place (or symlink) their own `virtuoso-daemon` under `~/.cargo/bin` because the
+SKILL bridge resolved the daemon path in two conflicting places — a top-level
+resolver that claimed to honor `RB_DAEMON_PATH`, and `_RBAutoStart()` which ran
+last and unconditionally hardcoded `$HOME/.cargo/bin/virtuoso-daemon`, silently
+overriding everything (including `RB_DAEMON_PATH`). This release unifies daemon
+resolution behind a single ordered search chain, lets one shared install serve
+every user with zero per-user setup, and revives the deploy-time `__DAEMON_PATH__`
+injection point so `vcli tunnel start` and the new `install.sh` bake in an exact
+path for any prefix. 100% backward compatible: existing `~/.cargo/bin` installs
+still work (lowest priority in the chain).
+
+### Added
+
+- **`install.sh`** — one-shot shared/multi-user installer. Flags: `--prefix DIR`,
+  `--system` (default prefix `/opt/virtuoso-cli`), `--user` (default prefix
+  `~/.local`), `--no-build`. Builds `vcli`/`vtui`/`virtuoso-daemon` (unless
+  `--no-build`), installs binaries to `$PREFIX/bin`, installs `ramic_bridge.il`
+  to `$PREFIX/share/virtuoso-cli/` with `__DAEMON_PATH__` substituted to the
+  real daemon path, and prints the `.cdsinit` `load(...)` line to add.
+- **`RBResolveDaemonPath()`** (`resources/ramic_bridge.il`) — single ordered
+  daemon-path resolver used by both the top-level load-time resolution and
+  `_RBAutoStart()`.
+
+### Fixed
+
+- **Daemon path hardcode in `_RBAutoStart()`** (`resources/ramic_bridge.il`):
+  replaced `RBDPath = $HOME/.cargo/bin/virtuoso-daemon` with
+  `RBDPath = RBResolveDaemonPath()`. This is the change that makes
+  `RB_DAEMON_PATH` and shared installs actually take effect — the hardcode ran
+  last on every `load()` and clobbered them.
+- **Dead `__DAEMON_PATH__` injection point** (`resources/ramic_bridge.il`,
+  `src/transport/tunnel.rs`): `deploy_il_script()` has always done
+  `.replace("__DAEMON_PATH__", daemon_path)`, but the committed `.il` no longer
+  contained the token, so `vcli tunnel start` uploaded the daemon to its setup
+  dir yet the bridge still resolved `~/.cargo/bin`. The token is reintroduced in
+  the resolver's first (highest-priority) candidate; when the `.il` is loaded
+  directly the literal token is not a real file (`isFile()` nil) and is skipped.
+
+### Changed
+
+- **Daemon resolution is now an ordered search chain** (first existing wins):
+  (1) `__DAEMON_PATH__` deploy-time substitution, (2) `RB_DAEMON_PATH` env
+  override, (3) shared installs `/opt/virtuoso-cli/bin`, `/usr/local/bin`,
+  (4) per-user `~/.local/bin`, `~/.cargo/bin` (backward compatibility).
+- **`; RB_VERSION:`** in `resources/ramic_bridge.il` bumped to `1.3.4` to match
+  `Cargo.toml`; the daemon reports `1.3.4` after rebuild (version-skew triad).
+- **README** — documented multi-user / shared install, the search chain, and
+  corrected the stale "resets path to ~/.cargo/bin" description of `_RBAutoStart`.
+
 ## [1.3.3] - 2026-09-04
 
 IPC deadline hardening. The 1.3.2 release introduced dynamic socket timeouts,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtuoso-cli"
-version = "1.3.3"
+version = "1.3.4"
 edition = "2021"
 description = "CLI tool to control Cadence Virtuoso from anywhere, locally or remotely"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,41 @@ All binaries (`vcli`, `vtui`) are installed to `~/.cargo/bin/`.
 
 > **Note**: Do not name the binary `virtuoso` — it conflicts with Cadence's `virtuoso` executable.
 
+### Multi-user / shared install
+
+On a shared host you do **not** need to install the daemon under every user's
+`~/.cargo/bin`. Install once to a shared prefix and every user picks it up
+automatically:
+
+```bash
+# Build + install vcli/vtui/virtuoso-daemon + ramic_bridge.il to a shared prefix
+./install.sh --system                 # prefix /opt/virtuoso-cli (needs write perm)
+./install.sh --prefix /opt/eda/vcli   # or any prefix you choose
+./install.sh --user                   # per-user prefix ~/.local
+./install.sh --system --no-build      # skip cargo build, install existing target/release
+```
+
+`install.sh` installs the binaries to `$PREFIX/bin`, writes
+`ramic_bridge.il` to `$PREFIX/share/virtuoso-cli/` with the daemon path baked in,
+and prints the one line each user adds to their `~/.cdsinit` (or a site-wide
+`.cdsinit`):
+
+```skill
+load("$PREFIX/share/virtuoso-cli/ramic_bridge.il")
+```
+
+**How the daemon is resolved.** On `load`, the bridge finds `virtuoso-daemon`
+via an ordered search chain (first existing wins):
+
+1. `__DAEMON_PATH__` — a path baked in at deploy time by `install.sh` or
+   `vcli tunnel start` (arbitrary prefix, zero per-user config);
+2. `$RB_DAEMON_PATH` — explicit environment override;
+3. shared installs: `/opt/virtuoso-cli/bin`, `/usr/local/bin`;
+4. per-user installs: `~/.local/bin`, `~/.cargo/bin` (backward compatibility).
+
+A plain `cargo install` under `~/.cargo/bin` therefore keeps working with no
+changes; a shared `install.sh` deployment serves all users with none.
+
 ### System Dependencies
 
 The X11 GUI automation features (`vcli window action-x11`, `action-x11-batch`, `list-windows-x11`) and the `virtuoso-gui-debug` skill's local executor require the following tools on the Virtuoso host (the machine running the X11 display):
@@ -96,7 +131,7 @@ The X11 GUI automation features (`vcli window action-x11`, `action-x11-batch`, `
 load("/path/to/virtuoso-cli/resources/ramic_bridge.il")
 ```
 
-`load` automatically stops any existing daemon, resets the path to `~/.cargo/bin/virtuoso-daemon`, starts fresh, and prints the Ready banner — works for first load and for reloading after updates.
+`load` automatically stops any existing daemon, re-resolves the daemon binary via an ordered search chain (see [Multi-user / shared install](#multi-user--shared-install)), starts fresh, and prints the Ready banner — works for first load and for reloading after updates.
 
 Output:
 ```
@@ -300,7 +335,7 @@ vcli [--profile P] [--session S] [--format json|table]
 | `VB_PROFILE` | — | Config profile (reads `VB_*_<profile>` vars) |
 | `VB_CLIENT_ID` | `$VB_PROFILE` or `gethostname()` | Per-client remote scratch scoping (e.g. `vcli-A`, `vcli-B`); isolates `/tmp/virtuoso_bridge/<client>/` paths between concurrent operators |
 | `VCLI_CAPABILITY` | `user` | Set to `admin` to unlock `vcli skill broadcast` and raw SKILL exec |
-| `RB_DAEMON_PATH` | auto-detected | Override daemon binary path |
+| `RB_DAEMON_PATH` | search chain | Override daemon binary path (checked before shared/per-user install locations; see [Multi-user / shared install](#multi-user--shared-install)) |
 
 ### SSH Remote Connection Setup
 
@@ -581,6 +616,39 @@ cargo install --path .
 
 > **注意**：不要将 CLI 命名为 `virtuoso`，与 Cadence Virtuoso 二进制名冲突。
 
+### 多用户 / 共享安装
+
+在共享主机上**无需**为每个用户都往其 `~/.cargo/bin` 装一份 daemon。装一次到共享
+前缀，所有用户即自动命中：
+
+```bash
+# 构建 + 安装 vcli/vtui/virtuoso-daemon + ramic_bridge.il 到共享前缀
+./install.sh --system                 # 前缀 /opt/virtuoso-cli（需写权限）
+./install.sh --prefix /opt/eda/vcli   # 或任意自选前缀
+./install.sh --user                   # 按用户前缀 ~/.local
+./install.sh --system --no-build      # 跳过 cargo build，装已有 target/release
+```
+
+`install.sh` 把二进制装到 `$PREFIX/bin`，把 `ramic_bridge.il` 写到
+`$PREFIX/share/virtuoso-cli/` 并将 daemon 路径烤入其中，最后打印每个用户加到
+`~/.cdsinit`（或站点级 `.cdsinit`）的一行：
+
+```skill
+load("$PREFIX/share/virtuoso-cli/ramic_bridge.il")
+```
+
+**daemon 如何解析**：`load` 时 bridge 通过有序搜索链找 `virtuoso-daemon`（第一个
+存在者胜出）：
+
+1. `__DAEMON_PATH__` —— `install.sh` 或 `vcli tunnel start` 在部署时烤入的路径
+   （任意前缀，零按用户配置）；
+2. `$RB_DAEMON_PATH` —— 显式环境变量覆盖；
+3. 共享安装：`/opt/virtuoso-cli/bin`、`/usr/local/bin`；
+4. 按用户安装：`~/.local/bin`、`~/.cargo/bin`（向后兼容）。
+
+因此普通 `cargo install` 装到 `~/.cargo/bin` 仍照旧可用；而共享 `install.sh`
+部署可零配置服务所有用户。
+
 ### 系统依赖
 
 X11 GUI 自动化功能（`vcli window action-x11`、`action-x11-batch`、`list-windows-x11`）以及 `virtuoso-gui-debug` 技能的 local 执行器，需要在 Virtuoso 所在主机（运行 X11 display 的机器）上安装以下工具：
@@ -605,7 +673,7 @@ X11 GUI 自动化功能（`vcli window action-x11`、`action-x11-batch`、`list-
 load("/path/to/virtuoso-cli/resources/ramic_bridge.il")
 ```
 
-`load` 会自动停止旧 daemon、将路径重置为 `~/.cargo/bin/virtuoso-daemon` 并重启，首次加载和更新后重载均适用。
+`load` 会自动停止旧 daemon、按有序搜索链重新解析 daemon 二进制（见[多用户 / 共享安装](#多用户--共享安装)）并重启，首次加载和更新后重载均适用。
 
 输出：
 ```
@@ -763,7 +831,7 @@ vcli [--profile P] [--session S] [--format json|table]
 | `VB_PROFILE` | - | 配置 profile（读取 `VB_*_<profile>` 变量） |
 | `VB_CLIENT_ID` | `$VB_PROFILE` 或 `gethostname()` | 每客户端远端 scratch 隔离标识（如 `vcli-A`、`vcli-B`）；隔离 `/tmp/virtuoso_bridge/<client>/` 路径，避免多操作员并发冲突 |
 | `VCLI_CAPABILITY` | `user` | 设为 `admin` 解锁 `vcli skill broadcast` 与原始 SKILL 执行权限 |
-| `RB_DAEMON_PATH` | 自动检测 | 覆盖 daemon 二进制路径 |
+| `RB_DAEMON_PATH` | 搜索链 | 覆盖 daemon 二进制路径（优先于共享/按用户安装位置检查；见[多用户 / 共享安装](#多用户--共享安装)） |
 
 ### SSH 远程连接配置
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# install.sh — shared / multi-user installer for virtuoso-cli.
+#
+# Installs vcli, vtui and virtuoso-daemon to a shared or per-user prefix, and
+# installs ramic_bridge.il with the daemon path baked in (the __DAEMON_PATH__
+# token is substituted to $PREFIX/bin/virtuoso-daemon). One shared install then
+# serves every user on the host with zero per-user setup — each user only adds a
+# single load(...) line to their ~/.cdsinit.
+#
+# Usage:
+#   ./install.sh [--system | --user | --prefix DIR] [--no-build]
+#
+#   --system        install to /opt/virtuoso-cli   (shared; needs write perm)
+#   --user          install to ~/.local            (per-user; default)
+#   --prefix DIR    install to DIR                 (any prefix)
+#   --no-build      skip `cargo build`; install the existing target/release bins
+#   -h, --help      show this help
+#
+# Layout created:
+#   $PREFIX/bin/{vcli,vtui,virtuoso-daemon}
+#   $PREFIX/share/virtuoso-cli/ramic_bridge.il   (with __DAEMON_PATH__ resolved)
+
+set -euo pipefail
+
+# --- locate the repo (this script lives at the crate root) ------------------
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+IL_SRC="$SCRIPT_DIR/resources/ramic_bridge.il"
+TARGET_DIR="$SCRIPT_DIR/target/release"
+BINS=(vcli vtui virtuoso-daemon)
+
+# --- defaults ---------------------------------------------------------------
+PREFIX=""
+MODE=""          # system | user | prefix
+NO_BUILD=0
+
+die() { printf 'install.sh: error: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+    sed -n '3,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+# --- parse args -------------------------------------------------------------
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --system)      MODE="system" ;;
+        --user)        MODE="user" ;;
+        --prefix)      shift; [ $# -gt 0 ] || die "--prefix requires a directory argument"; PREFIX="$1"; MODE="prefix" ;;
+        --prefix=*)    PREFIX="${1#--prefix=}"; MODE="prefix" ;;
+        --no-build)    NO_BUILD=1 ;;
+        -h|--help)     usage 0 ;;
+        *)             die "unknown argument: $1 (try --help)" ;;
+    esac
+    shift
+done
+
+# --- resolve prefix ---------------------------------------------------------
+case "$MODE" in
+    system)  PREFIX="/opt/virtuoso-cli" ;;
+    user|"") PREFIX="${PREFIX:-$HOME/.local}"; MODE="${MODE:-user}" ;;
+    prefix)  [ -n "$PREFIX" ] || die "empty --prefix" ;;
+esac
+# Expand a leading ~ if the caller quoted it.
+case "$PREFIX" in "~"/*) PREFIX="$HOME/${PREFIX#~/}" ;; esac
+
+BIN_DIR="$PREFIX/bin"
+SHARE_DIR="$PREFIX/share/virtuoso-cli"
+DAEMON_BIN="$BIN_DIR/virtuoso-daemon"
+IL_DEST="$SHARE_DIR/ramic_bridge.il"
+
+printf '==> virtuoso-cli install\n'
+printf '    prefix : %s\n' "$PREFIX"
+printf '    binaries -> %s\n' "$BIN_DIR"
+printf '    bridge   -> %s\n' "$IL_DEST"
+
+# --- build ------------------------------------------------------------------
+if [ "$NO_BUILD" -eq 0 ]; then
+    command -v cargo >/dev/null 2>&1 || die "cargo not found in PATH; install Rust or pass --no-build"
+    printf '==> cargo build --release --features daemon\n'
+    ( cd "$SCRIPT_DIR" && cargo build --release --features daemon )
+else
+    printf '==> --no-build: using existing %s\n' "$TARGET_DIR"
+fi
+
+# --- verify build artifacts -------------------------------------------------
+for b in "${BINS[@]}"; do
+    [ -x "$TARGET_DIR/$b" ] || die "missing built binary: $TARGET_DIR/$b (run without --no-build, or build with: cargo build --release --features daemon)"
+done
+[ -f "$IL_SRC" ] || die "missing bridge script: $IL_SRC"
+grep -q '__DAEMON_PATH__' "$IL_SRC" || printf 'install.sh: warning: __DAEMON_PATH__ token not found in %s; the bridge will fall back to its search chain\n' "$IL_SRC" >&2
+
+# --- install ----------------------------------------------------------------
+mkdir -p "$BIN_DIR" "$SHARE_DIR" || die "cannot create $BIN_DIR / $SHARE_DIR (need sudo for a system prefix?)"
+
+printf '==> installing binaries\n'
+for b in "${BINS[@]}"; do
+    install -m 0755 "$TARGET_DIR/$b" "$BIN_DIR/$b"
+    printf '    %s\n' "$BIN_DIR/$b"
+done
+
+printf '==> installing bridge (baking __DAEMON_PATH__ = %s)\n' "$DAEMON_BIN"
+# '|' delimiter: filesystem paths do not contain it.
+sed "s|__DAEMON_PATH__|$DAEMON_BIN|g" "$IL_SRC" > "$IL_DEST"
+chmod 0644 "$IL_DEST"
+printf '    %s\n' "$IL_DEST"
+
+# --- done -------------------------------------------------------------------
+cat <<EOF
+
+==> Done. Each user adds this line to their ~/.cdsinit (or a site-wide .cdsinit):
+
+    load("$IL_DEST")
+
+If $BIN_DIR is not on PATH, add it (e.g. in ~/.bashrc):
+
+    export PATH="$BIN_DIR:\$PATH"
+
+Verify:
+
+    "$BIN_DIR/vcli" --version        # expect 1.3.4
+    "$DAEMON_BIN" --version          # expect 1.3.4
+EOF

--- a/resources/ramic_bridge.il
+++ b/resources/ramic_bridge.il
@@ -1,4 +1,4 @@
-; RB_VERSION: 1.3.3
+; RB_VERSION: 1.3.4
 ; Stamp must match the vcli binary's `Cargo.toml` version. `vcli session show`
 ; compares this with the daemon's `RBDVersion` global (parsed from the
 ; `VERSION:x.x.x` line the daemon prints to stderr on startup). If you see a
@@ -10,28 +10,51 @@
 ;RBD = RB Daemon
 ;RBM = RB Monitor
 
-; Daemon binary path: resolved at load-time, never hardcoded.
-; sh() returns t/nil (not stdout), so `which` cannot be used for path detection.
-; Priority: (1) RB_DAEMON_PATH env var, (2) ~/.cargo/bin/virtuoso-daemon.
-; Re-resolved on reload if previously empty or the file no longer exists.
-when(!boundp('RBDPath) || RBDPath == "" || RBDPath == nil || !isFile(RBDPath)
-    RBDPath = let((fromEnv cargoPath)
-        fromEnv = getShellEnvVar("RB_DAEMON_PATH")
-        if(fromEnv then
-            fromEnv
-        else
-            cargoPath = strcat(getShellEnvVar("HOME") "/.cargo/bin/virtuoso-daemon")
-            if(isFile(cargoPath) then
-                cargoPath
-            else
-                ""
-            )
+; Daemon binary path: resolved at load-time via an ordered search chain,
+; never hardcoded. sh() returns t/nil (not stdout), so `which` cannot be used
+; for path detection — candidates are probed with isFile() instead.
+; Search order (first existing wins):
+;   (1) __DAEMON_PATH__  deploy-time substitution (vcli tunnel start / install.sh)
+;   (2) RB_DAEMON_PATH   explicit env override
+;   (3) /opt/virtuoso-cli/bin, /usr/local/bin   shared multi-user installs
+;   (4) ~/.local/bin, ~/.cargo/bin              per-user installs (back-compat)
+; Multi-user friendly: one shared install (e.g. /opt/virtuoso-cli/bin) is found
+; by every user with zero per-user setup. Re-resolved on reload if previously
+; empty or the file no longer exists.
+procedure(RBResolveDaemonPath()
+    let((home deployPath envPath cand candidates result)
+        home = getShellEnvVar("HOME")
+        unless(home home = "")
+        result = ""
+        ; (1) Deploy-time substitution. `vcli tunnel start` and install.sh replace
+        ;     the __DAEMON_PATH__ token with an absolute path. When the .il is loaded
+        ;     directly the token stays literal, so isFile() is nil and it is skipped
+        ;     — no split-literal trick needed since it is never a real file.
+        deployPath = "__DAEMON_PATH__"
+        when(result == "" && isFile(deployPath) result = deployPath)
+        ; (2) Explicit env override (now actually honored — _RBAutoStart no longer
+        ;     clobbers it).
+        envPath = getShellEnvVar("RB_DAEMON_PATH")
+        when(result == "" && envPath && isFile(envPath) result = envPath)
+        ; (3)+(4) Shared installs first (multi-user), then per-user (compat).
+        candidates = list(
+            "/opt/virtuoso-cli/bin/virtuoso-daemon"
+            "/usr/local/bin/virtuoso-daemon"
+            strcat(home "/.local/bin/virtuoso-daemon")
+            strcat(home "/.cargo/bin/virtuoso-daemon")
         )
+        foreach(cand candidates
+            when(result == "" && isFile(cand) result = cand))
+        result
     )
 )
+when(!boundp('RBDPath) || RBDPath == "" || RBDPath == nil || !isFile(RBDPath)
+    RBDPath = RBResolveDaemonPath()
+)
 when(RBDPath == "" || RBDPath == nil
-    printf("[RAMIC Bridge] ERROR: virtuoso-daemon not found.\n")
-    printf("[RAMIC Bridge] Set RB_DAEMON_PATH or run: cargo install --path <repo> --bin virtuoso-daemon --features daemon\n")
+    printf("[RAMIC Bridge] ERROR: virtuoso-daemon not found in any known location.\n")
+    printf("[RAMIC Bridge] Searched (in order): deploy path, $RB_DAEMON_PATH, /opt/virtuoso-cli/bin, /usr/local/bin, ~/.local/bin, ~/.cargo/bin\n")
+    printf("[RAMIC Bridge] Fix: run install.sh (shared/multi-user), set RB_DAEMON_PATH, or cargo install --path <repo> --bin virtuoso-daemon --features daemon\n")
 )
 ; RBPython is no longer used (daemon is a standalone binary), kept for compatibility
 unless(boundp('RBPython) RBPython = "")
@@ -489,13 +512,14 @@ RBLoadedPackages = nil
 ; )
 
 ; ============================================================================
-; Auto-start on every load(): stop stale daemon, reset path, start fresh.
+; Auto-start on every load(): stop stale daemon, re-resolve daemon path via the
+; search chain (RBResolveDaemonPath), start fresh.
 ; Wrapped in a procedure so no intermediate return values echo in CIW.
 ; ============================================================================
 
 procedure(_RBAutoStart()
     RBPython = ""
-    RBDPath = strcat(getShellEnvVar("HOME") "/.cargo/bin/virtuoso-daemon")
+    RBDPath = RBResolveDaemonPath()
     ; No manual package loading needed — Virtuoso handles context loading internally.
     ; Manual loadi() calls caused "too many arguments" parser errors in IC25.
     when(boundp('RBIpc) && ipcIsAliveProcess(RBIpc) RBStop())


### PR DESCRIPTION
# 支持多用户 / 共享 daemon 部署

中文说明在前，英文原文保留在后。

## 问题

在共享主机上，原实现要求每个用户都在自己的 `~/.cargo/bin` 下放置或链接一份
`virtuoso-daemon`。根因是 SKILL bridge 在两处解析 daemon 路径，而且结果相互冲突：

- 顶层解析逻辑尝试读取 `RB_DAEMON_PATH`。
- 每次 `load()` 最后执行的 `_RBAutoStart()` 又无条件将路径设为
  `$HOME/.cargo/bin/virtuoso-daemon`，覆盖前面的解析结果，包括环境变量设置。

此外，`src/transport/tunnel.rs` 中的 `deploy_il_script()` 一直保留着
`.replace("__DAEMON_PATH__", daemon_path)`，但原有 `ramic_bridge.il` 已不包含该占位符。
因此 `vcli tunnel start` 虽然将 daemon 上传到了部署目录，bridge 却仍然查找
`~/.cargo/bin`，部署时的路径注入没有实际生效。

## 改动

新增统一的 `RBResolveDaemonPath()`，按以下顺序查找，返回第一个存在的候选文件：

1. `__DAEMON_PATH__`：由 `install.sh` 或 `vcli tunnel start` 在部署时替换的路径。
2. `$RB_DAEMON_PATH`：显式设置的环境变量路径。
3. 共享位置：`/opt/virtuoso-cli/bin`、`/usr/local/bin`。
4. 用户位置：`~/.local/bin`、`~/.cargo/bin`，保留原安装方式作为兜底。

顶层加载逻辑与 `_RBAutoStart()` 都调用该函数，消除后者对路径的硬编码覆盖，并恢复
`__DAEMON_PATH__` 的部署注入功能。

新增 `install.sh`，支持 `--system`、`--user`、`--prefix DIR` 和 `--no-build`：
安装二进制，并将实际 daemon 路径写入安装后的 `ramic_bridge.il`。

最初的实现基于 1.3.3，包含升级到 1.3.4 的提交。但上游随后已经发布 1.3.4，因此提交
PR 前整合了上游 `main` 的 `609e060`，保留上游版本标记，将本功能放到 `Unreleased`
条目中，最终发布版本由维护者决定。

## 行为与兼容性

- 当没有更高优先级的候选路径时，原有 `cargo install` 安装到 `~/.cargo/bin` 的方式
  仍可使用。如果机器上同时存在多份安装，新顺序会优先选择部署时写入的路径，其次是
  环境变量，然后是共享安装位置；这一优先级变化是有意的。
- 客户端连接方式保持原样：每个用户通过自己的 SSH 隧道连接 `127.0.0.1`；会话仍保存
  在 `~/.cache/virtuoso_bridge`；`/tmp` 临时空间及基于 `$USER` 的端口规则不变。
- 共享安装完成后，无需每个用户分别安装 daemon；每个用户只需在 `~/.cdsinit` 中添加
  一行 `load(...)`。

## 验证

- 整合后的贡献提交 `e83f40e` 已在本地通过默认和 daemon 测试、`cargo fmt --check`、
  默认严格 clippy、daemon/all-targets 严格 clippy，以及 `native-ssh` 严格 clippy。
  GitHub 云端 CI 结果以本 PR 的检查状态为准。
- 原始四提交分支也独立复跑通过了默认和 daemon 的 `cargo test`、默认及
  daemon/all-targets 的 `clippy -D warnings`、格式检查和
  `cargo build --release --features daemon`。
- 已确认 `.il` 包含 `__DAEMON_PATH__`，且 `_RBAutoStart()` 中不再含 `.cargo/bin`
  硬编码；Cargo 版本、bridge 版本标记和构建出的 daemon 版本均为 1.3.4。
- `bash -n install.sh` 通过；使用 `--no-build --prefix <临时绝对路径>` 做了真实安装，
  安装后的 bridge 不再含未替换的占位符，daemon 输出版本 1.3.4。该检查覆盖常规绝对
  路径部署，没有声称覆盖所有可能的路径写法。
- 实现阶段的交接记录报告：在 Cadence Virtuoso IC23 上，将 daemon 部署到
  `~/.local/bin` 后已完成实机验证，包括 bridge 无版本偏差启动、ping、版本查询、
  library 列表和 cell 路径查询。本次提交 PR 的 agent 没有重新连接或重启共享主机上
  的 Virtuoso。

## 给维护者的说明

- `deploy_il_script()` 中的路径替换本来就存在；本 PR 恢复的是 `.il` 中对应的
  占位符，没有修改该处 Rust 逻辑。
- `RBStopAll()` 行为保持原样，不属于本次改动范围。
- 原始四个提交完整保留，没有 squash；另加一个整合提交，保留上游新增的 README
  内容和发布历史。仓库清理建议未混入本 PR。
- 欢迎对 daemon 搜索优先级和发布安排提出意见，我们愿意按项目约定调整这项改动。

---

# Enable multi-user / shared daemon deployment

## Problem

On a shared host, every user had to place (or symlink) their own
`virtuoso-daemon` under `~/.cargo/bin`, because the SKILL bridge resolved the
daemon path in **two conflicting places**:

- a top-level resolver that claimed to honor `RB_DAEMON_PATH`, and
- `_RBAutoStart()`, which runs last on every `load()` and **unconditionally
  hardcoded** `$HOME/.cargo/bin/virtuoso-daemon`, silently overriding the
  resolver (and `RB_DAEMON_PATH`).

Separately, `deploy_il_script()` in `src/transport/tunnel.rs` has always done
`.replace("__DAEMON_PATH__", daemon_path)`, but the committed `ramic_bridge.il`
no longer contained the token — so `vcli tunnel start` uploaded the daemon to
its setup dir yet the bridge still resolved `~/.cargo/bin`. Dead injection point.

## Change

Unify daemon resolution behind a single ordered search chain and revive the
deploy-time injection point:

- **`RBResolveDaemonPath()`** (new) resolves `virtuoso-daemon`, first-existing-wins:
  1. `__DAEMON_PATH__` — deploy-time substitution (`install.sh` / `vcli tunnel start`)
  2. `$RB_DAEMON_PATH` — explicit env override (now actually honored)
  3. shared: `/opt/virtuoso-cli/bin`, `/usr/local/bin`
  4. per-user: `~/.local/bin`, `~/.cargo/bin` (backward compatibility)
- **`_RBAutoStart()`** now calls `RBResolveDaemonPath()` instead of hardcoding
  `~/.cargo/bin` — the one change that makes overrides and shared installs work.
- The top-level load-time resolver uses the same function.
- **`install.sh`** (new): one-shot shared/multi-user installer
  (`--system` / `--user` / `--prefix DIR` / `--no-build`); installs the binaries
  and writes `ramic_bridge.il` with `__DAEMON_PATH__` baked to the real path.
- The original implementation was based on 1.3.3 and included a 1.3.4 bump.
  Upstream has since released 1.3.4. The contribution integrates upstream main
  `609e060`, preserves its version stamps, and records this feature under
  `Unreleased` rather than claiming another 1.3.4 release.

## Behavior / compatibility

- A plain `cargo install` under `~/.cargo/bin` remains a fallback when no
  higher-priority candidate exists. If several installations coexist, the new
  search order intentionally prefers the baked path, env override, then shared
  locations. No client-side changes: connection still
  `127.0.0.1` via each user's own SSH tunnel; sessions still under
  `~/.cache/virtuoso_bridge`; `/tmp` scratch and `$USER`-derived port unchanged.
- A single shared `install.sh` deployment now serves all users with **zero**
  per-user setup — each user only adds one `load(...)` line to `~/.cdsinit`.

## Testing

- On the integrated contribution head `e83f40e`: default and daemon tests,
  `cargo fmt --check`, strict default clippy, strict daemon/all-targets clippy,
  and strict `native-ssh` clippy all passed locally. GitHub-hosted CI results
  are reported separately on this PR.
- Independently rerun on the original four-commit head: default and daemon
  `cargo test`, strict default and daemon/all-targets `clippy -D warnings`,
  `cargo fmt --check`, and `cargo build --release --features daemon` all passed.
- Grep asserts: `__DAEMON_PATH__` present in `.il`; no `.cargo/bin` literal left
  in `_RBAutoStart`.
- Version triad all report `1.3.4`.
- `bash -n install.sh` and a real `--no-build --prefix <temporary-absolute-path>`
  install passed; the installed bridge contained no unresolved placeholder and
  the installed daemon reported 1.3.4. This validates the ordinary absolute-prefix
  deployment path, not every possible path spelling.
- The implementing agent's handoff reports successful live verification on
  Cadence Virtuoso IC23 with a daemon installed under `~/.local/bin`: bridge
  startup without version skew, ping, version, library listing, and cell-path
  lookup. The contribution agent did not reconnect to or restart the shared
  Virtuoso host.

## Notes for reviewer

- The `.replace("__DAEMON_PATH__", …)` in `deploy_il_script()` was already
  present; this PR only makes the token exist again in the shipped `.il`, so no
  Rust logic changed there.
- `RBStopAll()` semantics are unchanged and remain out of scope.
- The original four commits are preserved without squashing; one integration
  merge retains upstream's README additions and release history. Repository
  hygiene cleanup is deliberately excluded from this contribution.
- Feedback on the daemon search priority and preferred release placement is
  welcome. Happy to adjust this focused change to the project's conventions.
