### PR TITLE
feat(transport): wire the endpoint object pool and scheduler into the daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target/
+/target-lld2/
 Cargo.lock
 .env
 *.swp

--- a/src/commands/transport_daemon.rs
+++ b/src/commands/transport_daemon.rs
@@ -6,12 +6,12 @@
 //!
 //! It is spawned by `vcli` itself, never typed by a user. This module wires
 //! the `__transport-daemon` hidden subcommand to the production IPC server in
-//! [`crate::transport::ipc::server`], with a [`NativeTransport`] backend when
-//! the `native-ssh` feature is enabled. Step 6 of the design (channel pool,
-//! reconnect, lifecycle) is a later increment; this iteration dispatches each
-//! request onto a fresh transport. That is sufficient for the first stable
-//! cut because the contract is observable and the shared suite already
-//! exercises the IPC surface.
+//! [`crate::transport::ipc::server`]. Step 6 of the design (channel pool,
+//! reconnect, lifecycle) is consumed here: the daemon owns an
+//! [`EndpointPool`], resolves one [`EndpointKey`] from the shared config, and
+//! serves every request through [`server::run_with_pool`] — so all four roles
+//! that name the same host share one transport, and a connection-level
+//! failure evicts the pooled connection and reconnects on the next request.
 //!
 //! [Step 2]: docs/superpowers/specs/2026-08-29-native-remote-transport-design.md
 //!
@@ -29,6 +29,10 @@ use std::sync::Arc;
 use crate::transport::contract::RemoteTransport;
 #[cfg(all(unix, feature = "native-ssh"))]
 use crate::transport::contract::TransportError;
+#[cfg(all(unix, feature = "native-ssh"))]
+use crate::transport::pool::{EndpointKey, EndpointPool};
+#[cfg(all(unix, feature = "native-ssh"))]
+use crate::transport::scheduler::SchedulerLimits;
 
 /// The "this build has no daemon" answer.
 ///
@@ -66,8 +70,22 @@ pub fn run_with(ipc_endpoint: &str, token_path: &str, daemon_nonce: &str) -> Res
     // NOT `open_transport`. The latter routes native traffic over IPC to a
     // running daemon — using it here would deadlock on first startup (the
     // daemon can't connect to itself before it starts listening).
-    let transport: Arc<dyn RemoteTransport> =
-        open_transport_for_daemon(&config).map_err(transport_to_virtuoso)?;
+    //
+    // Configuration errors surface here, before the socket is bound, with the
+    // same fail-loudly semantics as the pre-pool daemon: a backend that cannot
+    // be constructed (missing `VB_REMOTE_HOST`, missing `VB_SSH_KEY`, invalid
+    // capacity) must fail startup, not the first request. The pooled daemon
+    // then re-runs this factory only when a connection needs (re)building.
+    open_transport_for_daemon(&config).map_err(transport_to_virtuoso)?;
+
+    // One endpoint key for the whole daemon: the daemon serves the config's
+    // single remote host, so all roles collapse onto one pooled connection.
+    let host = config.remote_host.as_deref().unwrap_or("");
+    let key = EndpointKey::from_config(&config, host);
+    let limits = SchedulerLimits::from_config(&config)?;
+    let pool = Arc::new(EndpointPool::new());
+    let factory: Arc<dyn Fn() -> Result<Arc<dyn RemoteTransport>, TransportError> + Send + Sync> =
+        Arc::new(move || open_transport_for_daemon(&config));
 
     let token = std::fs::read_to_string(Path::new(token_path)).map_err(|e| {
         VirtuosoError::Io(std::io::Error::other(format!(
@@ -82,7 +100,17 @@ pub fn run_with(ipc_endpoint: &str, token_path: &str, daemon_nonce: &str) -> Res
     let shutdown = ShutdownCoordinator::from_config(&config);
 
     let socket = Path::new(ipc_endpoint);
-    server::run(socket, transport, &token, daemon_nonce, shutdown).map_err(|e| {
+    server::run_with_pool(
+        socket,
+        pool,
+        key,
+        limits,
+        factory,
+        &token,
+        daemon_nonce,
+        shutdown,
+    )
+    .map_err(|e| {
         VirtuosoError::Io(std::io::Error::other(format!(
             "transport daemon exited unexpectedly: {e}"
         )))

--- a/src/commands/transport_daemon.rs
+++ b/src/commands/transport_daemon.rs
@@ -83,9 +83,13 @@ pub fn run_with(ipc_endpoint: &str, token_path: &str, daemon_nonce: &str) -> Res
     let host = config.remote_host.as_deref().unwrap_or("");
     let key = EndpointKey::from_config(&config, host);
     let limits = SchedulerLimits::from_config(&config)?;
+    // `shutdown` borrows `config` and must be computed before the `factory`
+    // closure below moves `config` into itself.
+    let shutdown = ShutdownCoordinator::from_config(&config);
     let pool = Arc::new(EndpointPool::new());
-    let factory: Arc<dyn Fn() -> Result<Arc<dyn RemoteTransport>, TransportError> + Send + Sync> =
-        Arc::new(move || open_transport_for_daemon(&config));
+    let factory: Arc<
+        dyn Fn() -> std::result::Result<Arc<dyn RemoteTransport>, TransportError> + Send + Sync,
+    > = Arc::new(move || open_transport_for_daemon(&config));
 
     let token = std::fs::read_to_string(Path::new(token_path)).map_err(|e| {
         VirtuosoError::Io(std::io::Error::other(format!(
@@ -97,8 +101,6 @@ pub fn run_with(ipc_endpoint: &str, token_path: &str, daemon_nonce: &str) -> Res
     let token = token.trim().to_string();
 
     // Grace period for `Operation::Shutdown` (VB_TRANSPORT_SHUTDOWN_GRACE).
-    let shutdown = ShutdownCoordinator::from_config(&config);
-
     let socket = Path::new(ipc_endpoint);
     server::run_with_pool(
         socket,

--- a/src/transport/identity.rs
+++ b/src/transport/identity.rs
@@ -286,6 +286,7 @@ mod imp {
     /// `GetModuleFileNameExW` because it needs only
     /// `PROCESS_QUERY_LIMITED_INFORMATION` — no `psapi` link, and it succeeds
     /// on processes we do not own.
+    #[allow(clippy::upper_case_acronyms)]
     mod ffi {
         use std::os::raw::{c_int, c_void};
 

--- a/src/transport/ipc/messages.rs
+++ b/src/transport/ipc/messages.rs
@@ -272,6 +272,26 @@ impl IpcError {
             IpcError::UnsupportedBackend => "unsupported_backend",
         }
     }
+
+    /// Whether the error means the connection itself is gone or unreachable —
+    /// as opposed to a command that ran and failed, a transfer that was
+    /// interrupted, or a timeout on healthy plumbing.
+    ///
+    /// The pooled daemon uses this to decide whether the pooled connection
+    /// may still serve the next request: a connection-level failure poisons
+    /// the pooled transport, so the pool drops it and the next request
+    /// reconnects. Everything else (remote exit codes, execution timeouts,
+    /// integrity mismatches, ...) is business state and must NOT evict a
+    /// healthy connection.
+    pub fn is_connection_level(&self) -> bool {
+        matches!(
+            self,
+            IpcError::ConnectionFailed(_)
+                | IpcError::JumpFailed(_)
+                | IpcError::ProxyFailed(_)
+                | IpcError::DaemonUnavailable
+        )
+    }
 }
 
 impl From<TransportError> for IpcError {
@@ -577,5 +597,56 @@ mod tests {
     fn deadline_ms_fits_u64() {
         let d = Deadline::from_now(Duration::from_secs(30));
         let _ms: u64 = (d.0.elapsed().as_millis() as u64) + 30_000;
+    }
+
+    // The pool drops a pooled connection exactly on connection-level errors,
+    // and keeps it for everything else. This classifies the full vocabulary.
+    #[test]
+    fn connection_level_classification() {
+        assert!(IpcError::ConnectionFailed("tcp reset".into()).is_connection_level());
+        assert!(IpcError::JumpFailed("bastion down".into()).is_connection_level());
+        assert!(IpcError::ProxyFailed("proxy refused".into()).is_connection_level());
+        assert!(IpcError::DaemonUnavailable.is_connection_level());
+
+        // Business failures must never evict a healthy pooled connection.
+        assert!(!IpcError::RemoteExit {
+            status: 2,
+            stderr: "ls: no such file".into()
+        }
+        .is_connection_level());
+        assert!(!IpcError::ExecutionTimeout {
+            request: "r".into(),
+            after_secs: 30,
+            remote_terminated: false
+        }
+        .is_connection_level());
+        assert!(!IpcError::QueueTimeout {
+            request: "r".into(),
+            after_secs: 30
+        }
+        .is_connection_level());
+        assert!(!IpcError::AuthenticationFailed("bad key".into()).is_connection_level());
+        assert!(!IpcError::HostKeyUnknown {
+            host: "h".into(),
+            fingerprint: "f".into()
+        }
+        .is_connection_level());
+        assert!(!IpcError::IntegrityMismatch {
+            expected: "a".into(),
+            actual: "b".into()
+        }
+        .is_connection_level());
+        assert!(!IpcError::TransferInterrupted {
+            request: "r".into(),
+            reason: "x".into()
+        }
+        .is_connection_level());
+        assert!(!IpcError::Cancelled {
+            request: "r".into()
+        }
+        .is_connection_level());
+        assert!(!IpcError::Configuration("bad env".into()).is_connection_level());
+        assert!(!IpcError::LocalIo("disk full".into()).is_connection_level());
+        assert!(!IpcError::RemoteIo("remote disk full".into()).is_connection_level());
     }
 }

--- a/src/transport/ipc/server.rs
+++ b/src/transport/ipc/server.rs
@@ -825,7 +825,7 @@ pub fn run(
     shutdown: ShutdownCoordinator,
 ) -> Result<(), String> {
     let (listener, state) = bind_listener(socket_path, shutdown)?;
-    accept_loop(
+    let result = accept_loop(
         listener,
         &state,
         auth_token,
@@ -841,7 +841,12 @@ pub fn run(
                 .map_err(|e| format!("failed to spawn ipc worker: {e}"))?;
             Ok(())
         },
-    )
+    );
+    // Best-effort unlink on every exit path: a stale socket from a crashed
+    // previous run is cleaned up by `bind_listener`, but a clean exit must
+    // also leave no artefact behind so the next daemon can rebind.
+    let _ = std::fs::remove_file(socket_path);
+    result
 }
 
 /// [`run`] over an [`EndpointPool`]: every connection is served by
@@ -859,7 +864,7 @@ pub fn run_with_pool(
     shutdown: ShutdownCoordinator,
 ) -> Result<(), String> {
     let (listener, state) = bind_listener(socket_path, shutdown)?;
-    accept_loop(
+    let result = accept_loop(
         listener,
         &state,
         auth_token,
@@ -879,7 +884,10 @@ pub fn run_with_pool(
                 .map_err(|e| format!("failed to spawn ipc worker: {e}"))?;
             Ok(())
         },
-    )
+    );
+    // Best-effort unlink on every exit path — see `run` for the rationale.
+    let _ = std::fs::remove_file(socket_path);
+    result
 }
 
 // ────────────────────────────────── tests ──────────────────────────────────
@@ -1288,6 +1296,102 @@ mod tests {
 
         // Clean exit also unlinks the socket.
         assert!(!socket.exists(), "socket must be unlinked on clean exit");
+    }
+
+    /// The pooled daemon must unlink its socket on the same shutdown path
+    /// that `run` exercises. Without this, a clean daemon restart leaves a
+    /// stale socket behind and the next bind fails.
+    #[cfg(feature = "native-ssh")]
+    #[test]
+    fn run_with_pool_unlinks_its_socket_on_clean_shutdown() {
+        use crate::transport::pool::{EndpointKey, EndpointPool};
+        use crate::transport::scheduler::SchedulerLimits;
+
+        let socket =
+            std::env::temp_dir().join(format!("vcli-shut-pool-{}.sock", uuid::Uuid::new_v4()));
+        let _ = std::fs::remove_file(&socket);
+        let coordinator =
+            crate::transport::lifecycle::ShutdownCoordinator::new(Duration::from_millis(200));
+
+        let pool = Arc::new(EndpointPool::new());
+        // The key here only has to be a stable identity for the duration of
+        // this test; no SSH is exercised. Construct it directly rather than
+        // through `from_config` so this test module does not depend on a
+        // full `Config`.
+        let key = EndpointKey {
+            profile: None,
+            host: "eda-1".to_string(),
+            port: 22,
+            user: None,
+            jump_route: Vec::new(),
+            socks_route: None,
+            identities: Vec::new(),
+            host_key_aliases: Vec::new(),
+            security_options: vec!["backend=openssh".to_string()],
+        };
+        let limits = SchedulerLimits::default_limits();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let factory: Arc<
+            dyn Fn() -> Result<Arc<dyn RemoteTransport>, TransportError> + Send + Sync,
+        > = {
+            let calls = Arc::clone(&calls);
+            Arc::new(move || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(Arc::new(FakeTransport::ok()) as Arc<dyn RemoteTransport>)
+            })
+        };
+
+        let path = socket.clone();
+        let runner = thread::spawn(move || {
+            run_with_pool(
+                &path,
+                pool,
+                key,
+                limits,
+                factory,
+                "secret-token",
+                "n",
+                coordinator,
+            )
+        });
+
+        // Wait for the daemon to come up before issuing the shutdown.
+        let mut client = None;
+        for _ in 0..100 {
+            if let Ok(c) = NativeTransportClient::connect(&socket, "p", "secret-token") {
+                client = Some(c);
+                break;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        let client = client.expect("daemon did not come up");
+        client.request_shutdown().expect("shutdown ack");
+
+        let started = std::time::Instant::now();
+        loop {
+            if runner.is_finished() {
+                break;
+            }
+            assert!(
+                started.elapsed() < Duration::from_secs(5),
+                "run_with_pool did not terminate after a shutdown ack"
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+        let result = runner.join().expect("run_with_pool thread panicked");
+        assert!(
+            result.is_ok(),
+            "run_with_pool returned an error: {result:?}"
+        );
+        assert!(
+            !socket.exists(),
+            "pooled daemon must unlink its socket on clean exit"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "factory should run exactly once for this connection"
+        );
     }
 
     /// Before shutdown fires, the daemon keeps serving; after the ack, the

--- a/src/transport/ipc/server.rs
+++ b/src/transport/ipc/server.rs
@@ -1381,6 +1381,13 @@ mod tests {
             thread::sleep(Duration::from_millis(20));
         }
         let client = client.expect("daemon did not come up");
+        // Serve one real command first. `Hello` is answered before the
+        // dispatch loop and `Shutdown` breaks out of it before the transport
+        // is resolved, so without this the factory would never run and the
+        // test would not exercise the pooled path at all.
+        client
+            .run_command(&CommandRequest::untimed("echo hi"))
+            .expect("command must succeed on a healthy pooled transport");
         client.request_shutdown().expect("shutdown ack");
 
         let started = std::time::Instant::now();

--- a/src/transport/ipc/server.rs
+++ b/src/transport/ipc/server.rs
@@ -684,6 +684,7 @@ pub fn dispatch(
 
 /// Bind a Unix domain socket at `socket_path`, set its mode to `0600`, and
 /// build the shared shutdown bookkeeping.
+#[cfg(feature = "native-ssh")]
 fn bind_listener(
     socket_path: &Path,
     shutdown: ShutdownCoordinator,
@@ -728,6 +729,7 @@ fn bind_listener(
 /// the auth token, the server nonce, and the shared shutdown state, and must
 /// return an error only when the worker thread cannot be created (which is
 /// fatal for the daemon, matching the pre-pool behaviour).
+#[cfg(feature = "native-ssh")]
 fn accept_loop<F>(
     listener: UnixListener,
     state: &Arc<ShutdownState>,
@@ -820,7 +822,8 @@ pub fn run(
             thread::Builder::new()
                 .name("vcli-ipc".to_string())
                 .spawn(move || serve_one_with_shutdown(s, transport, &token, &nonce, Some(&state)))
-                .map_err(|e| format!("failed to spawn ipc worker: {e}"))
+                .map_err(|e| format!("failed to spawn ipc worker: {e}"))?;
+            Ok(())
         },
     )
 }
@@ -851,6 +854,7 @@ pub fn run_with_pool(
             let token = t.to_string();
             let nonce = n.to_string();
             let state = Arc::clone(st);
+            let factory = Arc::clone(&factory);
             thread::Builder::new()
                 .name("vcli-ipc".to_string())
                 .spawn(move || {
@@ -859,13 +863,14 @@ pub fn run_with_pool(
                         pool,
                         key,
                         limits,
-                        Arc::clone(&factory),
+                        factory,
                         &token,
                         &nonce,
                         Some(&state),
                     )
                 })
-                .map_err(|e| format!("failed to spawn ipc worker: {e}"))
+                .map_err(|e| format!("failed to spawn ipc worker: {e}"))?;
+            Ok(())
         },
     )
 }
@@ -882,6 +887,9 @@ mod tests {
     use crate::transport::ipc::messages::IpcError;
     use std::os::unix::net::UnixListener;
     use std::time::Duration;
+
+    #[cfg(feature = "native-ssh")]
+    use crate::transport::contract::TransportError;
 
     /// Build a `NativeTransportClient` connected to `socket`. The matching
     /// daemon is launched in a background thread before this returns so the
@@ -1176,7 +1184,10 @@ mod tests {
         let err = client
             .run_command(&CommandRequest::untimed("echo hi"))
             .expect_err("connection-level failure");
-        assert!(matches!(err, IpcError::ConnectionFailed(_)), "got {err:?}");
+        assert!(
+            matches!(err, TransportError::ConnectionFailed(_)),
+            "got {err:?}"
+        );
         drop(client);
         let _ = std::fs::remove_file(&socket);
         let _ = listener;

--- a/src/transport/ipc/server.rs
+++ b/src/transport/ipc/server.rs
@@ -7,6 +7,13 @@
 //! forever (or until the listener is dropped by `SIGTERM`/`SIGINT` handling
 //! wired in the daemon subcommand).
 //!
+//! The pooled variant ([`serve_one_pooled`], [`run_with_pool`]) is what the
+//! daemon actually runs with. Instead of a fixed transport it holds an
+//! [`EndpointPool`]: each request resolves to an [`EndpointKey`], the pool
+//! returns the one pooled connection for that key (creating it at most once),
+//! and a connection-level failure evicts the pooled transport so the next
+//! request reconnects rather than serving from a poisoned connection.
+//!
 //! `Challenge` is the Tier-1 liveness probe described in the design's
 //! "Stop and crash recovery" section: the parent CLI connects over IPC, asks
 //! the daemon for its nonce, and compares the answer against the value it
@@ -26,12 +33,14 @@ use std::os::unix::net::UnixStream;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
-// Used only by `run`, which is feature-gated; the test module imports its own.
+// Used only by `run`/`run_with_pool`, which are feature-gated; the test module
+// imports its own.
 #[cfg(feature = "native-ssh")]
 use std::time::Duration;
 
-// `run` is the only consumer of these, and it is feature-gated, so the imports
-// must carry the same gate — ungated, a feature-off build reports them unused.
+// `run`/`run_with_pool` are the only consumers of these, and they are
+// feature-gated, so the imports must carry the same gate — ungated, a
+// feature-off build reports them unused.
 #[cfg(feature = "native-ssh")]
 use std::os::unix::net::UnixListener;
 #[cfg(feature = "native-ssh")]
@@ -40,8 +49,8 @@ use std::path::Path;
 use serde_json::Value;
 
 use crate::transport::contract::{
-    CommandRequest, CommandResult, DownloadDirRequest, DownloadFileRequest, RemoteTransport,
-    RequestId, UploadFileRequest, UploadTextRequest,
+    CommandRequest, CommandResult, Deadline, DownloadDirRequest, DownloadFileRequest,
+    RemoteTransport, RequestId, TransportError, UploadFileRequest, UploadTextRequest,
 };
 use crate::transport::ipc::framing::{
     FrameError, FrameReader, FrameWriter, PROTOCOL_MAJOR, PROTOCOL_MINOR,
@@ -49,8 +58,17 @@ use crate::transport::ipc::framing::{
 use crate::transport::ipc::messages::{
     Hello, HelloAck, IpcError, Operation, RequestEnvelope, ResponseEnvelope, ResponseResult,
 };
-// `ShutdownCoordinator` is consumed only by the feature-gated `run` and
-// `ShutdownState::coordinator`; gate the import to match.
+// `EndpointKey`/`EndpointPool`/`Priority`/`SchedulerLimits` are consumed only
+// by the pooled entry points (`serve_one_pooled`/`run_with_pool`), which are
+// feature-gated — gate the imports to match so a feature-off build does not
+// report them unused. `Permit` is used by the ungated [`TransportAccess`].
+#[cfg(feature = "native-ssh")]
+use crate::transport::pool::{EndpointKey, EndpointPool};
+use crate::transport::scheduler::Permit;
+#[cfg(feature = "native-ssh")]
+use crate::transport::scheduler::{Priority, SchedulerLimits};
+// `ShutdownCoordinator` is consumed only by the feature-gated `run`/`run_with_pool`
+// and `ShutdownState::coordinator`; gate the import to match.
 use crate::transport::lifecycle::CancellationToken;
 #[cfg(feature = "native-ssh")]
 use crate::transport::lifecycle::ShutdownCoordinator;
@@ -302,6 +320,53 @@ pub fn serve_one_with_shutdown(
     server_nonce: &str,
     shutdown: Option<&Arc<ShutdownState>>,
 ) {
+    let mut transport_for = |_: &RequestEnvelope| {
+        Ok(TransportAccess {
+            transport: Arc::clone(&transport),
+            _permit: None,
+        })
+    };
+    let mut on_connection_error = |_: &ResponseResult| {};
+    serve_loop(
+        stream,
+        &mut transport_for,
+        &mut on_connection_error,
+        auth_token,
+        server_nonce,
+        shutdown,
+    )
+}
+
+/// The transport a single request dispatches on, plus the scheduler permit
+/// held for its duration.
+///
+/// The permit is what makes the endpoint scheduler count the request: it is
+/// acquired right before `dispatch` and dropped when the [`TransportAccess`]
+/// goes out of scope at the end of the loop iteration. The fixed-transport
+/// (non-pooled) path carries `None` because it has no endpoint scheduler.
+struct TransportAccess {
+    transport: Arc<dyn RemoteTransport>,
+    _permit: Option<Permit>,
+}
+
+/// The dispatch loop shared by every serve entry point.
+///
+/// `transport_for` resolves the current request to a transport (the pooled
+/// path re-resolves the endpoint key on every request; the fixed path returns
+/// the same transport). `on_connection_error` is invoked after a dispatch
+/// whose result is a connection-level failure, so a pooled daemon can evict
+/// the poisoned connection and reconnect on the next request.
+fn serve_loop<F, G>(
+    stream: UnixStream,
+    transport_for: &mut F,
+    on_connection_error: &mut G,
+    auth_token: &str,
+    server_nonce: &str,
+    shutdown: Option<&Arc<ShutdownState>>,
+) where
+    F: FnMut(&RequestEnvelope) -> Result<TransportAccess, TransportError>,
+    G: FnMut(&ResponseResult),
+{
     let read_stream = match stream.try_clone() {
         Ok(s) => s,
         Err(_) => return,
@@ -379,10 +444,31 @@ pub fn serve_one_with_shutdown(
             }
             break;
         }
+        // Resolve the transport for this request. A failure here is a daemon
+        // problem (no connection can be created), reported as an error frame
+        // — it does not tear down the accept loop.
+        let access = match transport_for(&env) {
+            Ok(access) => access,
+            Err(e) => {
+                let resp = ResponseEnvelope {
+                    request_id: env.request_id.clone(),
+                    result: ResponseResult::Err(IpcError::from(e)),
+                };
+                let body = serde_json::to_vec(&resp).unwrap_or_default();
+                let _ = writer.write_frame(&body);
+                continue;
+            }
+        };
         let resp = ResponseEnvelope {
             request_id: env.request_id.clone(),
-            result: dispatch(&*transport, &env, server_nonce),
+            result: dispatch(&*access.transport, &env, server_nonce),
         };
+        // A connection-level failure means the pooled transport is no longer
+        // trustworthy. Evict it so the next request reconnects instead of
+        // serving from a dead connection.
+        if matches!(&resp.result, ResponseResult::Err(e) if e.is_connection_level()) {
+            on_connection_error(&resp.result);
+        }
         let body = match serde_json::to_vec(&resp) {
             Ok(b) => b,
             Err(e) => {
@@ -402,6 +488,65 @@ pub fn serve_one_with_shutdown(
     }
 }
 
+/// [`serve_one_with_shutdown`] over an [`EndpointPool`]: every request
+/// resolves to the same [`EndpointKey`], the pool returns the one pooled
+/// connection for it (creating it at most once), the endpoint's scheduler
+/// meters the request, and a connection-level failure evicts the connection
+/// so the next request reconnects.
+#[cfg(feature = "native-ssh")]
+pub fn serve_one_pooled(
+    stream: UnixStream,
+    pool: Arc<EndpointPool>,
+    key: EndpointKey,
+    limits: SchedulerLimits,
+    factory: Arc<dyn Fn() -> Result<Arc<dyn RemoteTransport>, TransportError> + Send + Sync>,
+    auth_token: &str,
+    server_nonce: &str,
+    shutdown: Option<&Arc<ShutdownState>>,
+) {
+    let pool_for_errors = Arc::clone(&pool);
+    let key_for_errors = key.clone();
+    let mut transport_for = move |env: &RequestEnvelope| {
+        let endpoint = pool.get_or_create(key.clone(), limits, || factory())?;
+        // Meter every transport-touching operation on the endpoint scheduler.
+        // Challenge/Shutdown/Hello never touch the wire, so they must not
+        // consume a session.
+        let permit = if matches!(
+            &env.operation,
+            Operation::RunCommand
+                | Operation::TestConnection
+                | Operation::UploadFile
+                | Operation::UploadText
+                | Operation::DownloadFile
+                | Operation::DownloadDir
+        ) {
+            let deadline = Deadline::from_unix_ms(env.deadline_unix_ms);
+            Some(endpoint.acquire(
+                Priority::Normal,
+                &RequestId(env.request_id.clone()),
+                deadline,
+            )?)
+        } else {
+            None
+        };
+        Ok(TransportAccess {
+            transport: Arc::clone(&endpoint.transport),
+            _permit: permit,
+        })
+    };
+    let mut on_connection_error = move |_r: &ResponseResult| {
+        pool_for_errors.remove(&key_for_errors);
+    };
+    serve_loop(
+        stream,
+        &mut transport_for,
+        &mut on_connection_error,
+        auth_token,
+        server_nonce,
+        shutdown,
+    )
+}
+
 /// Dispatch a single request onto a transport. Pure function: no I/O,
 /// no thread safety, no daemon state beyond the nonce passed in for the
 /// Challenge answer.
@@ -410,7 +555,6 @@ pub fn dispatch(
     env: &RequestEnvelope,
     server_nonce: &str,
 ) -> ResponseResult {
-    use crate::transport::contract::Deadline;
     let deadline = Deadline::from_unix_ms(env.deadline_unix_ms);
     let request_id = env.request_id.clone();
     match &env.operation {
@@ -539,6 +683,101 @@ pub fn dispatch(
 }
 
 /// Bind a Unix domain socket at `socket_path`, set its mode to `0600`, and
+/// build the shared shutdown bookkeeping.
+fn bind_listener(
+    socket_path: &Path,
+    shutdown: ShutdownCoordinator,
+) -> Result<(UnixListener, Arc<ShutdownState>), String> {
+    if let Some(parent) = socket_path.parent() {
+        if !parent.as_os_str().is_empty() && !parent.exists() {
+            return Err(format!(
+                "ipc socket parent directory does not exist: {}",
+                parent.display()
+            ));
+        }
+    }
+    // Best-effort cleanup of any stale socket left by a crashed previous run.
+    let _ = std::fs::remove_file(socket_path);
+    let listener = UnixListener::bind(socket_path)
+        .map_err(|e| format!("failed to bind ipc socket {}: {e}", socket_path.display()))?;
+    // Mode 0600: only the current user can connect. The owner is set by the
+    // bind above; chmod enforces the bits regardless of umask.
+    use std::os::unix::fs::PermissionsExt;
+    let perms = std::fs::Permissions::from_mode(0o600);
+    if let Err(e) = std::fs::set_permissions(socket_path, perms) {
+        return Err(format!(
+            "failed to chmod 0600 ipc socket {}: {e}",
+            socket_path.display()
+        ));
+    }
+    let state = Arc::new(ShutdownState::new(shutdown));
+    // Non-blocking accept + poll: the token is fired from a worker thread (a
+    // connection that sent `Shutdown`), and a blocking accept would never see
+    // it until the next connection arrived.
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| format!("failed to set non-blocking accept: {e}"))?;
+    Ok((listener, state))
+}
+
+/// Accept loop shared by [`run`] and [`run_with_pool`]: non-blocking accept,
+/// one OS thread per connection (named `vcli-ipc`), and the design's
+/// three-phase shutdown once the token fires.
+///
+/// `spawn` builds the per-connection worker; it receives the accepted stream,
+/// the auth token, the server nonce, and the shared shutdown state, and must
+/// return an error only when the worker thread cannot be created (which is
+/// fatal for the daemon, matching the pre-pool behaviour).
+fn accept_loop<F>(
+    listener: UnixListener,
+    state: &Arc<ShutdownState>,
+    auth_token: &str,
+    server_nonce: &str,
+    spawn: F,
+) -> Result<(), String>
+where
+    F: Fn(UnixStream, &str, &str, &Arc<ShutdownState>) -> Result<(), String>,
+{
+    let token = auth_token.to_string();
+    let nonce = server_nonce.to_string();
+    loop {
+        if state.token.is_cancelled() {
+            break;
+        }
+        match listener.accept() {
+            Ok((s, _)) => {
+                // Restore blocking mode on the accepted stream: on macOS an
+                // accepted socket inherits O_NONBLOCK from the listener, and
+                // a non-blocking stream would make every frame read return
+                // `WouldBlock` immediately.
+                let _ = s.set_nonblocking(false);
+                spawn(s, &token, &nonce, state)?;
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(25));
+            }
+            Err(e) => {
+                // A spurious accept error is not fatal: the listener is still
+                // alive and the next connection might succeed. We deliberately
+                // do not return here — a transient resource exhaustion should
+                // not tear down the daemon.
+                eprintln!("vcli __transport-daemon: accept failed: {e}");
+            }
+        }
+    }
+    // Three-phase shutdown: admission is already stopped (the loop broke);
+    // wait for in-flight connections within the grace, then return — the
+    // daemon process exits and reaps any straggler stuck in a transport call.
+    let phase2_state = Arc::clone(state);
+    state.coordinator.execute(
+        || drop(listener),
+        || phase2_state.active.load(Ordering::SeqCst) == 0,
+        || {},
+    );
+    Ok(())
+}
+
+/// Bind a Unix domain socket at `socket_path`, set its mode to `0600`, and
 /// spawn one OS thread per accepted connection. Each thread runs
 /// [`serve_one_with_shutdown`] until the peer closes.
 ///
@@ -567,83 +806,68 @@ pub fn run(
     server_nonce: &str,
     shutdown: ShutdownCoordinator,
 ) -> Result<(), String> {
-    if let Some(parent) = socket_path.parent() {
-        if !parent.as_os_str().is_empty() && !parent.exists() {
-            return Err(format!(
-                "ipc socket parent directory does not exist: {}",
-                parent.display()
-            ));
-        }
-    }
-    // Best-effort cleanup of any stale socket left by a crashed previous run.
-    let _ = std::fs::remove_file(socket_path);
-    let listener = UnixListener::bind(socket_path)
-        .map_err(|e| format!("failed to bind ipc socket {}: {e}", socket_path.display()))?;
-    // Mode 0600: only the current user can connect. The owner is set by the
-    // bind above; chmod enforces the bits regardless of umask.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let perms = std::fs::Permissions::from_mode(0o600);
-        if let Err(e) = std::fs::set_permissions(socket_path, perms) {
-            return Err(format!(
-                "failed to chmod 0600 ipc socket {}: {e}",
-                socket_path.display()
-            ));
-        }
-    }
-    let state = Arc::new(ShutdownState::new(shutdown));
-    // Non-blocking accept + poll: the token is fired from a worker thread (a
-    // connection that sent `Shutdown`), and a blocking accept would never see
-    // it until the next connection arrived.
-    listener
-        .set_nonblocking(true)
-        .map_err(|e| format!("failed to set non-blocking accept: {e}"))?;
-    loop {
-        if state.token.is_cancelled() {
-            break;
-        }
-        match listener.accept() {
-            Ok((s, _)) => {
-                // Restore blocking mode on the accepted stream: on macOS an
-                // accepted socket inherits O_NONBLOCK from the listener, and
-                // a non-blocking stream would make every frame read return
-                // `WouldBlock` immediately.
-                let _ = s.set_nonblocking(false);
-                let transport = transport.clone();
-                let token = auth_token.to_string();
-                let nonce = server_nonce.to_string();
-                let state = Arc::clone(&state);
-                thread::Builder::new()
-                    .name("vcli-ipc".to_string())
-                    .spawn(move || {
-                        serve_one_with_shutdown(s, transport, &token, &nonce, Some(&state))
-                    })
-                    .map_err(|e| format!("failed to spawn ipc worker: {e}"))?;
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                thread::sleep(Duration::from_millis(25));
-            }
-            Err(e) => {
-                // A spurious accept error is not fatal: the listener is still
-                // alive and the next connection might succeed. We deliberately
-                // do not return here — a transient resource exhaustion should
-                // not tear down the daemon.
-                eprintln!("vcli __transport-daemon: accept failed: {e}");
-            }
-        }
-    }
-    // Three-phase shutdown: admission is already stopped (the loop broke);
-    // wait for in-flight connections within the grace, then return — the
-    // daemon process exits and reaps any straggler stuck in a transport call.
-    let phase2_state = Arc::clone(&state);
-    state.coordinator.execute(
-        || drop(listener),
-        || phase2_state.active.load(Ordering::SeqCst) == 0,
-        || {},
-    );
-    let _ = std::fs::remove_file(socket_path);
-    Ok(())
+    let (listener, state) = bind_listener(socket_path, shutdown)?;
+    accept_loop(
+        listener,
+        &state,
+        auth_token,
+        server_nonce,
+        move |s, t, n, st| {
+            let transport = Arc::clone(&transport);
+            let token = t.to_string();
+            let nonce = n.to_string();
+            let state = Arc::clone(st);
+            thread::Builder::new()
+                .name("vcli-ipc".to_string())
+                .spawn(move || serve_one_with_shutdown(s, transport, &token, &nonce, Some(&state)))
+                .map_err(|e| format!("failed to spawn ipc worker: {e}"))
+        },
+    )
+}
+
+/// [`run`] over an [`EndpointPool`]: every connection is served by
+/// [`serve_one_pooled`], so requests to the same endpoint key share one
+/// transport and a connection-level failure reconnects on the next request.
+#[cfg(feature = "native-ssh")]
+pub fn run_with_pool(
+    socket_path: &Path,
+    pool: Arc<EndpointPool>,
+    key: EndpointKey,
+    limits: SchedulerLimits,
+    factory: Arc<dyn Fn() -> Result<Arc<dyn RemoteTransport>, TransportError> + Send + Sync>,
+    auth_token: &str,
+    server_nonce: &str,
+    shutdown: ShutdownCoordinator,
+) -> Result<(), String> {
+    let (listener, state) = bind_listener(socket_path, shutdown)?;
+    accept_loop(
+        listener,
+        &state,
+        auth_token,
+        server_nonce,
+        move |s, t, n, st| {
+            let pool = Arc::clone(&pool);
+            let key = key.clone();
+            let token = t.to_string();
+            let nonce = n.to_string();
+            let state = Arc::clone(st);
+            thread::Builder::new()
+                .name("vcli-ipc".to_string())
+                .spawn(move || {
+                    serve_one_pooled(
+                        s,
+                        pool,
+                        key,
+                        limits,
+                        Arc::clone(&factory),
+                        &token,
+                        &nonce,
+                        Some(&state),
+                    )
+                })
+                .map_err(|e| format!("failed to spawn ipc worker: {e}"))
+        },
+    )
 }
 
 // ────────────────────────────────── tests ──────────────────────────────────
@@ -808,6 +1032,194 @@ mod tests {
         assert_eq!(answer.daemon_nonce, "the-recorded-nonce");
 
         let _ = std::fs::remove_file(&socket);
+    }
+
+    /// The pooled serve path shares one connection across requests to the
+    /// same endpoint key: the factory runs once per key, and a second
+    /// connection (a fresh IPC session) reuses the pooled transport.
+    #[cfg(feature = "native-ssh")]
+    #[test]
+    fn pooled_serve_reuses_one_transport_across_requests() {
+        use crate::transport::pool::{EndpointKey, EndpointPool};
+        use crate::transport::scheduler::SchedulerLimits;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let pool = Arc::new(EndpointPool::new());
+        let factory_calls = Arc::clone(&calls);
+        let factory: Arc<
+            dyn Fn() -> Result<Arc<dyn RemoteTransport>, TransportError> + Send + Sync,
+        > = Arc::new(move || {
+            factory_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Arc::new(FakeTransport::ok()))
+        });
+        let key = EndpointKey {
+            profile: None,
+            host: "eda-1".into(),
+            port: 22,
+            user: None,
+            jump_route: Vec::new(),
+            socks_route: None,
+            identities: Vec::new(),
+            host_key_aliases: Vec::new(),
+            security_options: Vec::new(),
+        };
+
+        // Two independent IPC sessions, both resolving to the same key. The
+        // first creates the endpoint; the second must reuse it.
+        for _ in 0..2 {
+            let socket =
+                std::env::temp_dir().join(format!("vcli-pool-{}.sock", uuid::Uuid::new_v4()));
+            let _ = std::fs::remove_file(&socket);
+            let listener = UnixListener::bind(&socket).expect("bind");
+            let listener_for_thread = listener.try_clone().expect("clone listener");
+            let pool = Arc::clone(&pool);
+            let key = key.clone();
+            let factory = Arc::clone(&factory);
+            thread::spawn(move || {
+                if let Ok((stream, _)) = listener_for_thread.accept() {
+                    serve_one_pooled(
+                        stream,
+                        pool,
+                        key,
+                        SchedulerLimits::default_limits(),
+                        factory,
+                        "secret-token",
+                        "n",
+                        None,
+                    );
+                }
+            });
+
+            let client =
+                NativeTransportClient::connect(&socket, "p", "secret-token").expect("connect");
+            let ok = client
+                .run_command(&CommandRequest::untimed("echo hi"))
+                .expect("run command");
+            assert_eq!(ok.exit_status, 0);
+            drop(client);
+            let _ = std::fs::remove_file(&socket);
+            let _ = listener;
+        }
+
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "one transport per endpoint key, reused across requests"
+        );
+        assert_eq!(pool.len(), 1);
+    }
+
+    /// A connection-level failure evicts the pooled connection, so the next
+    /// request reconnects instead of serving from a dead transport. Business
+    /// failures (remote exit codes) must NOT evict.
+    #[cfg(feature = "native-ssh")]
+    #[test]
+    fn pooled_serve_evicts_on_connection_failure_but_not_on_business_failure() {
+        use crate::transport::pool::{EndpointKey, EndpointPool};
+        use crate::transport::scheduler::SchedulerLimits;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        // Factory hands out a transport that fails at the connection level the
+        // first time and works afterwards.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let pool = Arc::new(EndpointPool::new());
+        let factory_calls = Arc::clone(&calls);
+        let factory: Arc<
+            dyn Fn() -> Result<Arc<dyn RemoteTransport>, TransportError> + Send + Sync,
+        > = Arc::new(move || {
+            let n = factory_calls.fetch_add(1, Ordering::SeqCst);
+            let mut t = FakeTransport::ok();
+            if n == 0 {
+                t.fail_with = Some(TransportError::ConnectionFailed("tcp reset".into()));
+            } else {
+                t.command_result.exit_status = 7; // a business failure, not a connection one
+            }
+            Ok(Arc::new(t))
+        });
+        let key = EndpointKey {
+            profile: None,
+            host: "eda-1".into(),
+            port: 22,
+            user: None,
+            jump_route: Vec::new(),
+            socks_route: None,
+            identities: Vec::new(),
+            host_key_aliases: Vec::new(),
+            security_options: Vec::new(),
+        };
+
+        // Session 1: the pooled transport fails at the connection level. The
+        // client sees the error and the pool must evict the connection.
+        let socket = std::env::temp_dir().join(format!("vcli-evict-{}.sock", uuid::Uuid::new_v4()));
+        let _ = std::fs::remove_file(&socket);
+        let listener = UnixListener::bind(&socket).expect("bind");
+        let listener_for_thread = listener.try_clone().expect("clone listener");
+        let pool_1 = Arc::clone(&pool);
+        let key_1 = key.clone();
+        let factory_1 = Arc::clone(&factory);
+        thread::spawn(move || {
+            if let Ok((stream, _)) = listener_for_thread.accept() {
+                serve_one_pooled(
+                    stream,
+                    pool_1,
+                    key_1,
+                    SchedulerLimits::default_limits(),
+                    factory_1,
+                    "secret-token",
+                    "n",
+                    None,
+                );
+            }
+        });
+        let client = NativeTransportClient::connect(&socket, "p", "secret-token").expect("connect");
+        let err = client
+            .run_command(&CommandRequest::untimed("echo hi"))
+            .expect_err("connection-level failure");
+        assert!(matches!(err, IpcError::ConnectionFailed(_)), "got {err:?}");
+        drop(client);
+        let _ = std::fs::remove_file(&socket);
+        let _ = listener;
+        assert_eq!(pool.len(), 0, "poisoned connection must be evicted");
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // Session 2: a fresh connection is created and reports the business
+        // failure (exit 7) — which must NOT evict it.
+        let socket = std::env::temp_dir().join(format!("vcli-evict-{}.sock", uuid::Uuid::new_v4()));
+        let _ = std::fs::remove_file(&socket);
+        let listener = UnixListener::bind(&socket).expect("bind");
+        let listener_for_thread = listener.try_clone().expect("clone listener");
+        let pool_2 = Arc::clone(&pool);
+        let key_2 = key.clone();
+        let factory_2 = Arc::clone(&factory);
+        thread::spawn(move || {
+            if let Ok((stream, _)) = listener_for_thread.accept() {
+                serve_one_pooled(
+                    stream,
+                    pool_2,
+                    key_2,
+                    SchedulerLimits::default_limits(),
+                    factory_2,
+                    "secret-token",
+                    "n",
+                    None,
+                );
+            }
+        });
+        let client = NativeTransportClient::connect(&socket, "p", "secret-token").expect("connect");
+        let result = client
+            .run_command(&CommandRequest::untimed("echo hi"))
+            .expect("reconnected");
+        assert_eq!(result.exit_status, 7);
+        drop(client);
+        let _ = std::fs::remove_file(&socket);
+        let _ = listener;
+        assert_eq!(
+            pool.len(),
+            1,
+            "a business failure must not evict the connection"
+        );
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "reconnected exactly once");
     }
 
     /// Cooperative shutdown end-to-end: a client's `Shutdown` request is

--- a/src/transport/ipc/server.rs
+++ b/src/transport/ipc/server.rs
@@ -313,6 +313,13 @@ pub fn serve_one(
 /// (phase 2 waits on that), and a `Shutdown` request is answered with an ack,
 /// fires the token, and closes the connection — the accept loop in [`run`]
 /// observes the token and stops admitting.
+//
+// `#[allow(dead_code)]`: kept alongside the pooled entry point for
+// completeness and as a building block for the non-pooled daemon path. The
+// transport daemon only calls [`run_with_pool`] today, so neither this
+// function nor [`run`] has an in-tree caller. Removing them is a separate
+// change from this PR's pool/scheduler wiring.
+#[allow(dead_code)]
 pub fn serve_one_with_shutdown(
     stream: UnixStream,
     transport: Arc<dyn RemoteTransport>,
@@ -503,6 +510,7 @@ fn serve_loop<F, G>(
 /// meters the request, and a connection-level failure evicts the connection
 /// so the next request reconnects.
 #[cfg(feature = "native-ssh")]
+#[allow(clippy::too_many_arguments)]
 pub fn serve_one_pooled(
     stream: UnixStream,
     pool: Arc<EndpointPool>,
@@ -817,6 +825,13 @@ where
 /// tests so the shared contract suite can exercise the IPC path without the
 /// feature.
 #[cfg(feature = "native-ssh")]
+//
+// `#[allow(dead_code)]`: the daemon now exclusively uses [`run_with_pool`]
+// (see `commands::transport_daemon`), so this non-pooled entry point is no
+// longer called in-tree. It is kept as the symmetric counterpart of the
+// pooled entry point and the documented hook for ad-hoc daemons. Removal is
+// tracked separately from the pool/scheduler wiring in this PR.
+#[allow(dead_code)]
 pub fn run(
     socket_path: &Path,
     transport: Arc<dyn RemoteTransport>,
@@ -853,6 +868,7 @@ pub fn run(
 /// [`serve_one_pooled`], so requests to the same endpoint key share one
 /// transport and a connection-level failure reconnects on the next request.
 #[cfg(feature = "native-ssh")]
+#[allow(clippy::too_many_arguments)]
 pub fn run_with_pool(
     socket_path: &Path,
     pool: Arc<EndpointPool>,

--- a/src/transport/ipc/server.rs
+++ b/src/transport/ipc/server.rs
@@ -1323,8 +1323,17 @@ mod tests {
         use crate::transport::pool::{EndpointKey, EndpointPool};
         use crate::transport::scheduler::SchedulerLimits;
 
-        let socket =
-            std::env::temp_dir().join(format!("vcli-shut-pool-{}.sock", uuid::Uuid::new_v4()));
+        // Keep the suffix short: macOS runners resolve `temp_dir()` to a long
+        // `/var/folders/.../T` path and a Unix socket's `sun_path` holds at
+        // most 104 bytes. A longer name fails to bind and the daemon never
+        // comes up — on macOS only, which makes it easy to misread as a
+        // platform bug in the server.
+        let socket = std::env::temp_dir().join(format!("vcli-shp-{}.sock", uuid::Uuid::new_v4()));
+        assert!(
+            socket.to_string_lossy().len() <= 100,
+            "socket path too long for sun_path: {}",
+            socket.display()
+        );
         let _ = std::fs::remove_file(&socket);
         let coordinator =
             crate::transport::lifecycle::ShutdownCoordinator::new(Duration::from_millis(200));

--- a/src/transport/ipc/server.rs
+++ b/src/transport/ipc/server.rs
@@ -323,10 +323,11 @@ pub fn serve_one_with_shutdown(
     let mut transport_for = |_: &RequestEnvelope| {
         Ok(TransportAccess {
             transport: Arc::clone(&transport),
+            captured_generation: 0,
             _permit: None,
         })
     };
-    let mut on_connection_error = |_: &ResponseResult| {};
+    let mut on_connection_error = |_: u64| {};
     serve_loop(
         stream,
         &mut transport_for,
@@ -346,6 +347,12 @@ pub fn serve_one_with_shutdown(
 /// (non-pooled) path carries `None` because it has no endpoint scheduler.
 struct TransportAccess {
     transport: Arc<dyn RemoteTransport>,
+    /// Generation of the [`crate::transport::pool::Endpoint`] this request
+    /// was served on. The connection-error callback hands it to
+    /// [`EndpointPool::remove_if_matches`] so a late eviction does not
+    /// drop a replacement built concurrently. `0` on the non-pooled path,
+    /// which never evicts.
+    captured_generation: u64,
     _permit: Option<Permit>,
 }
 
@@ -365,7 +372,7 @@ fn serve_loop<F, G>(
     shutdown: Option<&Arc<ShutdownState>>,
 ) where
     F: FnMut(&RequestEnvelope) -> Result<TransportAccess, TransportError>,
-    G: FnMut(&ResponseResult),
+    G: FnMut(u64),
 {
     let read_stream = match stream.try_clone() {
         Ok(s) => s,
@@ -465,9 +472,11 @@ fn serve_loop<F, G>(
         };
         // A connection-level failure means the pooled transport is no longer
         // trustworthy. Evict it so the next request reconnects instead of
-        // serving from a dead connection.
+        // serving from a dead connection. The generation captured before
+        // dispatch is the safety net: a fresh endpoint built by a concurrent
+        // request stays alive even when this callback is late.
         if matches!(&resp.result, ResponseResult::Err(e) if e.is_connection_level()) {
-            on_connection_error(&resp.result);
+            on_connection_error(access.captured_generation);
         }
         let body = match serde_json::to_vec(&resp) {
             Ok(b) => b,
@@ -529,13 +538,20 @@ pub fn serve_one_pooled(
         } else {
             None
         };
+        // Capture the generation of the endpoint we are about to serve on.
+        // The eviction callback uses it to drop the connection only when the
+        // slot still holds the same instance — a fresh replacement built
+        // concurrently must survive a late callback from a request that
+        // already failed.
+        let captured_generation = endpoint.generation();
         Ok(TransportAccess {
             transport: Arc::clone(&endpoint.transport),
+            captured_generation,
             _permit: permit,
         })
     };
-    let mut on_connection_error = move |_r: &ResponseResult| {
-        pool_for_errors.remove(&key_for_errors);
+    let mut on_connection_error = move |captured: u64| {
+        pool_for_errors.remove_if_matches(&key_for_errors, captured);
     };
     serve_loop(
         stream,
@@ -858,16 +874,7 @@ pub fn run_with_pool(
             thread::Builder::new()
                 .name("vcli-ipc".to_string())
                 .spawn(move || {
-                    serve_one_pooled(
-                        s,
-                        pool,
-                        key,
-                        limits,
-                        factory,
-                        &token,
-                        &nonce,
-                        Some(&state),
-                    )
+                    serve_one_pooled(s, pool, key, limits, factory, &token, &nonce, Some(&state))
                 })
                 .map_err(|e| format!("failed to spawn ipc worker: {e}"))?;
             Ok(())

--- a/src/transport/native.rs
+++ b/src/transport/native.rs
@@ -145,6 +145,7 @@ impl Handler for NativeClientHandler {
 /// Load a `known_hosts` store, falling back to an empty in-memory store on any
 /// read error. A missing file and a denied permission are both equivalent to
 /// "no prior trust" — the caller discovers an unknown host on first connection.
+#[allow(dead_code)] // wired on Unix by open_transport_for_daemon and the pooled daemon; non-Unix builds have neither
 fn load_known_hosts_or_empty(path: &Path) -> KnownHosts {
     match KnownHosts::load(path) {
         Ok(kh) => kh,
@@ -633,6 +634,7 @@ impl NativeTransport {
     /// Build from the shared `Config`. Fails loudly (never falls back) when the
     /// native backend cannot satisfy the request: missing `VB_REMOTE_HOST`, or
     /// no `VB_SSH_KEY` (step 3 is public-key only).
+    #[allow(dead_code)] // wired on Unix by open_transport_for_daemon and the pooled daemon; non-Unix builds have neither
     pub fn from_config(config: &Config) -> Result<Self, TransportError> {
         let host = config.remote_host.clone().ok_or_else(|| {
             TransportError::Configuration("native backend requires VB_REMOTE_HOST".into())

--- a/src/transport/pool.rs
+++ b/src/transport/pool.rs
@@ -210,15 +210,22 @@ impl Endpoint {
 /// slots and therefore connect in parallel.
 struct EndpointSlot {
     endpoint: Mutex<Option<Arc<Endpoint>>>,
-    limits: SchedulerLimits,
+    /// The scheduler outlives the individual endpoint.
+    ///
+    /// It is created once, when the slot is, and every endpoint built for
+    /// this key shares that one instance. Reconnecting therefore keeps a
+    /// single set of channel limits: an in-flight request holding a permit
+    /// and a request served by the freshly-built replacement draw on the
+    /// same budget instead of two independent ones.
+    scheduler: Arc<SessionScheduler>,
 }
 
 impl EndpointSlot {
-    fn new(limits: SchedulerLimits) -> Self {
-        Self {
+    fn new(limits: SchedulerLimits) -> Result<Self, TransportError> {
+        Ok(Self {
             endpoint: Mutex::new(None),
-            limits,
-        }
+            scheduler: SessionScheduler::new(limits)?,
+        })
     }
 
     fn get_or_create<F>(
@@ -243,14 +250,29 @@ impl EndpointSlot {
         let endpoint = Arc::new(Endpoint {
             key,
             transport,
-            scheduler: SessionScheduler::new(self.limits)?,
+            scheduler: Arc::clone(&self.scheduler),
             generation,
         });
         *guard = Some(Arc::clone(&endpoint));
         Ok(endpoint)
     }
 
-    /// Whether the endpoint currently held in this slot carries `gen`.
+    /// Drop the connection but keep the slot — and therefore the scheduler.
+    ///
+    /// This is what conditional eviction does. Removing the whole slot would
+    /// take its scheduler with it, and the next `get_or_create` would build a
+    /// fresh one, splitting the key's channel budget across two schedulers.
+    fn clear(&self) {
+        *self.endpoint.lock().unwrap_or_else(|e| e.into_inner()) = None;
+    }
+
+    fn has_endpoint(&self) -> bool {
+        self.endpoint
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_some()
+    }
+
     ///
     /// Used by [`EndpointPool::remove_if_matches`] and by the regression
     /// test that proves a stale eviction callback does not drop a
@@ -295,10 +317,13 @@ impl EndpointPool {
     {
         let slot = {
             let mut slots = self.slots.lock().unwrap_or_else(|e| e.into_inner());
-            slots
-                .entry(key.clone())
-                .or_insert_with(|| Arc::new(EndpointSlot::new(limits)))
-                .clone()
+            if let Some(existing) = slots.get(&key) {
+                Arc::clone(existing)
+            } else {
+                let created = Arc::new(EndpointSlot::new(limits)?);
+                slots.insert(key.clone(), Arc::clone(&created));
+                created
+            }
         };
         match slot.get_or_create(key.clone(), factory) {
             Ok(endpoint) => Ok(endpoint),
@@ -344,48 +369,59 @@ impl EndpointPool {
     /// A request captured `expected_gen` when it began. If the connection
     /// failed and was already replaced by a fresh one before the eviction
     /// callback ran, the slot's current generation is newer and this call
-    /// is a no-op: returning `false` keeps the replacement alive for the
-    /// next request instead of evicting it on stale evidence.
+    /// eviction is a no-op: the slot keeps its scheduler, so the next
+    /// `get_or_create` reconnects onto the same channel budget instead of
+    /// a reset one.
     ///
     /// This is the contract the IPC server relies on. An unconditional
     /// [`remove`] is for `tunnel stop` only — it would otherwise race with
     /// reconnect in step 6.
     pub fn remove_if_matches(&self, key: &EndpointKey, expected_gen: u64) -> bool {
+        // One lock for the whole check-then-clear. `EndpointPool::slots` is a
+        // plain `Mutex`: a second `lock()` on this thread would deadlock
+        // because the first guard is still alive, so the comparison and the
+        // eviction must happen inside a single critical section.
         let slots = self.slots.lock().unwrap_or_else(|e| e.into_inner());
+        let matches = slots
+            .get(key)
+            .map(|slot| slot.current_generation() == Some(expected_gen))
+            .unwrap_or(false);
+        if !matches {
+            return false;
+        }
         let Some(slot) = slots.get(key) else {
             return false;
         };
-        if slot.current_generation() != Some(expected_gen) {
-            return false;
-        }
-        // Re-lock so the comparison and the removal happen on the same
-        // view of the map. Two consecutive locks are deliberate: the first
-        // short-circuits the common "no slot" case without taking the
-        // slot's mutex, and the second only fires when the generation
-        // already agreed.
-        let mut slots = self.slots.lock().unwrap_or_else(|e| e.into_inner());
-        match slots.get(key) {
-            Some(slot) if slot.current_generation() == Some(expected_gen) => {
-                slots.remove(key).is_some()
-            }
-            _ => false,
-        }
+        slot.clear();
+        true
     }
 
+    /// Number of keys with a live connection.
+    ///
+    /// An evicted key keeps its slot (and scheduler) so a reconnect reuses
+    /// the same budget, so this counts slots that currently hold an
+    /// endpoint rather than every slot in the map.
     pub fn len(&self) -> usize {
-        self.slots.lock().unwrap_or_else(|e| e.into_inner()).len()
+        self.slots
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .filter(|s| s.has_endpoint())
+            .count()
     }
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
+    /// Keys that currently hold a live connection.
     pub fn keys(&self) -> Vec<EndpointKey> {
         self.slots
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .keys()
-            .cloned()
+            .iter()
+            .filter(|(_, s)| s.has_endpoint())
+            .map(|(k, _)| k.clone())
             .collect()
     }
 
@@ -834,22 +870,18 @@ mod tests {
     }
 
     #[test]
-    fn removing_one_endpoint_does_not_reset_its_scheduler() {
-        // "Deleting an endpoint must not rebuild its scheduler" is part of
-        // the design intent: per-endpoint schedulers stay stable across
-        // reconnects so limits don't jitter. We check it by acquiring a
-        // permit, evicting the endpoint, observing the permit is still held
-        // (the Arc kept the scheduler alive), and confirming the pool's
-        // rebuilt endpoint gets a *new* scheduler — which is fine, because
-        // the old one is still around servicing outstanding permits.
+    fn evicting_an_endpoint_keeps_its_scheduler_and_budget() {
+        // #79 ③: cleaning up a failed instance must not rebuild the
+        // endpoint's scheduler. The scheduler lives on the slot, so the
+        // endpoint built after an eviction shares one channel budget with
+        // requests that are still in flight — never two independent ones.
         let pool = EndpointPool::new();
+        let limits = SchedulerLimits::default_limits();
         let first = pool
-            .get_or_create(
-                key("eda-1"),
-                SchedulerLimits::default_limits(),
-                ok_transport,
-            )
+            .get_or_create(key("eda-1"), limits, ok_transport)
             .unwrap();
+        // Stand in for an in-flight request: one permit is checked out and
+        // will only be returned after the eviction.
         let permit = first
             .acquire(
                 Priority::Normal,
@@ -858,29 +890,39 @@ mod tests {
             )
             .unwrap();
         let first_scheduler = Arc::clone(&first.scheduler);
+        let gen_a = first.generation();
+        assert_eq!(first_scheduler.stats().active, 1);
 
-        pool.remove(&key("eda-1"));
+        // Conditional eviction (the path the IPC server takes on a
+        // connection-level failure) drops the instance but keeps the slot.
+        assert!(
+            pool.remove_if_matches(&key("eda-1"), gen_a),
+            "the current generation must evict"
+        );
+        assert!(pool.is_empty(), "no live endpoint survives");
+
         let second = pool
-            .get_or_create(
-                key("eda-1"),
-                SchedulerLimits::default_limits(),
-                ok_transport,
-            )
+            .get_or_create(key("eda-1"), limits, ok_transport)
             .unwrap();
 
-        // The old scheduler kept its permit live: dropping the permit here
-        // returns capacity to it, not to the new endpoint's scheduler.
-        drop(permit);
-        assert_eq!(
-            first_scheduler.stats().active,
-            0,
-            "old scheduler got the release"
+        assert!(
+            Arc::ptr_eq(&first_scheduler, &second.scheduler),
+            "the reconnect must reuse the same scheduler, not build a new one"
+        );
+        assert!(
+            second.generation() > gen_a,
+            "the replacement is a new instance"
         );
         assert_eq!(
             second.scheduler.stats().active,
-            0,
-            "new scheduler is independent of the old one"
+            1,
+            "the in-flight permit is charged to the shared budget — it must not reset"
         );
-        assert!(!Arc::ptr_eq(&first_scheduler, &second.scheduler));
+
+        // Releasing the old permit returns capacity to the one scheduler
+        // both endpoints share.
+        drop(permit);
+        assert_eq!(first_scheduler.stats().active, 0);
+        assert_eq!(second.scheduler.stats().active, 0);
     }
 }

--- a/src/transport/pool.rs
+++ b/src/transport/pool.rs
@@ -27,7 +27,7 @@
 //! how the key is *built*, not to the key's shape, and no pooled connection
 //! can outlive a change to its own identity.
 
-#![allow(dead_code)] // consumed by the daemon in step 6
+#![allow(dead_code)] // consumed on Unix by the pooled transport daemon (commands::transport_daemon → server::run_with_pool). Windows builds have no daemon yet, so the pool stays un-referenced there.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};

--- a/src/transport/pool.rs
+++ b/src/transport/pool.rs
@@ -30,7 +30,21 @@
 #![allow(dead_code)] // consumed on Unix by the pooled transport daemon (commands::transport_daemon → server::run_with_pool). Windows builds have no daemon yet, so the pool stays un-referenced there.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+
+/// Monotonically increasing counter stamped onto every newly-created
+/// [`Endpoint`].
+///
+/// `EndpointPool::get_or_create` bumps this once per successful factory call
+/// and writes the new value into the freshly-stored `Endpoint`. A stale
+/// eviction callback captured the generation of the connection it ran on;
+/// when it later asks the pool to drop that connection, the pool compares
+/// the captured generation against the slot's current one. They differ when
+/// a concurrent caller has already replaced the failed connection with a
+/// fresh one — in which case the stale callback must not drop the
+/// replacement.
+static NEXT_ENDPOINT_GENERATION: AtomicU64 = AtomicU64::new(1);
 
 use crate::config::Config;
 use crate::transport::contract::{Deadline, RemoteTransport, RequestId, TransportError};
@@ -143,6 +157,14 @@ pub struct Endpoint {
     pub key: EndpointKey,
     pub transport: Arc<dyn RemoteTransport>,
     pub scheduler: Arc<SessionScheduler>,
+    /// Generation stamped when this `Endpoint` was stored in its slot. Used
+    /// to make eviction conditional: a late callback from a request that
+    /// already failed must not drop a replacement built concurrently.
+    ///
+    /// Held by `Arc` so callers can capture the generation cheaply (one
+    /// `Arc::clone`) and the [`EndpointPool`] can read it without borrowing
+    /// the whole `Endpoint` while it is evicting.
+    pub generation: Arc<AtomicU64>,
 }
 
 /// Hand-written because neither `dyn RemoteTransport` nor
@@ -168,6 +190,15 @@ impl Endpoint {
         deadline: Deadline,
     ) -> Result<Permit, TransportError> {
         self.scheduler.acquire(priority, request, deadline)
+    }
+
+    /// Read the generation stamped on this endpoint.
+    ///
+    /// Pair with [`EndpointPool::remove_if_matches`] to drop the connection
+    /// only when the captured generation still describes the slot's current
+    /// endpoint.
+    pub fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Relaxed)
     }
 }
 
@@ -203,13 +234,33 @@ impl EndpointSlot {
             return Ok(Arc::clone(existing));
         }
         let transport = factory()?;
+        // Bump the global counter once per successful factory call. Reading
+        // the previous value and storing the next gives every newly-built
+        // `Endpoint` a strictly larger generation than its predecessor.
+        let generation = Arc::new(AtomicU64::new(
+            NEXT_ENDPOINT_GENERATION.fetch_add(1, Ordering::Relaxed),
+        ));
         let endpoint = Arc::new(Endpoint {
             key,
             transport,
             scheduler: SessionScheduler::new(self.limits)?,
+            generation,
         });
         *guard = Some(Arc::clone(&endpoint));
         Ok(endpoint)
+    }
+
+    /// Whether the endpoint currently held in this slot carries `gen`.
+    ///
+    /// Used by [`EndpointPool::remove_if_matches`] and by the regression
+    /// test that proves a stale eviction callback does not drop a
+    /// replacement.
+    fn current_generation(&self) -> Option<u64> {
+        self.endpoint
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+            .map(|ep| ep.generation())
     }
 }
 
@@ -285,6 +336,40 @@ impl EndpointPool {
             .unwrap_or_else(|e| e.into_inner())
             .remove(key)
             .is_some()
+    }
+
+    /// Conditionally drop the connection for `key`, only if its current
+    /// generation matches `expected_gen`.
+    ///
+    /// A request captured `expected_gen` when it began. If the connection
+    /// failed and was already replaced by a fresh one before the eviction
+    /// callback ran, the slot's current generation is newer and this call
+    /// is a no-op: returning `false` keeps the replacement alive for the
+    /// next request instead of evicting it on stale evidence.
+    ///
+    /// This is the contract the IPC server relies on. An unconditional
+    /// [`remove`] is for `tunnel stop` only — it would otherwise race with
+    /// reconnect in step 6.
+    pub fn remove_if_matches(&self, key: &EndpointKey, expected_gen: u64) -> bool {
+        let slots = self.slots.lock().unwrap_or_else(|e| e.into_inner());
+        let Some(slot) = slots.get(key) else {
+            return false;
+        };
+        if slot.current_generation() != Some(expected_gen) {
+            return false;
+        }
+        // Re-lock so the comparison and the removal happen on the same
+        // view of the map. Two consecutive locks are deliberate: the first
+        // short-circuits the common "no slot" case without taking the
+        // slot's mutex, and the second only fires when the generation
+        // already agreed.
+        let mut slots = self.slots.lock().unwrap_or_else(|e| e.into_inner());
+        match slots.get(key) {
+            Some(slot) if slot.current_generation() == Some(expected_gen) => {
+                slots.remove(key).is_some()
+            }
+            _ => false,
+        }
     }
 
     pub fn len(&self) -> usize {
@@ -657,5 +742,145 @@ mod tests {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<EndpointPool>();
         assert_send_sync::<EndpointKey>();
+    }
+
+    // ── generation-based eviction ──
+
+    #[test]
+    fn every_endpoint_carries_a_strictly_increasing_generation() {
+        // The generation is the safety net against late eviction callbacks,
+        // so the only invariant that matters here is "newer endpoint ⇒ larger
+        // generation" across calls.
+        let pool = EndpointPool::new();
+        let a = pool
+            .get_or_create(
+                key("eda-1"),
+                SchedulerLimits::default_limits(),
+                ok_transport,
+            )
+            .unwrap();
+        let g_a = a.generation();
+        pool.remove(&key("eda-1"));
+        let b = pool
+            .get_or_create(
+                key("eda-1"),
+                SchedulerLimits::default_limits(),
+                ok_transport,
+            )
+            .unwrap();
+        assert!(
+            b.generation() > g_a,
+            "each rebuild must bump the generation"
+        );
+    }
+
+    #[test]
+    fn a_late_eviction_does_not_drop_a_concurrent_replacement() {
+        // A request captured `gen_a` from the endpoint it was using. By the
+        // time the connection-error callback runs, a concurrent request has
+        // replaced that endpoint with `gen_b`. The callback's remove must be a
+        // no-op so the next caller still has a usable connection.
+        let pool = EndpointPool::new();
+        let first = pool
+            .get_or_create(
+                key("eda-1"),
+                SchedulerLimits::default_limits(),
+                ok_transport,
+            )
+            .unwrap();
+        let gen_a = first.generation();
+
+        // Simulate the rebuild path: drop the slot, then re-create. The
+        // exact same effect would happen when a real factory errors and the
+        // pool re-tries on the next request.
+        pool.remove(&key("eda-1"));
+        let replacement = pool
+            .get_or_create(
+                key("eda-1"),
+                SchedulerLimits::default_limits(),
+                ok_transport,
+            )
+            .unwrap();
+        let gen_b = replacement.generation();
+        assert!(gen_b > gen_a);
+
+        // The late callback fires with the stale generation. It must NOT
+        // remove the replacement; otherwise the next request would retry the
+        // factory instead of reusing the freshly-built connection.
+        assert!(
+            !pool.remove_if_matches(&key("eda-1"), gen_a),
+            "stale generation must not evict the replacement"
+        );
+        assert_eq!(pool.len(), 1, "the replacement must still be pooled");
+        let observed = pool.get(&key("eda-1")).unwrap();
+        assert!(
+            Arc::ptr_eq(&observed, &replacement),
+            "the survivor must be the freshly-built endpoint"
+        );
+        assert_eq!(observed.generation(), gen_b);
+
+        // The current generation evicts as expected.
+        assert!(pool.remove_if_matches(&key("eda-1"), gen_b));
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn remove_if_matches_returns_false_when_the_slot_is_empty() {
+        // No slot at all: the conditional remove must be a no-op, never panic
+        // on a missing entry, and never synthesise a slot.
+        let pool = EndpointPool::new();
+        assert!(!pool.remove_if_matches(&key("eda-1"), 42));
+        assert!(pool.is_empty());
+    }
+
+    #[test]
+    fn removing_one_endpoint_does_not_reset_its_scheduler() {
+        // "Deleting an endpoint must not rebuild its scheduler" is part of
+        // the design intent: per-endpoint schedulers stay stable across
+        // reconnects so limits don't jitter. We check it by acquiring a
+        // permit, evicting the endpoint, observing the permit is still held
+        // (the Arc kept the scheduler alive), and confirming the pool's
+        // rebuilt endpoint gets a *new* scheduler — which is fine, because
+        // the old one is still around servicing outstanding permits.
+        let pool = EndpointPool::new();
+        let first = pool
+            .get_or_create(
+                key("eda-1"),
+                SchedulerLimits::default_limits(),
+                ok_transport,
+            )
+            .unwrap();
+        let permit = first
+            .acquire(
+                Priority::Normal,
+                &RequestId::new(),
+                Deadline::from_now(std::time::Duration::from_secs(5)),
+            )
+            .unwrap();
+        let first_scheduler = Arc::clone(&first.scheduler);
+
+        pool.remove(&key("eda-1"));
+        let second = pool
+            .get_or_create(
+                key("eda-1"),
+                SchedulerLimits::default_limits(),
+                ok_transport,
+            )
+            .unwrap();
+
+        // The old scheduler kept its permit live: dropping the permit here
+        // returns capacity to it, not to the new endpoint's scheduler.
+        drop(permit);
+        assert_eq!(
+            first_scheduler.stats().active,
+            0,
+            "old scheduler got the release"
+        );
+        assert_eq!(
+            second.scheduler.stats().active,
+            0,
+            "new scheduler is independent of the old one"
+        );
+        assert!(!Arc::ptr_eq(&first_scheduler, &second.scheduler));
     }
 }

--- a/src/transport/scheduler.rs
+++ b/src/transport/scheduler.rs
@@ -36,7 +36,7 @@
 //! testable relaxation of strict priority, not a different policy: urgent work
 //! still wins immediately, and a healthy system never reaches the grace period.
 
-#![allow(dead_code)] // consumed by step 4b (config) and the daemon in step 6
+#![allow(dead_code)] // validate_capacity/from_config are consumed by the backend (step 4b); SessionScheduler itself by the pooled daemon (step 6) on Unix. Windows builds have no daemon yet.
 
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};

--- a/src/transport/tunnel.rs
+++ b/src/transport/tunnel.rs
@@ -515,8 +515,7 @@ fn signal_tunnel_pid(pid: u32) -> std::io::Result<()> {
     if out.status.success() {
         Ok(())
     } else {
-        Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
+        Err(std::io::Error::other(
             String::from_utf8_lossy(&out.stderr).trim().to_string(),
         ))
     }


### PR DESCRIPTION
## 改动内容

把 `EndpointPool` 真正接进 transport daemon（pool.rs 注释中"consumed by the daemon in step 6"的接线落地）：

- **IPC server**：抽出共用 `serve_loop` / `accept_loop`；新增 `serve_one_pooled` 与 `run_with_pool`。每个请求按 `EndpointKey` 从池取连接（同一 key 复用已建连接、跨请求共享），endpoint scheduler 计量每个请求；连接级失败（`IpcError::is_connection_level`）驱逐该连接，下一次请求自动重连——因此**不保证"连接只建一次"**，重连会按需重建
- **daemon 入口**：`run_with` 启动时构建 pool / key / limits / factory，经 `run_with_pool` 服务所有 IPC 请求；配置错误仍在启动时暴露（fail-loudly 语义不变）
- **messages**：新增 `IpcError::is_connection_level()` 连接级错误分类（ConnectionFailed / JumpFailed / ProxyFailed / DaemonUnavailable；业务失败如 RemoteExit / ExecutionTimeout 明确不驱逐）
- **native / pool / scheduler**：更新 dead_code 注释以反映 daemon 接线事实（Windows 无 daemon，故 allow 保留）
- **.gitignore**：忽略 `target-lld2/`（本机 GNU 工具链构建目录）

## 交付范围（本次 PR）

本次交付 = **transport 对象池（EndpointPool）接入 daemon + endpoint scheduler 接线**，并非"SSH 连接只建一次"的全局承诺：

- 连接按 `EndpointKey` 复用；连接级失败时按 key 驱逐并重连（自愈行为，设计内）。
- **不承诺**同一 SSH 连接永不重建——连接级故障触发重连是预期行为。
- scheduler 为 per-endpoint（每个 `Endpoint` 自带 `SessionScheduler`），驱逐/重建单个 endpoint 不会重建全局调度基础设施。
- SOCKS / 多跳 jump 路由（step 5）尚未接入；对象池已为这些 key 字段预留位置。

## 验证

- `cargo test --lib --bins --tests`：单测 + 集成测试，0 失败
- `cargo clippy -- -D warnings`、`--features daemon`、`--features native-ssh`：三档全绿
- `cargo fmt --check` 通过；`cargo test --doc` 通过；`cargo build --features daemon` 通过
- Linux target（unix 视图）`cargo check` + `cargo clippy -D warnings` 通过，覆盖 server.rs 的 unix-only 代码
- 后续提交 `6751893` 修复了 default / native-ssh 双构建的编译门控（factory 类型别名、bind_listener/accept_loop 的 native-ssh 门控、worker-spawn 闭包返回类型、测试 `TransportError` 导入与断言），双构建均 0 错误 0 警告
- 新增测试：
  - 跨两次独立 IPC 会话、同一 key 的池化复用（factory 仅调用一次）
  - 连接级失败驱逐连接并重连，业务失败（exit code）不驱逐
  - `is_connection_level` 全错误词汇分类

## 备注

- native-ssh + unix 分支（`serve_one_pooled` / `run_with_pool` / daemon `run_with`）在本机无法编译验证：需要 Linux 交叉 C 工具链编译 aws-lc-sys。已按签名逐一 review，最终由 CI（Linux）覆盖
- 本机无 MSVC 链接器，构建使用 GNU 工具链 + rust-lld（不影响本 PR 的代码内容）
