### PR TITLE
ci: run .claude/skills Python tests in CI

### DIFF
--- a/.github/scripts/run-skill-tests.sh
+++ b/.github/scripts/run-skill-tests.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Syntax-check every skill script and run each skill's unittest suite.
+#
+# Used by .github/workflows/skill-tests.yml. Exits non-zero if any skill fails,
+# or if no skill suite was found at all (a renamed/removed tests/ directory must
+# not silently turn this job green).
+set -euo pipefail
+
+# Keep the working tree clean: importing skill modules must not litter
+# __pycache__ directories (the repo tracks bytecode under .claude).
+export PYTHONDONTWRITEBYTECODE=1
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$root"
+
+echo "== syntax check: .claude/skills/**/*.py =="
+# AST parse rather than compileall: same syntax coverage, but writes no
+# __pycache__ (the repo tracks a .pyc under .claude, so stray bytecode files
+# would show up as working-tree noise).
+find .claude/skills -name "*.py" -print0 | xargs -0 -r python3 -c '
+import ast, sys
+bad = 0
+for path in sys.argv[1:]:
+    try:
+        ast.parse(open(path, "rb").read(), filename=path)
+    except SyntaxError as e:
+        print(f"   SyntaxError: {path}: {e}")
+        bad += 1
+sys.exit(1 if bad else 0)
+' || exit 1
+echo "   OK"
+
+suites=0
+failures=0
+
+for tests_dir in .claude/skills/*/tests; do
+    [ -d "$tests_dir" ] || continue
+    skill_dir="$(dirname "$tests_dir")"
+    suites=$((suites + 1))
+    echo "== unittest discover: $skill_dir =="
+    # Tests inject their own sys.path for the skill's scripts/ package, so run
+    # from the skill directory rather than the repo root.
+    if (cd "$skill_dir" && python3 -m unittest discover tests); then
+        echo "   OK"
+    else
+        echo "   FAILED: $skill_dir"
+        failures=$((failures + 1))
+    fi
+done
+
+if [ "$suites" -eq 0 ]; then
+    echo "ERROR: no .claude/skills/*/tests directory found; refusing to pass." >&2
+    exit 1
+fi
+
+if [ "$failures" -ne 0 ]; then
+    echo "ERROR: $failures of $suites skill suite(s) failed." >&2
+    exit 1
+fi
+
+echo "OK: $suites skill suite(s) passed."

--- a/.github/workflows/skill-tests.yml
+++ b/.github/workflows/skill-tests.yml
@@ -1,0 +1,39 @@
+name: Skill Tests
+
+# The Rust workflows (ci.yml / integration.yml) never invoke python, so changes
+# under .claude/skills used to land with zero automated verification. This
+# workflow covers them: byte-compile every skill script and run each skill's
+# unittest suite. Path-filtered so pure-Rust PRs are not slowed down.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".claude/skills/**"
+      - ".github/workflows/skill-tests.yml"
+      - ".github/scripts/run-skill-tests.sh"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".claude/skills/**"
+      - ".github/workflows/skill-tests.yml"
+      - ".github/scripts/run-skill-tests.sh"
+
+jobs:
+  python:
+    name: Skill tests (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.9 = oldest supported system python, 3.13 = current stable.
+        python-version: ["3.9", "3.13"]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run skill test suites
+        run: bash .github/scripts/run-skill-tests.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,3 +160,8 @@ where `dirs::home_dir()` reads `FOLDERID_Profile` and ignores `HOME`).
 快速检查用 `scripts/xdotool_cli.py`（env/state/find/shot/click/type/key/drag/scroll/wait/smoke）。
 场景 DSL 规范见 `references/scenario-schema.md`，xdotool 命令参考见 `references/xdotool-cheatsheet.md`。
 测试：`cd .claude/skills/virtuoso-gui-debug && python3 -m unittest discover tests`。
+
+**CI 会跑这些测试**：`.github/workflows/skill-tests.yml` 在 `.claude/skills/**` 变更时触发，
+对 Python 3.9 / 3.13 各跑一次（语法检查 + 全部 skill 的 unittest 套件，脚本见
+`.github/scripts/run-skill-tests.sh`）。纯 Rust 的 PR 不会触发它，因此它仍是 skill 类改动的
+唯一自动化验证 —— 但**不要**因为 Rust 工作流全绿就假定 skill 脚本没问题。


### PR DESCRIPTION
## 背景

PR #74 是纯 Python 改动（4 个提交，全在 `.claude/skills/virtuoso-gui-debug/`），合并前的绿灯**完全没验证到它的主体**：仓库 4 个 workflow 里没有任何一处出现 python。它的绿灯只说明 Rust 没被改坏，Python 侧靠本地补跑才发现 242/242 通过。

长期依赖本地补跑容易再次漏验，因此把 skill 测试接入 CI。

## 改动

**`.github/workflows/skill-tests.yml`**（新增）
- `paths` 过滤到 `.claude/skills/**`（外加 workflow/脚本自身），**纯 Rust PR 不受影响**，不会拖慢门禁
- matrix：Python **3.9**（最老受支持系统版本）× **3.13**（当前稳定）
- `fail-fast: false`，两个版本都跑完

**`.github/scripts/run-skill-tests.sh`**（新增）
1. AST 解析 `.claude/skills/**/*.py`，先兜住语法错误
2. 遍历 `.claude/skills/*/tests`，逐个 `unittest discover`
   - 每个测试文件自己 `sys.path.insert` 注入 `scripts/`，所以从** skill 目录**跑，不是仓库根
3. 守卫：一个 tests 目录都没找到 → **失败**。目录被改名或误删时不能静默转绿
4. 兼容未来新增的 skill，不硬编码 `virtuoso-gui-debug`

**`AGENTS.md`**：补一段说明 CI 会跑这些测试，并提醒不要因为 Rust 工作流全绿就假定 skill 脚本没问题。

## 两个实现细节（避免副作用）

- **用 `ast.parse` 而不是 `compileall`**，并设 `PYTHONDONTWRITEBYTECODE=1`：仓库在 `.claude` 下**跟踪了一个 `.pyc`**，跑测试生成的 `__pycache__` 会变成工作区噪音。（我本地第一版用 compileall 就误删了那个被跟踪的文件，已 `git checkout` 恢复。）
- 无第三方依赖：skill 测试只用标准库，因此不需要 `pip install`。

## 验证

| 项 | 结果 |
|---|---|
| `bash -n` 脚本语法 | ✅ |
| workflow YAML 解析 | ✅ jobs = python，matrix 3.9/3.13，paths 正确 |
| 在 `origin/main` 的 `.claude` 上实跑 | ✅ **242 tests OK**，`EXIT=0` |
| Python 3.13.12 / 系统 3.9.6 | ✅ 均通过 |
| 无 tests 目录时 | ✅ 报 `ERROR: no .claude/skills/*/tests directory found`，非 0 退出 |
| `__pycache__` 增量 | ✅ 0（BEFORE=1 / AFTER=1，那 1 个是仓库自带的） |

## 关联

- 起因：PR #74（已合并）
- 相关 issue：#79（#78 合并前修复与范围澄清）、#80（后续真实 SSH 长连接复用）
