### PR TITLE
ci(skill-tests): fail when a discovered suite runs 0 tests

### DIFF
--- a/.github/scripts/run-skill-tests.sh
+++ b/.github/scripts/run-skill-tests.sh
@@ -2,8 +2,8 @@
 # Syntax-check every skill script and run each skill's unittest suite.
 #
 # Used by .github/workflows/skill-tests.yml. Exits non-zero if any skill fails,
-# or if no skill suite was found at all (a renamed/removed tests/ directory must
-# not silently turn this job green).
+# if no skill suite was found at all (a renamed/removed tests/ directory must
+# not silently turn this job green), or if a discovered suite ran 0 tests.
 set -euo pipefail
 
 # Keep the working tree clean: importing skill modules must not litter
@@ -40,7 +40,21 @@ for tests_dir in .claude/skills/*/tests; do
     echo "== unittest discover: $skill_dir =="
     # Tests inject their own sys.path for the skill's scripts/ package, so run
     # from the skill directory rather than the repo root.
-    if (cd "$skill_dir" && python3 -m unittest discover tests); then
+    status=0
+    out="$(cd "$skill_dir" && python3 -m unittest discover tests 2>&1)" || status=$?
+    printf '%s\n' "$out"
+    # A tests/ directory that merely exists is not proof of anything: unittest
+    # exits 0 when it discovers no tests at all (e.g. every test file was
+    # renamed, or the directory was emptied), which would turn this job green
+    # while verifying nothing. Require a positive "Ran N tests" line.
+    # Note the optional plural: unittest prints "Ran 1 test" (singular) for a
+    # single test, so `tests?` is required — `tests` alone would reject a
+    # suite that legitimately ran exactly one test.
+    if [ "$status" -eq 0 ] && ! printf '%s\n' "$out" | grep -qE '^Ran [1-9][0-9]* tests?'; then
+        echo "   ERROR: discovered 0 tests in $skill_dir"
+        status=1
+    fi
+    if [ "$status" -eq 0 ]; then
         echo "   OK"
     else
         echo "   FAILED: $skill_dir"


### PR DESCRIPTION
## 背景

#81 加了「找不到 `tests/` 目录就失败」的守卫，但**目录存在 ≠ 真的跑了测试**：

```
$ python3 -m unittest discover tests     # tests/ 是空目录
Ran 0 tests in 0.000s
OK                                        # ← Python 3.9 还打印 OK，退出码 0
```

所有测试文件被改名/删除时，这个 job 会**绿着通过但什么都没验证**。

## 改动

只动 `.github/scripts/run-skill-tests.sh`（+17/-3）：捕获每个 suite 的输出，要求出现
`Ran N tests` 且 N ≥ 1，否则判定失败。输出照常打印，日志仍能看到实际发生了什么。

⚠️ 正则必须接受单数：`tests?`

unittest 对**单个**测试打印 `Ran 1 test`（无 s）。我第一版写的 `tests`，用一个
1 测试的最小 fixture 跑出来直接误判为 0 —— 已修正并在注释里说明原因。

## 验证矩阵

| 场景 | Python | 结果 |
|---|---|---|
| 空 `tests/` 目录 | 3.9.6 | ✅ `ERROR: discovered 0 tests`，exit 1 |
| 空 `tests/` 目录 | 3.13.12 | ✅ `NO TESTS RAN`，非零退出 |
| 1 个测试的最小 fixture | 3.9.6 | ✅ `OK`，exit 0（**正是这条抓出单复数 bug**） |
| `origin/main` 的 `.claude` | 3.13.12 | ✅ `Ran 242 tests`，exit 0 |

`bash -n` 与 `git diff --check` 均通过。

本 PR 改动命中 skill-tests workflow 自身的 paths 过滤，因此 CI 会真跑一遍 py3.9 / py3.13。

## 关联

- 前序：#81（把 skill Python 测试接入 CI，已合并）
- 相关 issue：#79（#78 合并前修复与范围澄清）、#80（后续真实 SSH 长连接复用）
