### PR TITLE
feat(bridge): shared daemon installations (supersedes #76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- **`install.sh`** — shared/multi-user installer with `--system` (`/opt/virtuoso-cli`),
+  `--user` (`~/.local`), `--prefix DIR` and `--no-build`. Installs `vcli`/`vtui`/
+  `virtuoso-daemon` into `$PREFIX/bin` and `ramic_bridge.il` into
+  `$PREFIX/share/virtuoso-cli/` with `__DAEMON_PATH__` baked to the real daemon path,
+  so one shared install serves every user with zero per-user setup.
+
+### Fixed
+
+- **Daemon path resolution was split across two conflicting places.**
+  `_RBAutoStart()` unconditionally hardcoded `$HOME/.cargo/bin/virtuoso-daemon` and
+  silently overrode the top-level resolver — and therefore `RB_DAEMON_PATH`. Both now
+  call the new `RBResolveDaemonPath()`.
+- **`__DAEMON_PATH__` was a dead injection point.** `deploy_il_script()` substituted a
+  token that the shipped `ramic_bridge.il` no longer contained, so `vcli tunnel start`
+  uploaded the daemon while the bridge still looked under `~/.cargo/bin`. The token is
+  back in the bridge, so deploy-time path injection works again.
+
+### Changed
+
+- Daemon resolution is now an ordered search chain, first-existing-wins:
+  deploy-time `__DAEMON_PATH__` → `$RB_DAEMON_PATH` → `/opt/virtuoso-cli/bin`,
+  `/usr/local/bin` → `~/.local/bin`, `~/.cargo/bin`. Existing `cargo install` layouts
+  under `~/.cargo/bin` still work but are now the **lowest** priority: a shared install
+  wins over a per-user one. Set `RB_DAEMON_PATH` to force a specific binary.
+
 ## [1.3.4] - 2026-09-04
 
 CI green-up after the 1.3.3 IPC deadline work. The 1.3.3 release left the

--- a/README.md
+++ b/README.md
@@ -72,6 +72,41 @@ All binaries (`vcli`, `vtui`) are installed to `~/.cargo/bin/`.
 
 > **Note**: Do not name the binary `virtuoso` — it conflicts with Cadence's `virtuoso` executable.
 
+### Multi-user / shared install
+
+On a shared host you do **not** need to install the daemon under every user's
+`~/.cargo/bin`. Install once to a shared prefix and every user picks it up
+automatically:
+
+```bash
+# Build + install vcli/vtui/virtuoso-daemon + ramic_bridge.il to a shared prefix
+./install.sh --system                 # prefix /opt/virtuoso-cli (needs write perm)
+./install.sh --prefix /opt/eda/vcli   # or any prefix you choose
+./install.sh --user                   # per-user prefix ~/.local
+./install.sh --system --no-build      # skip cargo build, install existing target/release
+```
+
+`install.sh` installs the binaries to `$PREFIX/bin`, writes
+`ramic_bridge.il` to `$PREFIX/share/virtuoso-cli/` with the daemon path baked in,
+and prints the one line each user adds to their `~/.cdsinit` (or a site-wide
+`.cdsinit`):
+
+```skill
+load("$PREFIX/share/virtuoso-cli/ramic_bridge.il")
+```
+
+**How the daemon is resolved.** On `load`, the bridge finds `virtuoso-daemon`
+via an ordered search chain (first existing wins):
+
+1. `__DAEMON_PATH__` — a path baked in at deploy time by `install.sh` or
+   `vcli tunnel start` (arbitrary prefix, zero per-user config);
+2. `$RB_DAEMON_PATH` — explicit environment override;
+3. shared installs: `/opt/virtuoso-cli/bin`, `/usr/local/bin`;
+4. per-user installs: `~/.local/bin`, `~/.cargo/bin` (backward compatibility).
+
+A plain `cargo install` under `~/.cargo/bin` therefore keeps working with no
+changes; a shared `install.sh` deployment serves all users with none.
+
 ### System Dependencies
 
 The X11 GUI automation features (`vcli window action-x11`, `action-x11-batch`, `list-windows-x11`) and the `virtuoso-gui-debug` skill's local executor require the following tools on the Virtuoso host (the machine running the X11 display):
@@ -96,7 +131,7 @@ The X11 GUI automation features (`vcli window action-x11`, `action-x11-batch`, `
 load("/path/to/virtuoso-cli/resources/ramic_bridge.il")
 ```
 
-`load` automatically stops any existing daemon, resets the path to `~/.cargo/bin/virtuoso-daemon`, starts fresh, and prints the Ready banner — works for first load and for reloading after updates.
+`load` automatically stops any existing daemon, re-resolves the daemon binary via an ordered search chain (see [Multi-user / shared install](#multi-user--shared-install)), starts fresh, and prints the Ready banner — works for first load and for reloading after updates.
 
 Output:
 ```
@@ -301,7 +336,7 @@ vcli [--profile P] [--session S] [--format json|table]
 | `VB_CLIENT_ID` | `$VB_PROFILE` or `gethostname()` | Per-client remote scratch scoping (e.g. `vcli-A`, `vcli-B`); isolates `/tmp/virtuoso_bridge/<client>/` paths between concurrent operators |
 | `VCLI_CAPABILITY` | `user` | Set to `admin` to unlock `vcli skill broadcast` and raw SKILL exec |
 | `VB_TARGETS_FILE` | `~/.vcli/targets.yaml` | Explicit path to the targets config file (needed on Windows, where `HOME` is ignored for home-dir lookup) |
-| `RB_DAEMON_PATH` | auto-detected | Override daemon binary path |
+| `RB_DAEMON_PATH` | search chain | Override daemon binary path (checked before shared/per-user install locations; see [Multi-user / shared install](#multi-user--shared-install)) |
 
 ### SSH Remote Connection Setup
 
@@ -582,6 +617,39 @@ cargo install --path .
 
 > **注意**：不要将 CLI 命名为 `virtuoso`，与 Cadence Virtuoso 二进制名冲突。
 
+### 多用户 / 共享安装
+
+在共享主机上**无需**为每个用户都往其 `~/.cargo/bin` 装一份 daemon。装一次到共享
+前缀，所有用户即自动命中：
+
+```bash
+# 构建 + 安装 vcli/vtui/virtuoso-daemon + ramic_bridge.il 到共享前缀
+./install.sh --system                 # 前缀 /opt/virtuoso-cli（需写权限）
+./install.sh --prefix /opt/eda/vcli   # 或任意自选前缀
+./install.sh --user                   # 按用户前缀 ~/.local
+./install.sh --system --no-build      # 跳过 cargo build，装已有 target/release
+```
+
+`install.sh` 把二进制装到 `$PREFIX/bin`，把 `ramic_bridge.il` 写到
+`$PREFIX/share/virtuoso-cli/` 并将 daemon 路径烤入其中，最后打印每个用户加到
+`~/.cdsinit`（或站点级 `.cdsinit`）的一行：
+
+```skill
+load("$PREFIX/share/virtuoso-cli/ramic_bridge.il")
+```
+
+**daemon 如何解析**：`load` 时 bridge 通过有序搜索链找 `virtuoso-daemon`（第一个
+存在者胜出）：
+
+1. `__DAEMON_PATH__` —— `install.sh` 或 `vcli tunnel start` 在部署时烤入的路径
+   （任意前缀，零按用户配置）；
+2. `$RB_DAEMON_PATH` —— 显式环境变量覆盖；
+3. 共享安装：`/opt/virtuoso-cli/bin`、`/usr/local/bin`；
+4. 按用户安装：`~/.local/bin`、`~/.cargo/bin`（向后兼容）。
+
+因此普通 `cargo install` 装到 `~/.cargo/bin` 仍照旧可用；而共享 `install.sh`
+部署可零配置服务所有用户。
+
 ### 系统依赖
 
 X11 GUI 自动化功能（`vcli window action-x11`、`action-x11-batch`、`list-windows-x11`）以及 `virtuoso-gui-debug` 技能的 local 执行器，需要在 Virtuoso 所在主机（运行 X11 display 的机器）上安装以下工具：
@@ -606,7 +674,7 @@ X11 GUI 自动化功能（`vcli window action-x11`、`action-x11-batch`、`list-
 load("/path/to/virtuoso-cli/resources/ramic_bridge.il")
 ```
 
-`load` 会自动停止旧 daemon、将路径重置为 `~/.cargo/bin/virtuoso-daemon` 并重启，首次加载和更新后重载均适用。
+`load` 会自动停止旧 daemon、按有序搜索链重新解析 daemon 二进制（见[多用户 / 共享安装](#多用户--共享安装)）并重启，首次加载和更新后重载均适用。
 
 输出：
 ```
@@ -765,7 +833,7 @@ vcli [--profile P] [--session S] [--format json|table]
 | `VB_CLIENT_ID` | `$VB_PROFILE` 或 `gethostname()` | 每客户端远端 scratch 隔离标识（如 `vcli-A`、`vcli-B`）；隔离 `/tmp/virtuoso_bridge/<client>/` 路径，避免多操作员并发冲突 |
 | `VCLI_CAPABILITY` | `user` | 设为 `admin` 解锁 `vcli skill broadcast` 与原始 SKILL 执行权限 |
 | `VB_TARGETS_FILE` | `~/.vcli/targets.yaml` | targets 配置文件的显式路径（Windows 上 `HOME` 对 home 目录查找无效，必须用此变量） |
-| `RB_DAEMON_PATH` | 自动检测 | 覆盖 daemon 二进制路径 |
+| `RB_DAEMON_PATH` | 搜索链 | 覆盖 daemon 二进制路径（优先于共享/按用户安装位置检查；见[多用户 / 共享安装](#多用户--共享安装)） |
 
 ### SSH 远程连接配置
 

--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ NO_BUILD=0
 die() { printf 'install.sh: error: %s\n' "$*" >&2; exit 1; }
 
 usage() {
-    sed -n '3,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    sed -n '3,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
     exit "${1:-0}"
 }
 
@@ -100,9 +100,19 @@ for b in "${BINS[@]}"; do
 done
 
 printf '==> installing bridge (baking __DAEMON_PATH__ = %s)\n' "$DAEMON_BIN"
-# '|' delimiter: filesystem paths do not contain it.
-sed "s|__DAEMON_PATH__|$DAEMON_BIN|g" "$IL_SRC" > "$IL_DEST"
+# Bash's ${var//pat/repl} is a *literal* substitution: unlike sed it has no `&`
+# ("the whole match") magic and no delimiter, so a prefix containing `&`, `|`
+# or `\` — all legal in a Unix path — cannot corrupt the baked path.
+# The trailing `X` guard keeps any trailing newlines that $(...) would strip.
+IL_CONTENT="$(cat "$IL_SRC"; printf X)"
+IL_CONTENT="${IL_CONTENT%X}"
+printf '%s' "${IL_CONTENT//__DAEMON_PATH__/$DAEMON_BIN}" > "$IL_DEST"
 chmod 0644 "$IL_DEST"
+# Fail loudly if the token survived: a half-substituted bridge makes the
+# deploy-time injection silently no-op, which is exactly what this bakes.
+if grep -q '__DAEMON_PATH__' "$IL_DEST"; then
+    die "unresolved __DAEMON_PATH__ in $IL_DEST (prefix: $PREFIX)"
+fi
 printf '    %s\n' "$IL_DEST"
 
 # --- done -------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# install.sh — shared / multi-user installer for virtuoso-cli.
+#
+# Installs vcli, vtui and virtuoso-daemon to a shared or per-user prefix, and
+# installs ramic_bridge.il with the daemon path baked in (the __DAEMON_PATH__
+# token is substituted to $PREFIX/bin/virtuoso-daemon). One shared install then
+# serves every user on the host with zero per-user setup — each user only adds a
+# single load(...) line to their ~/.cdsinit.
+#
+# Usage:
+#   ./install.sh [--system | --user | --prefix DIR] [--no-build]
+#
+#   --system        install to /opt/virtuoso-cli   (shared; needs write perm)
+#   --user          install to ~/.local            (per-user; default)
+#   --prefix DIR    install to DIR                 (any prefix)
+#   --no-build      skip `cargo build`; install the existing target/release bins
+#   -h, --help      show this help
+#
+# Layout created:
+#   $PREFIX/bin/{vcli,vtui,virtuoso-daemon}
+#   $PREFIX/share/virtuoso-cli/ramic_bridge.il   (with __DAEMON_PATH__ resolved)
+
+set -euo pipefail
+
+# --- locate the repo (this script lives at the crate root) ------------------
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd -P)"
+IL_SRC="$SCRIPT_DIR/resources/ramic_bridge.il"
+TARGET_DIR="$SCRIPT_DIR/target/release"
+BINS=(vcli vtui virtuoso-daemon)
+
+# --- defaults ---------------------------------------------------------------
+PREFIX=""
+MODE=""          # system | user | prefix
+NO_BUILD=0
+
+die() { printf 'install.sh: error: %s\n' "$*" >&2; exit 1; }
+
+usage() {
+    sed -n '3,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit "${1:-0}"
+}
+
+# --- parse args -------------------------------------------------------------
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --system)      MODE="system" ;;
+        --user)        MODE="user" ;;
+        --prefix)      shift; [ $# -gt 0 ] || die "--prefix requires a directory argument"; PREFIX="$1"; MODE="prefix" ;;
+        --prefix=*)    PREFIX="${1#--prefix=}"; MODE="prefix" ;;
+        --no-build)    NO_BUILD=1 ;;
+        -h|--help)     usage 0 ;;
+        *)             die "unknown argument: $1 (try --help)" ;;
+    esac
+    shift
+done
+
+# --- resolve prefix ---------------------------------------------------------
+case "$MODE" in
+    system)  PREFIX="/opt/virtuoso-cli" ;;
+    user|"") PREFIX="${PREFIX:-$HOME/.local}"; MODE="${MODE:-user}" ;;
+    prefix)  [ -n "$PREFIX" ] || die "empty --prefix" ;;
+esac
+# Expand a leading ~ if the caller quoted it.
+case "$PREFIX" in "~"/*) PREFIX="$HOME/${PREFIX#~/}" ;; esac
+
+BIN_DIR="$PREFIX/bin"
+SHARE_DIR="$PREFIX/share/virtuoso-cli"
+DAEMON_BIN="$BIN_DIR/virtuoso-daemon"
+IL_DEST="$SHARE_DIR/ramic_bridge.il"
+
+printf '==> virtuoso-cli install\n'
+printf '    prefix : %s\n' "$PREFIX"
+printf '    binaries -> %s\n' "$BIN_DIR"
+printf '    bridge   -> %s\n' "$IL_DEST"
+
+# --- build ------------------------------------------------------------------
+if [ "$NO_BUILD" -eq 0 ]; then
+    command -v cargo >/dev/null 2>&1 || die "cargo not found in PATH; install Rust or pass --no-build"
+    printf '==> cargo build --release --features daemon\n'
+    ( cd "$SCRIPT_DIR" && cargo build --release --features daemon )
+else
+    printf '==> --no-build: using existing %s\n' "$TARGET_DIR"
+fi
+
+# --- verify build artifacts -------------------------------------------------
+for b in "${BINS[@]}"; do
+    [ -x "$TARGET_DIR/$b" ] || die "missing built binary: $TARGET_DIR/$b (run without --no-build, or build with: cargo build --release --features daemon)"
+done
+[ -f "$IL_SRC" ] || die "missing bridge script: $IL_SRC"
+grep -q '__DAEMON_PATH__' "$IL_SRC" || printf 'install.sh: warning: __DAEMON_PATH__ token not found in %s; the bridge will fall back to its search chain\n' "$IL_SRC" >&2
+
+# --- install ----------------------------------------------------------------
+mkdir -p "$BIN_DIR" "$SHARE_DIR" || die "cannot create $BIN_DIR / $SHARE_DIR (need sudo for a system prefix?)"
+
+printf '==> installing binaries\n'
+for b in "${BINS[@]}"; do
+    install -m 0755 "$TARGET_DIR/$b" "$BIN_DIR/$b"
+    printf '    %s\n' "$BIN_DIR/$b"
+done
+
+printf '==> installing bridge (baking __DAEMON_PATH__ = %s)\n' "$DAEMON_BIN"
+# '|' delimiter: filesystem paths do not contain it.
+sed "s|__DAEMON_PATH__|$DAEMON_BIN|g" "$IL_SRC" > "$IL_DEST"
+chmod 0644 "$IL_DEST"
+printf '    %s\n' "$IL_DEST"
+
+# --- done -------------------------------------------------------------------
+cat <<EOF
+
+==> Done. Each user adds this line to their ~/.cdsinit (or a site-wide .cdsinit):
+
+    load("$IL_DEST")
+
+If $BIN_DIR is not on PATH, add it (e.g. in ~/.bashrc):
+
+    export PATH="$BIN_DIR:\$PATH"
+
+Verify:
+
+    "$BIN_DIR/vcli" --version        # expect 1.3.4
+    "$DAEMON_BIN" --version          # expect 1.3.4
+EOF

--- a/resources/ramic_bridge.il
+++ b/resources/ramic_bridge.il
@@ -10,28 +10,51 @@
 ;RBD = RB Daemon
 ;RBM = RB Monitor
 
-; Daemon binary path: resolved at load-time, never hardcoded.
-; sh() returns t/nil (not stdout), so `which` cannot be used for path detection.
-; Priority: (1) RB_DAEMON_PATH env var, (2) ~/.cargo/bin/virtuoso-daemon.
-; Re-resolved on reload if previously empty or the file no longer exists.
-when(!boundp('RBDPath) || RBDPath == "" || RBDPath == nil || !isFile(RBDPath)
-    RBDPath = let((fromEnv cargoPath)
-        fromEnv = getShellEnvVar("RB_DAEMON_PATH")
-        if(fromEnv then
-            fromEnv
-        else
-            cargoPath = strcat(getShellEnvVar("HOME") "/.cargo/bin/virtuoso-daemon")
-            if(isFile(cargoPath) then
-                cargoPath
-            else
-                ""
-            )
+; Daemon binary path: resolved at load-time via an ordered search chain,
+; never hardcoded. sh() returns t/nil (not stdout), so `which` cannot be used
+; for path detection — candidates are probed with isFile() instead.
+; Search order (first existing wins):
+;   (1) __DAEMON_PATH__  deploy-time substitution (vcli tunnel start / install.sh)
+;   (2) RB_DAEMON_PATH   explicit env override
+;   (3) /opt/virtuoso-cli/bin, /usr/local/bin   shared multi-user installs
+;   (4) ~/.local/bin, ~/.cargo/bin              per-user installs (back-compat)
+; Multi-user friendly: one shared install (e.g. /opt/virtuoso-cli/bin) is found
+; by every user with zero per-user setup. Re-resolved on reload if previously
+; empty or the file no longer exists.
+procedure(RBResolveDaemonPath()
+    let((home deployPath envPath cand candidates result)
+        home = getShellEnvVar("HOME")
+        unless(home home = "")
+        result = ""
+        ; (1) Deploy-time substitution. `vcli tunnel start` and install.sh replace
+        ;     the __DAEMON_PATH__ token with an absolute path. When the .il is loaded
+        ;     directly the token stays literal, so isFile() is nil and it is skipped
+        ;     — no split-literal trick needed since it is never a real file.
+        deployPath = "__DAEMON_PATH__"
+        when(result == "" && isFile(deployPath) result = deployPath)
+        ; (2) Explicit env override (now actually honored — _RBAutoStart no longer
+        ;     clobbers it).
+        envPath = getShellEnvVar("RB_DAEMON_PATH")
+        when(result == "" && envPath && isFile(envPath) result = envPath)
+        ; (3)+(4) Shared installs first (multi-user), then per-user (compat).
+        candidates = list(
+            "/opt/virtuoso-cli/bin/virtuoso-daemon"
+            "/usr/local/bin/virtuoso-daemon"
+            strcat(home "/.local/bin/virtuoso-daemon")
+            strcat(home "/.cargo/bin/virtuoso-daemon")
         )
+        foreach(cand candidates
+            when(result == "" && isFile(cand) result = cand))
+        result
     )
 )
+when(!boundp('RBDPath) || RBDPath == "" || RBDPath == nil || !isFile(RBDPath)
+    RBDPath = RBResolveDaemonPath()
+)
 when(RBDPath == "" || RBDPath == nil
-    printf("[RAMIC Bridge] ERROR: virtuoso-daemon not found.\n")
-    printf("[RAMIC Bridge] Set RB_DAEMON_PATH or run: cargo install --path <repo> --bin virtuoso-daemon --features daemon\n")
+    printf("[RAMIC Bridge] ERROR: virtuoso-daemon not found in any known location.\n")
+    printf("[RAMIC Bridge] Searched (in order): deploy path, $RB_DAEMON_PATH, /opt/virtuoso-cli/bin, /usr/local/bin, ~/.local/bin, ~/.cargo/bin\n")
+    printf("[RAMIC Bridge] Fix: run install.sh (shared/multi-user), set RB_DAEMON_PATH, or cargo install --path <repo> --bin virtuoso-daemon --features daemon\n")
 )
 ; RBPython is no longer used (daemon is a standalone binary), kept for compatibility
 unless(boundp('RBPython) RBPython = "")
@@ -489,13 +512,14 @@ RBLoadedPackages = nil
 ; )
 
 ; ============================================================================
-; Auto-start on every load(): stop stale daemon, reset path, start fresh.
+; Auto-start on every load(): stop stale daemon, re-resolve daemon path via the
+; search chain (RBResolveDaemonPath), start fresh.
 ; Wrapped in a procedure so no intermediate return values echo in CIW.
 ; ============================================================================
 
 procedure(_RBAutoStart()
     RBPython = ""
-    RBDPath = strcat(getShellEnvVar("HOME") "/.cargo/bin/virtuoso-daemon")
+    RBDPath = RBResolveDaemonPath()
     ; No manual package loading needed — Virtuoso handles context loading internally.
     ; Manual loadi() calls caused "too many arguments" parser errors in IC25.
     when(boundp('RBIpc) && ipcIsAliveProcess(RBIpc) RBStop())


### PR DESCRIPTION
Carries **PR #76** (`fix(bridge): support shared daemon installations`, by @LXY-freshman) forward.

**Why a new PR rather than updating #76**

| #76 status | |
|---|---|
| CI | `gh pr checks 76` → **no checks reported** (zero verification) |
| Base | head sits on `609e060`, **15 commits behind `main`** — never compiled against the endpoint-pool/scheduler work from #78 |
| Head repo | `headRepository` resolves to `null` — the source branch cannot be pushed to |

CI only runs on `push: main` and `pull_request`, so a branch push alone would not verify anything. This PR re-applies the contribution on top of current `main` so it can actually be tested. **If @LXY-freshman updates #76 instead, close this one** — the authorship below is fully preserved.

**Carried over unchanged** (cherry-picked, author preserved)

- `97fb60d` `RBResolveDaemonPath()`: ordered search chain, and `_RBAutoStart()` no longer hardcodes `~/.cargo/bin` (which silently overrode `RB_DAEMON_PATH`).
- `dad43e6` `install.sh` for shared/multi-user deployment.
- `a9a3fac` README documentation (EN + 中文; one merge conflict resolved — kept `main`'s `VB_TARGETS_FILE` row alongside the updated `RB_DAEMON_PATH` row in both tables).

**Fixes added on top** (`bb7bb63`) — from the review on #76

1. **`install.sh` baked a corrupted path when the prefix contained `&`.** `sed`'s replacement treats `&` as "the whole match":
   ```console
   $ sed "s|__DAEMON_PATH__|/opt/a&b/virtuoso-daemon|g" <<< 'x = "__DAEMON_PATH__"'
   x = "/opt/a__DAEMON_PATH__b/virtuoso-daemon"
   ```
   The token was re-inserted instead of replaced, so `isFile()` is nil and the deploy-time injection — the thing this feature exists to restore — silently no-ops. `sed` still exits 0, so the script printed "Done" anyway. A `|` in the prefix aborted `sed` outright (the "paths do not contain `|`" comment was wrong).
   → Replaced with bash `${var//pat/repl}`, a literal substitution with no `&` magic and no delimiter. Byte-identical output to a correctly-escaped `sed` reference, trailing newlines preserved via an `X` guard.
2. **The placeholder guard checked the wrong file.** It grepped `$IL_SRC`, so it could never catch (1). → Now asserts on `$IL_DEST` and fails if the token survives.
3. **`--help` leaked raw shell code.** `usage()` read lines 3–28 but the header comment ends at 22, so it printed `set -euo pipefail` and `SCRIPT_DIR=...`. → `3,22p`.

Verified locally:

| Check | Result |
|---|---|
| `bash -n install.sh` | pass |
| `--prefix '/tmp/pfx&b'` | bakes `/tmp/pfx&b/bin/virtuoso-daemon` (was corrupted) |
| `--prefix '/tmp/pfx|c'` | bakes correctly (previously aborted `sed`) |
| `--prefix /tmp/pfx-plain` | unchanged, still correct |
| `--prefix /tmp/__DAEMON_PATH__` | guard fires: `error: unresolved __DAEMON_PATH__ in ...` |
| Output vs correctly-escaped `sed` reference | byte-identical (`diff` empty) |
| `--help` | ends at the last header line, no shell code |
| `git diff --check` | pass |

**Also added** (`0498e50`): a `## [Unreleased]` CHANGELOG entry. The contribution's own `chore(release): 1.3.4` commit was dropped — it duplicated upstream's `3461706 release: v1.3.4`, and the release version is the maintainer's call.

**Still open for the maintainer / contributor to decide** (raised on #76, not addressed here)

- The search chain probes `/opt/virtuoso-cli/bin` and `/usr/local/bin` **before** `~/.local/bin` and `~/.cargo/bin`, so a shared install shadows a user's own newer daemon — the version-skew case `src/commands/session.rs:257` warns about. `RB_DAEMON_PATH` remains the escape hatch and is documented.
- The execution trust boundary widens: resolution used to consult only user-controlled locations, and now probes shared system directories first. If `/usr/local/bin` is group-writable on a host, any user can plant a `virtuoso-daemon` that every other user's Virtuoso session will load. Not changed here since it is a design decision — worth a follow-up (README requirement that shared dirs be root-owned, or skipping world-writable candidates).

**Verified unaffected**: `resources/ramic_bridge.il` `; RB_VERSION: 1.3.4` still matches `Cargo.toml`, so the `ramic_bridge_version_stamp_matches_cargo_toml` guard stays green; `ramic_bridge_recovery_hint_strings_present` only asserts the window *after* `"is already running"`, which this PR does not touch; no Rust code changes.

Co-authored-by: LXY-freshman <57762866+LXY-freshman@users.noreply.github.com>
