### PR TITLE
feat(transport): reuse one live SSH connection per native transport (P1-2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ libc = "0.2"
 ratatui = "0.30"
 crossterm = "0.29"
 unicode-width = "0.2"
-tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "io-util"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "time", "io-util", "net", "sync"] }
 regex = "1"
 toml = "1.1"
 num_cpus = "1"
@@ -74,6 +74,9 @@ russh-sftp = { version = "2", optional = true }
 # half-written env while another test holds it. `#[serial]` covers both sides
 # with one mechanism.
 serial_test = "4"
+# In-process SSH server harness for native-transport behaviour tests (russh's
+# `PrivateKey::random` requires a rand 0.10 RNG).
+rand = { version = "0.10", features = ["thread_rng"] }
 
 [profile.release]
 lto = true

--- a/src/commands/maestro.rs
+++ b/src/commands/maestro.rs
@@ -2333,6 +2333,7 @@ mod tests {
 
     /// Build a valid staging tree (one regular file + one nested regular
     /// file) under the given staging root. Used by every publish test.
+    #[allow(dead_code)] // some feature/test combinations use inline literals instead
     fn make_nested_staging(staging: &Path) {
         std::fs::create_dir(staging.join("sub")).unwrap();
         std::fs::write(staging.join("top.txt"), b"TOP").unwrap();

--- a/src/transport/native.rs
+++ b/src/transport/native.rs
@@ -14,23 +14,28 @@
 //!   SFTP subsystem (design step 4) with an exec `cat` fallback for remotes
 //!   that do not advertise sftp, and directories keep tar-over-exec
 //!   (matching the OpenSSH backend);
-//! - ❌ connection pooling / channel scheduling — each operation reconnects
-//!   (the design's reuse requirement is step 4's daemon);
+//! - ✅ connection reuse (P1-2): one live SSH connection per transport,
+//!   established lazily and reused across operations; connection-level
+//!   failures clear the slot so the next operation re-establishes. Verified
+//!   by handshake count (not factory calls); the endpoint pool drives
+//!   generation/reconnect policy;
 //! - ❌ `ProxyJump` / jump-host routing, SOCKS5, RAMIC `direct-tcpip` forward,
 //!   agent/password/keyboard-interactive auth, and the IPC transport-daemon —
 //!   all later increments. Those paths return a clear `UnsupportedOperation`
 //!   rather than silently misbehaving.
 //!
-//! The contract methods are synchronous; russh is async. Each call spins up a
-//! fresh current-thread tokio runtime and `block_on`s the async work. That is
-//! deliberate: it keeps the async runtime entirely inside this module (never
-//! shared with the synchronous business layer) and avoids holding a `!Sync` russh
-//! session across a `&mut self` boundary.
+//! The contract methods are synchronous; russh is async. The module owns one
+//! current-thread tokio runtime per transport (kept in `SessionState`), and
+//! each operation `block_on`s its async work against the shared runtime while
+//! holding the session mutex. That keeps the async runtime entirely inside
+//! this module (never shared with the synchronous business layer) while the
+//! SSH connection itself survives across operations.
 
 #![cfg(feature = "native-ssh")]
 
 use std::path::{Path, PathBuf};
 use std::process::Command as SyncCommand;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -38,7 +43,6 @@ use base64::Engine;
 use russh::client::{self, Handler};
 use russh::keys::{load_secret_key, PrivateKeyWithHashAlg, PublicKeyOrCertificate};
 use russh::ChannelMsg;
-use russh::Disconnect;
 use sha2::{Digest, Sha256};
 use shlex;
 
@@ -375,55 +379,7 @@ fn establishment_seed() -> u64 {
     nanos ^ ((std::process::id() as u64) << 32)
 }
 
-/// Open an exec channel, optionally feed `stdin`, and drain stdout/stderr/status.
-async fn exec_command(
-    cfg: &NativeTransportConfig,
-    command: &str,
-    stdin: Option<Vec<u8>>,
-    deadline: Deadline,
-) -> Result<RawOutput, TransportError> {
-    let session = establish_with_retry(cfg, deadline).await?;
-    let mut channel = session
-        .channel_open_session()
-        .await
-        .map_err(map_russh_error)?;
-    channel
-        .exec(false, command.to_owned())
-        .await
-        .map_err(map_russh_error)?;
-    if let Some(data) = stdin {
-        channel.data_bytes(data).await.map_err(map_russh_error)?;
-        channel.eof().await.map_err(map_russh_error)?;
-    }
-
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    let mut exit_status: i32 = -1;
-    while let Some(msg) = channel.wait().await {
-        match msg {
-            ChannelMsg::Data { data } => stdout.extend_from_slice(&data),
-            ChannelMsg::ExtendedData { data, ext: 1 } => stderr.extend_from_slice(&data),
-            ChannelMsg::ExtendedData { .. } => {}
-            ChannelMsg::ExitStatus { exit_status: c } => exit_status = c as i32,
-            ChannelMsg::ExitSignal { .. } => exit_status = -1,
-            _ => {}
-        }
-    }
-    session
-        .disconnect(Disconnect::ByApplication, "", "English")
-        .await
-        .ok();
-    Ok(RawOutput {
-        stdout,
-        stderr,
-        exit_status,
-    })
-}
-
-/// 64 KiB SFTP write/read windows — small enough to stay beneath the SSH
-/// channel's max packet size while streaming large files without buffering
-/// them entirely in memory (design: "the daemon streams the local file
-/// itself", never the whole buffer across one frame).
+/// Upload window for the streaming SFTP write/read paths.
 const SFTP_CHUNK: usize = 64 * 1024;
 
 /// Whether an SFTP attempt failed because the remote did not advertise the
@@ -432,123 +388,6 @@ const SFTP_CHUNK: usize = 64 * 1024;
 /// transfer that directories already rely on.
 fn sftp_unavailable(e: &TransportError) -> bool {
     matches!(e, TransportError::UnsupportedOperation(_))
-}
-
-/// Establish a session and open the SFTP subsystem channel.
-///
-/// Returns the russh handle (kept alive for the duration of the file op) and a
-/// high-level [`SftpSession`]. A server that does not advertise sftp surfaces
-/// as [`TransportError::UnsupportedOperation`].
-async fn open_sftp(
-    cfg: &NativeTransportConfig,
-    deadline: Deadline,
-) -> Result<(client::Handle<NativeClientHandler>, SftpSession), TransportError> {
-    let session = establish_with_retry(cfg, deadline).await?;
-    let channel = session
-        .channel_open_session()
-        .await
-        .map_err(map_russh_error)?;
-    // A server that rejects the subsystem returns an error here; map it to
-    // `UnsupportedOperation` so the caller can fall back to exec transfer.
-    channel.request_subsystem(true, "sftp").await.map_err(|e| {
-        TransportError::UnsupportedOperation(format!(
-            "sftp subsystem unavailable on {}: {e}",
-            cfg.host
-        ))
-    })?;
-    let stream = channel.into_stream();
-    let sftp = SftpSession::new(stream).await.map_err(|e| {
-        TransportError::UnsupportedOperation(format!(
-            "sftp session init failed on {}: {e}",
-            cfg.host
-        ))
-    })?;
-    Ok((session, sftp))
-}
-
-/// Upload `data` to `remote` over the SFTP subsystem, streaming in 64 KiB
-/// windows. A missing sftp subsystem surfaces as `UnsupportedOperation`.
-async fn upload_via_sftp(
-    cfg: &NativeTransportConfig,
-    remote: &Path,
-    data: Vec<u8>,
-    deadline: Deadline,
-) -> Result<(), TransportError> {
-    let (_session, sftp) = open_sftp(cfg, deadline).await?;
-    let remote_str = remote.to_string_lossy().into_owned();
-    // Atomic upload: write to a staging file first, then rename into place.
-    // A failed upload leaves only the staging file (never a half-written target).
-    // Use a per-request UUID so concurrent uploads to the same target never
-    // share a staging file (PID alone is insufficient — same process can issue
-    // multiple concurrent transfers).
-    let staging = format!("{remote_str}.tmp.{}", uuid::Uuid::new_v4());
-    let mut file =
-        sftp.create(&staging)
-            .await
-            .map_err(|e| TransportError::TransferInterrupted {
-                request: RequestId::new(),
-                reason: format!("sftp create {staging}: {e}"),
-            })?;
-    sftp_write_all(&mut file, &data).await?;
-    drop(file);
-    // Atomic publish via exec `mv` — SFTP rename is not universally supported
-    // by all servers, and `mv` is atomic on the same filesystem.
-    let mv_cmd = format!(
-        "mv -f {src} {dst} && rm -f {src}",
-        src = shell_quote(&staging),
-        dst = shell_quote(&remote_str)
-    );
-    let mv_result = exec_command(cfg, &mv_cmd, None, deadline).await;
-    match mv_result {
-        Ok(r) if r.exit_status == 0 => Ok(()),
-        Ok(r) => {
-            // Best-effort cleanup of staging file on failure.
-            let _ = exec_command(
-                cfg,
-                &format!("rm -f {}", shell_quote(&staging)),
-                None,
-                deadline,
-            )
-            .await;
-            Err(TransportError::TransferInterrupted {
-                request: RequestId::new(),
-                reason: format!(
-                    "atomic rename failed: {}",
-                    String::from_utf8_lossy(&r.stderr)
-                ),
-            })
-        }
-        Err(e) => {
-            let _ = exec_command(
-                cfg,
-                &format!("rm -f {}", shell_quote(&staging)),
-                None,
-                deadline,
-            )
-            .await;
-            Err(e)
-        }
-    }
-}
-
-/// Download `remote` over the SFTP subsystem, streaming in 64 KiB windows into
-/// a local buffer. A missing sftp subsystem surfaces as `UnsupportedOperation`.
-async fn download_via_sftp(
-    cfg: &NativeTransportConfig,
-    remote: &Path,
-    deadline: Deadline,
-) -> Result<Vec<u8>, TransportError> {
-    let (_session, sftp) = open_sftp(cfg, deadline).await?;
-    let remote_str = remote.to_string_lossy().into_owned();
-    let mut file =
-        sftp.open(&remote_str)
-            .await
-            .map_err(|e| TransportError::TransferInterrupted {
-                request: RequestId::new(),
-                reason: format!("sftp open {remote_str}: {e}"),
-            })?;
-    let buf = sftp_read_all(&mut file).await?;
-    Ok(buf)
 }
 
 /// Stream `data` to an open SFTP `File` in [`SFTP_CHUNK`] windows and flush.
@@ -599,35 +438,49 @@ async fn sftp_read_all(file: &mut russh_sftp::client::fs::File) -> Result<Vec<u8
     Ok(buf)
 }
 
-/// Run `fut` on a fresh runtime, bounding it by `deadline`. A timeout surfaces as
-/// `ExecutionTimeout` carrying `req_id` (termination unproven — conservative).
-fn block_with_deadline<F, Fut, T>(
-    deadline: Deadline,
-    req_id: RequestId,
-    fut: F,
-) -> Result<T, TransportError>
-where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = Result<T, TransportError>>,
-{
-    let rt = make_runtime()?;
-    let span = deadline.remaining();
-    rt.block_on(async move {
-        match tokio::time::timeout(span, fut()).await {
-            Ok(r) => r,
-            Err(_) => Err(TransportError::ExecutionTimeout {
-                request: req_id,
-                after_secs: span.as_secs().max(1),
-                remote_terminated: false,
-            }),
-        }
-    })
+/// Shared state for the native transport's single live SSH connection.
+///
+/// P1-2 keeps the connection alive across operations instead of the step-3
+/// behaviour of establishing and disconnecting for every command. The russh
+/// handle lives here, protected by a mutex (russh's `Handle` is not `Clone` —
+/// its reply channel is a single consumer, so concurrent commands are
+/// serialised on this mutex). Connection-level failures clear the slot so the
+/// next operation re-establishes; the endpoint pool's generation guard
+/// decides whether the whole endpoint is replaced.
+struct SessionState {
+    inner: Mutex<Option<client::Handle<NativeClientHandler>>>,
+    runtime: tokio::runtime::Runtime,
+    /// Number of SSH connections ever established by this transport. Exposed
+    /// for tests and acceptance: "handshakes", not factory calls.
+    connections: AtomicU64,
 }
 
-/// The native transport: a resolved endpoint plus the sync bridge.
+impl std::fmt::Debug for SessionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionState")
+            .field("connections", &self.connections)
+            .field("runtime", &self.runtime)
+            .finish()
+    }
+}
+
+impl SessionState {
+    fn new() -> Result<Self, TransportError> {
+        Ok(Self {
+            inner: Mutex::new(None),
+            runtime: make_runtime()?,
+            connections: AtomicU64::new(0),
+        })
+    }
+}
+
+/// The native transport: a resolved endpoint plus a persistent SSH connection
+/// (established lazily, reused across operations until a connection-level
+/// failure clears it).
 #[derive(Clone, Debug)]
 pub struct NativeTransport {
     config: NativeTransportConfig,
+    session: Arc<SessionState>,
 }
 
 impl NativeTransport {
@@ -669,6 +522,7 @@ impl NativeTransport {
         let keepalive = KeepalivePolicy::from_config(config)?;
         let reconnect = ReconnectPolicy::from_config(config)?;
 
+        let session = Arc::new(SessionState::new()?);
         Ok(NativeTransport {
             config: NativeTransportConfig {
                 host,
@@ -681,7 +535,286 @@ impl NativeTransport {
                 keepalive,
                 reconnect,
             },
+            session,
         })
+    }
+
+    /// Serialise an operation on the single live SSH connection: lock, ensure a
+    /// session (establishing lazily), run `f` against the shared runtime, and
+    /// clear the connection on a connection-level failure so the next
+    /// operation re-establishes. `f` receives the session handle, the module
+    /// runtime and the remaining deadline, and drives its own async work with
+    /// `block_on` (a `timeout` around it preserves the deadline contract).
+    fn with_session<T>(
+        &self,
+        deadline: Deadline,
+        req_id: &RequestId,
+        f: impl FnOnce(
+            &mut client::Handle<NativeClientHandler>,
+            &tokio::runtime::Runtime,
+            Duration,
+        ) -> Result<T, TransportError>,
+    ) -> Result<T, TransportError> {
+        let mut guard = self.session.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if deadline.is_expired() {
+            return Err(TransportError::QueueTimeout {
+                request: req_id.clone(),
+                after_secs: 0,
+            });
+        }
+        if guard.as_ref().is_none_or(|h| h.is_closed()) {
+            let established = self
+                .session
+                .runtime
+                .block_on(establish_with_retry(&self.config, deadline))?;
+            self.session.connections.fetch_add(1, Ordering::Relaxed);
+            *guard = Some(established);
+        }
+        let remaining = deadline.remaining();
+        let rt = &self.session.runtime;
+        let result = f(guard.as_mut().expect("session"), rt, remaining);
+        if matches!(&result, Err(e) if FailureClass::of(e) == FailureClass::Transient) {
+            *guard = None;
+        }
+        result
+    }
+
+    /// Run `command` on the persistent SSH connection, reusing the live
+    /// session when present. The channel is closed after the command; the
+    /// connection itself is kept for the next operation.
+    fn exec_command(
+        &self,
+        command: &str,
+        stdin: Option<Vec<u8>>,
+        deadline: Deadline,
+        req_id: &RequestId,
+    ) -> Result<RawOutput, TransportError> {
+        let cmd = command.to_owned();
+        self.with_session(deadline, req_id, move |session, rt, remaining| {
+            rt.block_on(async move {
+                tokio::time::timeout(remaining, async move {
+                    let mut channel = session
+                        .channel_open_session()
+                        .await
+                        .map_err(map_russh_error)?;
+                    channel.exec(false, cmd).await.map_err(map_russh_error)?;
+                    if let Some(data) = stdin {
+                        channel.data_bytes(data).await.map_err(map_russh_error)?;
+                        channel.eof().await.map_err(map_russh_error)?;
+                    }
+                    let mut stdout = Vec::new();
+                    let mut stderr = Vec::new();
+                    let mut exit_status: i32 = -1;
+                    while let Some(msg) = channel.wait().await {
+                        match msg {
+                            ChannelMsg::Data { data } => stdout.extend_from_slice(&data),
+                            ChannelMsg::ExtendedData { data, ext: 1 } => {
+                                stderr.extend_from_slice(&data)
+                            }
+                            ChannelMsg::ExtendedData { .. } => {}
+                            ChannelMsg::ExitStatus { exit_status: c } => exit_status = c as i32,
+                            ChannelMsg::ExitSignal { .. } => exit_status = -1,
+                            _ => {}
+                        }
+                    }
+                    Ok(RawOutput {
+                        stdout,
+                        stderr,
+                        exit_status,
+                    })
+                })
+                .await
+                .map_err(|_| TransportError::ExecutionTimeout {
+                    request: req_id.clone(),
+                    after_secs: remaining.as_secs().max(1),
+                    remote_terminated: false,
+                })?
+            })
+        })
+    }
+
+    /// Open the SFTP subsystem on the persistent connection. The SSH
+    /// connection is reused; only a fresh SFTP channel is opened per call.
+    fn open_sftp(
+        &self,
+        deadline: Deadline,
+        req_id: &RequestId,
+    ) -> Result<SftpSession, TransportError> {
+        self.with_session(deadline, req_id, move |session, rt, remaining| {
+            rt.block_on(async move {
+                tokio::time::timeout(remaining, async move {
+                    let channel = session
+                        .channel_open_session()
+                        .await
+                        .map_err(map_russh_error)?;
+                    channel.request_subsystem(true, "sftp").await.map_err(|e| {
+                        TransportError::UnsupportedOperation(format!(
+                            "sftp subsystem unavailable: {e}"
+                        ))
+                    })?;
+                    let stream = channel.into_stream();
+                    let sftp = SftpSession::new(stream).await.map_err(|e| {
+                        TransportError::UnsupportedOperation(format!(
+                            "sftp session init failed: {e}"
+                        ))
+                    })?;
+                    Ok(sftp)
+                })
+                .await
+                .map_err(|_| TransportError::ExecutionTimeout {
+                    request: req_id.clone(),
+                    after_secs: remaining.as_secs().max(1),
+                    remote_terminated: false,
+                })?
+            })
+        })
+    }
+
+    /// Upload `data` to `remote` over the SFTP subsystem on the persistent
+    /// connection, streaming in 64 KiB windows. A missing sftp subsystem
+    /// surfaces as `UnsupportedOperation` so the caller can fall back to the
+    /// exec `cat` pipe.
+    fn upload_via_sftp(
+        &self,
+        remote: &Path,
+        data: Vec<u8>,
+        deadline: Deadline,
+        req_id: &RequestId,
+    ) -> Result<(), TransportError> {
+        if deadline.is_expired() {
+            return Err(TransportError::QueueTimeout {
+                request: req_id.clone(),
+                after_secs: 0,
+            });
+        }
+        let sftp = self.open_sftp(deadline, req_id)?;
+        let remaining = deadline.remaining();
+        let remote_str = remote.to_string_lossy().into_owned();
+        // Atomic upload: write to a staging file first, then rename into place.
+        // A failed upload leaves only the staging file (never a half-written
+        // target). Per-request UUID so concurrent uploads to the same target
+        // never share a staging file.
+        let staging = format!("{remote_str}.tmp.{}", uuid::Uuid::new_v4());
+        let staging_name = staging.clone();
+        let rt = &self.session.runtime;
+        let staged: Result<(), TransportError> = rt.block_on(async move {
+            tokio::time::timeout(remaining, async move {
+                let mut file = sftp.create(&staging_name).await.map_err(|e| {
+                    TransportError::TransferInterrupted {
+                        request: req_id.clone(),
+                        reason: format!("sftp create {staging_name}: {e}"),
+                    }
+                })?;
+                sftp_write_all(&mut file, &data).await?;
+                drop(file);
+                Ok(())
+            })
+            .await
+            .map_err(|_| TransportError::ExecutionTimeout {
+                request: req_id.clone(),
+                after_secs: remaining.as_secs().max(1),
+                remote_terminated: false,
+            })?
+        });
+        staged?;
+        // Atomic publish via exec `mv` — SFTP rename is not universally
+        // supported, and `mv` is atomic on the same filesystem.
+        let mv_cmd = format!(
+            "mv -f {src} {dst} && rm -f {src}",
+            src = shell_quote(&staging),
+            dst = shell_quote(&remote_str)
+        );
+        let mv_result = self.exec_command(&mv_cmd, None, deadline, req_id);
+        match mv_result {
+            Ok(r) if r.exit_status == 0 => Ok(()),
+            Ok(r) => {
+                let _ = self.exec_command(
+                    &format!("rm -f {}", shell_quote(&staging)),
+                    None,
+                    deadline,
+                    req_id,
+                );
+                Err(TransportError::TransferInterrupted {
+                    request: req_id.clone(),
+                    reason: format!(
+                        "atomic rename failed: {}",
+                        String::from_utf8_lossy(&r.stderr)
+                    ),
+                })
+            }
+            Err(e) => {
+                let _ = self.exec_command(
+                    &format!("rm -f {}", shell_quote(&staging)),
+                    None,
+                    deadline,
+                    req_id,
+                );
+                Err(e)
+            }
+        }
+    }
+
+    /// Download `remote` over the SFTP subsystem on the persistent connection,
+    /// streaming in 64 KiB windows into a local buffer. A missing sftp
+    /// subsystem surfaces as `UnsupportedOperation`.
+    fn download_via_sftp(
+        &self,
+        remote: &Path,
+        deadline: Deadline,
+        req_id: &RequestId,
+    ) -> Result<Vec<u8>, TransportError> {
+        if deadline.is_expired() {
+            return Err(TransportError::QueueTimeout {
+                request: req_id.clone(),
+                after_secs: 0,
+            });
+        }
+        let sftp = self.open_sftp(deadline, req_id)?;
+        let remaining = deadline.remaining();
+        let remote_str = remote.to_string_lossy().into_owned();
+        let rt = &self.session.runtime;
+        let fetched: Result<Vec<u8>, TransportError> = rt.block_on(async move {
+            tokio::time::timeout(remaining, async move {
+                let mut file = sftp.open(&remote_str).await.map_err(|e| {
+                    TransportError::TransferInterrupted {
+                        request: req_id.clone(),
+                        reason: format!("sftp open {remote_str}: {e}"),
+                    }
+                })?;
+                sftp_read_all(&mut file).await
+            })
+            .await
+            .map_err(|_| TransportError::ExecutionTimeout {
+                request: req_id.clone(),
+                after_secs: remaining.as_secs().max(1),
+                remote_terminated: false,
+            })?
+        });
+        fetched
+    }
+}
+
+impl Drop for NativeTransport {
+    fn drop(&mut self) {
+        // Only the last clone of a transport tears the shared connection down;
+        // an earlier clone must be able to keep using it.
+        if Arc::strong_count(&self.session) > 1 {
+            return;
+        }
+        if let Some(session) = self
+            .session
+            .inner
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .take()
+        {
+            let rt = &self.session.runtime;
+            rt.block_on(async move {
+                let _ = session
+                    .disconnect(russh::Disconnect::ByApplication, "", "English")
+                    .await;
+            });
+        }
     }
 }
 
@@ -693,24 +826,21 @@ impl RemoteTransport for NativeTransport {
                 after_secs: 0,
             });
         }
-        let cfg = self.config.clone();
-        block_with_deadline(deadline, RequestId::new(), move || async move {
-            // test_connection is an explicit idempotent probe, so re-establishing
-            // the path within the deadline is allowed here.
-            match establish_with_retry(&cfg, deadline).await {
-                Ok(_) => Ok(true),
-                // A connection-level failure means the host is not reachable;
-                // host-key / auth failures are real errors, not "unreachable".
-                Err(e) => match e {
-                    TransportError::ConnectionFailed(_)
-                    | TransportError::HostKeyUnknown { .. }
-                    | TransportError::HostKeyChanged { .. }
-                    | TransportError::HostKeyPolicyUnsupported(_)
-                    | TransportError::AuthenticationFailed(_) => Err(e),
-                    _ => Ok(false),
-                },
-            }
-        })
+        let req_id = RequestId::new();
+        // test_connection is an explicit idempotent probe: reuse the persistent
+        // connection (establishing lazily) or report a real failure. Host-key /
+        // auth failures are real errors, not "unreachable".
+        match self.with_session(deadline, &req_id, |_, _, _| Ok(true)) {
+            Ok(_) => Ok(true),
+            Err(e) => match e {
+                TransportError::ConnectionFailed(_)
+                | TransportError::HostKeyUnknown { .. }
+                | TransportError::HostKeyChanged { .. }
+                | TransportError::HostKeyPolicyUnsupported(_)
+                | TransportError::AuthenticationFailed(_) => Err(e),
+                _ => Ok(false),
+            },
+        }
     }
 
     fn run_command(&self, req: &CommandRequest) -> Result<CommandResult, TransportError> {
@@ -720,18 +850,13 @@ impl RemoteTransport for NativeTransport {
                 after_secs: 0,
             });
         }
-        let cfg = self.config.clone();
-        let cmd = req.command.clone();
-        let req_id = req.id.clone();
-        block_with_deadline(req.deadline, req_id, move || async move {
-            let raw = exec_command(&cfg, &cmd, None, req.deadline).await?;
-            Ok(CommandResult {
-                exit_status: raw.exit_status,
-                stdout: String::from_utf8_lossy(&raw.stdout).into_owned(),
-                stderr: String::from_utf8_lossy(&raw.stderr).into_owned(),
-                success: raw.exit_status == 0,
-                duration: Duration::ZERO,
-            })
+        let raw = self.exec_command(&req.command, None, req.deadline, &req.id)?;
+        Ok(CommandResult {
+            exit_status: raw.exit_status,
+            stdout: String::from_utf8_lossy(&raw.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&raw.stderr).into_owned(),
+            success: raw.exit_status == 0,
+            duration: Duration::ZERO,
         })
     }
 
@@ -742,66 +867,57 @@ impl RemoteTransport for NativeTransport {
                 after_secs: 0,
             });
         }
-        let cfg = self.config.clone();
-        let local = req.local.clone();
-        let remote = req.remote.clone();
-        let req_id = req.id.clone();
-        block_with_deadline(req.deadline, req_id, move || async move {
-            let bytes = std::fs::read(&local)
-                .map_err(|e| TransportError::LocalIo(format!("read {}: {e}", local.display())))?;
-            // Single files stream over the SFTP subsystem (design step 4). Where
-            // the remote does not advertise sftp, fall back to the exec `cat`
-            // pipe that directories already rely on.
-            // Clone for the SFTP attempt; the exec fallback still needs the
-            // original bytes if the remote lacks the sftp subsystem.
-            match upload_via_sftp(&cfg, Path::new(&remote), bytes.clone(), req.deadline).await {
-                Ok(()) => Ok(()),
-                Err(e) if sftp_unavailable(&e) => {
-                    // Atomic upload via exec: write to staging file, then mv.
-                    let staging = format!("{remote}.tmp.{}", uuid::Uuid::new_v4());
-                    let cmd = format!("cat > {}", shell_quote(&staging));
-                    let raw = exec_command(&cfg, &cmd, Some(bytes), req.deadline).await?;
-                    if raw.exit_status != 0 {
-                        let _ = exec_command(
-                            &cfg,
-                            &format!("rm -f {}", shell_quote(&staging)),
-                            None,
-                            req.deadline,
-                        )
-                        .await;
-                        return Err(TransportError::TransferInterrupted {
-                            request: req.id.clone(),
-                            reason: String::from_utf8_lossy(&raw.stderr).into_owned(),
-                        });
-                    }
-                    // Atomic publish.
-                    let mv_cmd = format!(
-                        "mv -f {src} {dst} && rm -f {src}",
-                        src = shell_quote(&staging),
-                        dst = shell_quote(&remote)
+        let bytes = std::fs::read(&req.local)
+            .map_err(|e| TransportError::LocalIo(format!("read {}: {e}", req.local.display())))?;
+        // Single files stream over the SFTP subsystem (design step 4). Where
+        // the remote does not advertise sftp, fall back to the exec `cat` pipe
+        // that directories already rely on. Clone for the SFTP attempt; the
+        // exec fallback still needs the original bytes.
+        match self.upload_via_sftp(Path::new(&req.remote), bytes.clone(), req.deadline, &req.id) {
+            Ok(()) => Ok(()),
+            Err(e) if sftp_unavailable(&e) => {
+                // Atomic upload via exec: write to staging file, then mv.
+                let staging = format!("{}.tmp.{}", req.remote, uuid::Uuid::new_v4());
+                let cmd = format!("cat > {}", shell_quote(&staging));
+                let raw = self.exec_command(&cmd, Some(bytes), req.deadline, &req.id)?;
+                if raw.exit_status != 0 {
+                    let _ = self.exec_command(
+                        &format!("rm -f {}", shell_quote(&staging)),
+                        None,
+                        req.deadline,
+                        &req.id,
                     );
-                    let mv_raw = exec_command(&cfg, &mv_cmd, None, req.deadline).await?;
-                    if mv_raw.exit_status != 0 {
-                        let _ = exec_command(
-                            &cfg,
-                            &format!("rm -f {}", shell_quote(&staging)),
-                            None,
-                            req.deadline,
-                        )
-                        .await;
-                        return Err(TransportError::TransferInterrupted {
-                            request: req.id.clone(),
-                            reason: format!(
-                                "atomic rename failed: {}",
-                                String::from_utf8_lossy(&mv_raw.stderr)
-                            ),
-                        });
-                    }
-                    Ok(())
+                    return Err(TransportError::TransferInterrupted {
+                        request: req.id.clone(),
+                        reason: String::from_utf8_lossy(&raw.stderr).into_owned(),
+                    });
                 }
-                Err(e) => Err(e),
+                // Atomic publish.
+                let mv_cmd = format!(
+                    "mv -f {src} {dst} && rm -f {src}",
+                    src = shell_quote(&staging),
+                    dst = shell_quote(&req.remote)
+                );
+                let mv_raw = self.exec_command(&mv_cmd, None, req.deadline, &req.id)?;
+                if mv_raw.exit_status != 0 {
+                    let _ = self.exec_command(
+                        &format!("rm -f {}", shell_quote(&staging)),
+                        None,
+                        req.deadline,
+                        &req.id,
+                    );
+                    return Err(TransportError::TransferInterrupted {
+                        request: req.id.clone(),
+                        reason: format!(
+                            "atomic rename failed: {}",
+                            String::from_utf8_lossy(&mv_raw.stderr)
+                        ),
+                    });
+                }
+                Ok(())
             }
-        })
+            Err(e) => Err(e),
+        }
     }
 
     fn upload_text(&self, req: &UploadTextRequest) -> Result<(), TransportError> {
@@ -811,52 +927,45 @@ impl RemoteTransport for NativeTransport {
                 after_secs: 0,
             });
         }
-        let cfg = self.config.clone();
         let bytes = req.text.clone().into_bytes();
-        let remote = req.remote.clone();
-        let req_id = req.id.clone();
-        block_with_deadline(req.deadline, req_id, move || async move {
-            // Atomic upload: write to staging, then mv into place.
-            let staging = format!("{remote}.tmp.{}", uuid::Uuid::new_v4());
-            let cmd = format!("cat > {}", shell_quote(&staging));
-            let raw = exec_command(&cfg, &cmd, Some(bytes), req.deadline).await?;
-            if raw.exit_status != 0 {
-                let _ = exec_command(
-                    &cfg,
-                    &format!("rm -f {}", shell_quote(&staging)),
-                    None,
-                    req.deadline,
-                )
-                .await;
-                return Err(TransportError::TransferInterrupted {
-                    request: req.id.clone(),
-                    reason: String::from_utf8_lossy(&raw.stderr).into_owned(),
-                });
-            }
-            let mv_cmd = format!(
-                "mv -f {src} {dst} && rm -f {src}",
-                src = shell_quote(&staging),
-                dst = shell_quote(&remote)
+        // Atomic upload: write to staging, then mv into place.
+        let staging = format!("{}.tmp.{}", req.remote, uuid::Uuid::new_v4());
+        let cmd = format!("cat > {}", shell_quote(&staging));
+        let raw = self.exec_command(&cmd, Some(bytes), req.deadline, &req.id)?;
+        if raw.exit_status != 0 {
+            let _ = self.exec_command(
+                &format!("rm -f {}", shell_quote(&staging)),
+                None,
+                req.deadline,
+                &req.id,
             );
-            let mv_raw = exec_command(&cfg, &mv_cmd, None, req.deadline).await?;
-            if mv_raw.exit_status != 0 {
-                let _ = exec_command(
-                    &cfg,
-                    &format!("rm -f {}", shell_quote(&staging)),
-                    None,
-                    req.deadline,
-                )
-                .await;
-                return Err(TransportError::TransferInterrupted {
-                    request: req.id.clone(),
-                    reason: format!(
-                        "atomic rename failed: {}",
-                        String::from_utf8_lossy(&mv_raw.stderr)
-                    ),
-                });
-            }
-            Ok(())
-        })
+            return Err(TransportError::TransferInterrupted {
+                request: req.id.clone(),
+                reason: String::from_utf8_lossy(&raw.stderr).into_owned(),
+            });
+        }
+        let mv_cmd = format!(
+            "mv -f {src} {dst} && rm -f {src}",
+            src = shell_quote(&staging),
+            dst = shell_quote(&req.remote)
+        );
+        let mv_raw = self.exec_command(&mv_cmd, None, req.deadline, &req.id)?;
+        if mv_raw.exit_status != 0 {
+            let _ = self.exec_command(
+                &format!("rm -f {}", shell_quote(&staging)),
+                None,
+                req.deadline,
+                &req.id,
+            );
+            return Err(TransportError::TransferInterrupted {
+                request: req.id.clone(),
+                reason: format!(
+                    "atomic rename failed: {}",
+                    String::from_utf8_lossy(&mv_raw.stderr)
+                ),
+            });
+        }
+        Ok(())
     }
 
     fn download_file(&self, req: &DownloadFileRequest) -> Result<(), TransportError> {
@@ -866,20 +975,13 @@ impl RemoteTransport for NativeTransport {
                 after_secs: 0,
             });
         }
-        let cfg = self.config.clone();
-        let remote = req.remote.clone();
-        let local = req.local.clone();
-        let req_id = req.id.clone();
-        block_with_deadline(req.deadline, req_id, move || async move {
-            // Atomic download: write to a local staging file, then rename.
-            // A failed download never leaves a half-written target file.
-            // Use a per-request UUID so concurrent downloads to the same target
-            // never share a staging file.
-            let local_staging = format!("{}.tmp.{}", local.display(), uuid::Uuid::new_v4());
-            let local_staging_path = std::path::PathBuf::from(&local_staging);
+        // Atomic download: write to a local staging file, then rename.
+        // A failed download never leaves a half-written target file.
+        let local_staging = format!("{}.tmp.{}", req.local.display(), uuid::Uuid::new_v4());
+        let local_staging_path = std::path::PathBuf::from(&local_staging);
 
-            let write_result = match download_via_sftp(&cfg, Path::new(&remote), req.deadline).await
-            {
+        let write_result =
+            match self.download_via_sftp(Path::new(&req.remote), req.deadline, &req.id) {
                 Ok(bytes) => {
                     std::fs::write(&local_staging_path, &bytes).map_err(|e| {
                         TransportError::LocalIo(format!("write {}: {e}", local_staging))
@@ -887,8 +989,8 @@ impl RemoteTransport for NativeTransport {
                     Ok(())
                 }
                 Err(e) if sftp_unavailable(&e) => {
-                    let cmd = format!("cat {}", shell_quote(&remote));
-                    let raw = exec_command(&cfg, &cmd, None, req.deadline).await?;
+                    let cmd = format!("cat {}", shell_quote(&req.remote));
+                    let raw = self.exec_command(&cmd, None, req.deadline, &req.id)?;
                     if raw.exit_status != 0 {
                         let _ = std::fs::remove_file(&local_staging_path);
                         return Err(TransportError::TransferInterrupted {
@@ -904,25 +1006,24 @@ impl RemoteTransport for NativeTransport {
                 Err(e) => Err(e),
             };
 
-            match write_result {
-                Ok(()) => {
-                    // Atomic publish: rename staging to target.
-                    std::fs::rename(&local_staging_path, &local).map_err(|e| {
-                        let _ = std::fs::remove_file(&local_staging_path);
-                        TransportError::LocalIo(format!(
-                            "atomic rename {} -> {}: {e}",
-                            local_staging,
-                            local.display()
-                        ))
-                    })?;
-                    Ok(())
-                }
-                Err(e) => {
+        match write_result {
+            Ok(()) => {
+                // Atomic publish: rename staging to target.
+                std::fs::rename(&local_staging_path, &req.local).map_err(|e| {
                     let _ = std::fs::remove_file(&local_staging_path);
-                    Err(e)
-                }
+                    TransportError::LocalIo(format!(
+                        "atomic rename {} -> {}: {e}",
+                        local_staging,
+                        req.local.display()
+                    ))
+                })?;
+                Ok(())
             }
-        })
+            Err(e) => {
+                let _ = std::fs::remove_file(&local_staging_path);
+                Err(e)
+            }
+        }
     }
 
     fn download_dir(&self, req: &DownloadDirRequest) -> Result<(), TransportError> {
@@ -932,45 +1033,41 @@ impl RemoteTransport for NativeTransport {
                 after_secs: 0,
             });
         }
-        let cfg = self.config.clone();
-        let remote = req.remote.clone();
-        let local = req.local.clone();
-        let req_id = req.id.clone();
-        block_with_deadline(req.deadline, req_id, move || async move {
-            let cmd = format!("tar -cf - -C {} .", shell_quote(&remote));
-            let raw = exec_command(&cfg, &cmd, None, req.deadline).await?;
-            if raw.exit_status != 0 {
-                return Err(TransportError::TransferInterrupted {
-                    request: req.id.clone(),
-                    reason: String::from_utf8_lossy(&raw.stderr).into_owned(),
-                });
-            }
-            std::fs::create_dir_all(&local)
-                .map_err(|e| TransportError::LocalIo(format!("create {}: {e}", local.display())))?;
-            // Untar locally. The remote side already produced the tar stream, so
-            // the local `tar` requirement mirrors the OpenSSH backend's remote
-            // `tar` requirement (no extra remote toolchain divergence).
-            let tmp = local.join(format!(".vcli-dl-{}.tar", std::process::id()));
-            std::fs::write(&tmp, &raw.stdout)
-                .map_err(|e| TransportError::LocalIo(format!("stage tar: {e}")))?;
-            let status = SyncCommand::new("tar")
-                .arg("-xf")
-                .arg(&tmp)
-                .arg("-C")
-                .arg(&local)
-                .status();
-            let _ = std::fs::remove_file(&tmp);
-            match status {
-                Ok(s) if s.success() => Ok(()),
-                Ok(s) => Err(TransportError::TransferInterrupted {
-                    request: req.id.clone(),
-                    reason: format!("local tar exited with {s}"),
-                }),
-                Err(e) => Err(TransportError::LocalIo(format!(
-                    "failed to run local tar (required for download_dir): {e}"
-                ))),
-            }
-        })
+        let cmd = format!("tar -cf - -C {} .", shell_quote(&req.remote));
+        let raw = self.exec_command(&cmd, None, req.deadline, &req.id)?;
+        if raw.exit_status != 0 {
+            return Err(TransportError::TransferInterrupted {
+                request: req.id.clone(),
+                reason: String::from_utf8_lossy(&raw.stderr).into_owned(),
+            });
+        }
+        std::fs::create_dir_all(&req.local)
+            .map_err(|e| TransportError::LocalIo(format!("create {}: {e}", req.local.display())))?;
+        // Untar locally. The remote side already produced the tar stream, so
+        // the local `tar` requirement mirrors the OpenSSH backend's remote
+        // `tar` requirement (no extra remote toolchain divergence).
+        let tmp = req
+            .local
+            .join(format!(".vcli-dl-{}.tar", std::process::id()));
+        std::fs::write(&tmp, &raw.stdout)
+            .map_err(|e| TransportError::LocalIo(format!("stage tar: {e}")))?;
+        let status = SyncCommand::new("tar")
+            .arg("-xf")
+            .arg(&tmp)
+            .arg("-C")
+            .arg(&req.local)
+            .status();
+        let _ = std::fs::remove_file(&tmp);
+        match status {
+            Ok(s) if s.success() => Ok(()),
+            Ok(s) => Err(TransportError::TransferInterrupted {
+                request: req.id.clone(),
+                reason: format!("local tar exited with {s}"),
+            }),
+            Err(e) => Err(TransportError::LocalIo(format!(
+                "failed to run local tar (required for download_dir): {e}"
+            ))),
+        }
     }
 }
 
@@ -1012,6 +1109,33 @@ mod tests {
             transport_daemon_socket: None,
             transport_daemon_token: None,
         }
+    }
+
+    #[test]
+    fn transport_reuses_the_session_slot_between_operations() {
+        // P1-2 acceptance at the unit level: one transport owns one live
+        // session slot plus a handshake counter, and every clone shares it
+        // (the pool clones transports). Actual handshake reuse is verified
+        // end-to-end by the native-pool probe against a real host — this
+        // locks the structure that makes that reuse possible.
+        let t = NativeTransport::from_config(&cfg_with("h", Some("/tmp/k"), None))
+            .expect("from_config builds without a jump host");
+        assert_eq!(
+            t.session.connections.load(Ordering::Relaxed),
+            0,
+            "no SSH connection has been established yet"
+        );
+        let t2 = t.clone();
+        assert!(
+            Arc::ptr_eq(&t.session, &t2.session),
+            "clones must share one SessionState (one live connection)"
+        );
+        assert_eq!(t2.session.connections.load(Ordering::Relaxed), 0);
+        // The slot starts empty: the first operation establishes lazily.
+        assert!(
+            t.session.inner.lock().unwrap().is_none(),
+            "connection must be lazy (nothing established at construction)"
+        );
     }
 
     #[test]
@@ -1331,9 +1455,12 @@ mod tests {
         // rather than silently attempting a single-hop connection. The guard
         // returns before any russh connect, so no network is touched.
         let rt = make_runtime().expect("runtime");
+        // The transport owns a tokio runtime (SessionState); construct it
+        // outside the test's block_on so dropping it happens on a plain
+        // thread, not inside an async context (tokio rejects that).
+        let t = NativeTransport::from_config(&cfg_with("h", Some("/tmp/k"), Some("jump")))
+            .expect("from_config accepts a jump host (deferred, not rejected at construction)");
         rt.block_on(async {
-            let t = NativeTransport::from_config(&cfg_with("h", Some("/tmp/k"), Some("jump")))
-                .expect("from_config accepts a jump host (deferred, not rejected at construction)");
             let err = establish(&t.config).await;
             assert!(
                 matches!(err, Err(TransportError::UnsupportedOperation(_))),

--- a/src/transport/native.rs
+++ b/src/transport/native.rs
@@ -25,11 +25,15 @@
 //!   rather than silently misbehaving.
 //!
 //! The contract methods are synchronous; russh is async. The module owns one
-//! current-thread tokio runtime per transport (kept in `SessionState`), and
-//! each operation `block_on`s its async work against the shared runtime while
-//! holding the session mutex. That keeps the async runtime entirely inside
-//! this module (never shared with the synchronous business layer) while the
-//! SSH connection itself survives across operations.
+//! multi-thread tokio runtime per transport (kept in `SessionState`) so the
+//! russh session task — including its keepalive loop — keeps running even
+//! between operations. Each operation drives its async work through
+//! `block_on` against that shared runtime. The session handle is guarded only
+//! while a channel is being opened; once the channel exists it is independent
+//! of the handle, so concurrent commands run on separate channels without
+//! serialising. Waiting for the handle, establishing the connection (connect +
+//! auth + reconnect retries) and the operation itself all share the request's
+//! deadline budget.
 
 #![cfg(feature = "native-ssh")]
 
@@ -38,6 +42,7 @@ use std::process::Command as SyncCommand;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::sync::Mutex as AsyncMutex;
 
 use base64::Engine;
 use russh::client::{self, Handler};
@@ -214,9 +219,13 @@ fn map_russh_error(e: russh::Error) -> TransportError {
     }
 }
 
-/// A fresh current-thread runtime for one synchronous call into russh.
+/// A fresh multi-thread runtime for the native transport. The worker threads
+/// keep the russh session task — and its keepalive probe loop — running even
+/// when no operation is in flight; a current-thread runtime would suspend the
+/// whole connection between `block_on` calls, making keepalive and liveness
+/// detection unreliable.
 fn make_runtime() -> Result<tokio::runtime::Runtime, TransportError> {
-    tokio::runtime::Builder::new_current_thread()
+    tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .map_err(|e| TransportError::LocalIo(format!("failed to start async runtime: {e}")))
@@ -442,14 +451,21 @@ async fn sftp_read_all(file: &mut russh_sftp::client::fs::File) -> Result<Vec<u8
 ///
 /// P1-2 keeps the connection alive across operations instead of the step-3
 /// behaviour of establishing and disconnecting for every command. The russh
-/// handle lives here, protected by a mutex (russh's `Handle` is not `Clone` —
-/// its reply channel is a single consumer, so concurrent commands are
-/// serialised on this mutex). Connection-level failures clear the slot so the
-/// next operation re-establishes; the endpoint pool's generation guard
-/// decides whether the whole endpoint is replaced.
+/// handle lives here in a `(generation, handle)` pair: opening a channel only
+/// borrows the handle briefly (russh's `channel_open_session` takes `&self`),
+/// so once a channel exists the lock is released and independent channels run
+/// concurrently. `generation` is bumped on every (re)establishment so a late
+/// connection-level failure from a stale request can never evict a
+/// replacement built concurrently — eviction matches the generation it
+/// started with. Connection-level failures still clear the slot so the next
+/// operation re-establishes; the endpoint pool's generation guard decides
+/// whether the whole endpoint is replaced.
 struct SessionState {
-    inner: Mutex<Option<client::Handle<NativeClientHandler>>>,
+    inner: AsyncMutex<Option<(u64, client::Handle<NativeClientHandler>)>>,
     runtime: tokio::runtime::Runtime,
+    /// Monotonic connection generation: incremented on every establishment.
+    /// Stale requests compare against it before clearing the slot.
+    epoch: AtomicU64,
     /// Number of SSH connections ever established by this transport. Exposed
     /// for tests and acceptance: "handshakes", not factory calls.
     connections: AtomicU64,
@@ -467,8 +483,9 @@ impl std::fmt::Debug for SessionState {
 impl SessionState {
     fn new() -> Result<Self, TransportError> {
         Ok(Self {
-            inner: Mutex::new(None),
+            inner: AsyncMutex::new(None),
             runtime: make_runtime()?,
+            epoch: AtomicU64::new(0),
             connections: AtomicU64::new(0),
         })
     }
@@ -539,42 +556,77 @@ impl NativeTransport {
         })
     }
 
-    /// Serialise an operation on the single live SSH connection: lock, ensure a
-    /// session (establishing lazily), run `f` against the shared runtime, and
-    /// clear the connection on a connection-level failure so the next
-    /// operation re-establishes. `f` receives the session handle, the module
-    /// runtime and the remaining deadline, and drives its own async work with
-    /// `block_on` (a `timeout` around it preserves the deadline contract).
-    fn with_session<T>(
+    /// Open a session channel on the live SSH connection and run `f` on it.
+    ///
+    /// Locking, establishment and channel-open all share the request's
+    /// deadline: waiting for the handle (a concurrent command's short
+    /// critical section), connecting + authenticating (with reconnect
+    /// retries) and the server confirming the channel cannot overrun the
+    /// budget. The handle lock is released as soon as the channel exists —
+    /// russh channels are independent once opened — so concurrent commands
+    /// run on separate channels instead of serialising on the handle.
+    /// Connection-level failures from `f` clear the slot, but only when it
+    /// still holds the same generation this call started with, so a late
+    /// failure from a stale request never evicts a replacement connection.
+    fn with_channel<T>(
         &self,
         deadline: Deadline,
         req_id: &RequestId,
         f: impl FnOnce(
-            &mut client::Handle<NativeClientHandler>,
+            russh::Channel<russh::client::Msg>,
             &tokio::runtime::Runtime,
             Duration,
         ) -> Result<T, TransportError>,
     ) -> Result<T, TransportError> {
-        let mut guard = self.session.inner.lock().unwrap_or_else(|e| e.into_inner());
         if deadline.is_expired() {
             return Err(TransportError::QueueTimeout {
                 request: req_id.clone(),
                 after_secs: 0,
             });
         }
-        if guard.as_ref().is_none_or(|h| h.is_closed()) {
-            let established = self
-                .session
-                .runtime
-                .block_on(establish_with_retry(&self.config, deadline))?;
-            self.session.connections.fetch_add(1, Ordering::Relaxed);
-            *guard = Some(established);
-        }
-        let remaining = deadline.remaining();
         let rt = &self.session.runtime;
-        let result = f(guard.as_mut().expect("session"), rt, remaining);
+        let (epoch, channel) = {
+            let remaining = deadline.remaining();
+            rt.block_on(async move {
+                tokio::time::timeout(remaining, async move {
+                    // Lock wait, establishment and channel-open all consume
+                    // the request's remaining budget (P1-2 / P1-3).
+                    let mut guard = self.session.inner.lock().await;
+                    if guard.as_ref().is_none_or(|(_, h)| h.is_closed()) {
+                        let established = establish_with_retry(&self.config, deadline).await?;
+                        self.session.connections.fetch_add(1, Ordering::Relaxed);
+                        let epoch = self.session.epoch.fetch_add(1, Ordering::Relaxed) + 1;
+                        *guard = Some((epoch, established));
+                    }
+                    let (epoch, handle) = guard.as_ref().expect("session");
+                    let channel = handle
+                        .channel_open_session()
+                        .await
+                        .map_err(map_russh_error)?;
+                    Ok::<(u64, russh::Channel<russh::client::Msg>), TransportError>((
+                        *epoch, channel,
+                    ))
+                })
+                .await
+                .map_err(|_| TransportError::ExecutionTimeout {
+                    request: req_id.clone(),
+                    after_secs: remaining.as_secs().max(1),
+                    remote_terminated: false,
+                })?
+            })?
+        };
+        // The handle lock was released above: the channel is independent, so
+        // another command can open its own channel and run concurrently.
+        let result = f(channel, rt, deadline.remaining());
         if matches!(&result, Err(e) if FailureClass::of(e) == FailureClass::Transient) {
-            *guard = None;
+            // Generation-matched eviction: never drop a replacement built by
+            // a concurrent request after our connection died.
+            rt.block_on(async move {
+                let mut guard = self.session.inner.lock().await;
+                if guard.as_ref().map(|(e, _)| *e) == Some(epoch) {
+                    *guard = None;
+                }
+            });
         }
         result
     }
@@ -590,13 +642,10 @@ impl NativeTransport {
         req_id: &RequestId,
     ) -> Result<RawOutput, TransportError> {
         let cmd = command.to_owned();
-        self.with_session(deadline, req_id, move |session, rt, remaining| {
+        self.with_channel(deadline, req_id, move |channel, rt, remaining| {
             rt.block_on(async move {
                 tokio::time::timeout(remaining, async move {
-                    let mut channel = session
-                        .channel_open_session()
-                        .await
-                        .map_err(map_russh_error)?;
+                    let mut channel = channel;
                     channel.exec(false, cmd).await.map_err(map_russh_error)?;
                     if let Some(data) = stdin {
                         channel.data_bytes(data).await.map_err(map_russh_error)?;
@@ -640,13 +689,9 @@ impl NativeTransport {
         deadline: Deadline,
         req_id: &RequestId,
     ) -> Result<SftpSession, TransportError> {
-        self.with_session(deadline, req_id, move |session, rt, remaining| {
+        self.with_channel(deadline, req_id, move |channel, rt, remaining| {
             rt.block_on(async move {
                 tokio::time::timeout(remaining, async move {
-                    let channel = session
-                        .channel_open_session()
-                        .await
-                        .map_err(map_russh_error)?;
                     channel.request_subsystem(true, "sftp").await.map_err(|e| {
                         TransportError::UnsupportedOperation(format!(
                             "sftp subsystem unavailable: {e}"
@@ -801,13 +846,7 @@ impl Drop for NativeTransport {
         if Arc::strong_count(&self.session) > 1 {
             return;
         }
-        if let Some(session) = self
-            .session
-            .inner
-            .lock()
-            .unwrap_or_else(|e| e.into_inner())
-            .take()
-        {
+        if let Some((_, session)) = self.session.inner.blocking_lock().take() {
             let rt = &self.session.runtime;
             rt.block_on(async move {
                 let _ = session
@@ -827,19 +866,89 @@ impl RemoteTransport for NativeTransport {
             });
         }
         let req_id = RequestId::new();
-        // test_connection is an explicit idempotent probe: reuse the persistent
-        // connection (establishing lazily) or report a real failure. Host-key /
-        // auth failures are real errors, not "unreachable".
-        match self.with_session(deadline, &req_id, |_, _, _| Ok(true)) {
-            Ok(_) => Ok(true),
-            Err(e) => match e {
-                TransportError::ConnectionFailed(_)
-                | TransportError::HostKeyUnknown { .. }
-                | TransportError::HostKeyChanged { .. }
-                | TransportError::HostKeyPolicyUnsupported(_)
-                | TransportError::AuthenticationFailed(_) => Err(e),
-                _ => Ok(false),
-            },
+        let rt = &self.session.runtime;
+        // test_connection is an explicit liveness probe. If a session already
+        // exists it is probed in place (an SSH ping/pong) and, when the remote
+        // has gone away, reported unhealthy — never silently re-established,
+        // so callers can observe the disconnect. Only when no session exists
+        // yet does the probe establish one, as a reachability check. Host-key
+        // / auth failures are real errors, not "unreachable".
+        let (epoch, probe): (u64, Result<(), TransportError>) = {
+            let remaining = deadline.remaining();
+            rt.block_on(async move {
+                tokio::time::timeout(remaining, async move {
+                    let mut guard = self.session.inner.lock().await;
+                    match guard.as_ref() {
+                        // No session yet: this is the reachability case, so
+                        // establish (lazily) and ping the fresh handle.
+                        None => {
+                            let established = establish_with_retry(&self.config, deadline).await?;
+                            self.session.connections.fetch_add(1, Ordering::Relaxed);
+                            let epoch = self.session.epoch.fetch_add(1, Ordering::Relaxed) + 1;
+                            *guard = Some((epoch, established));
+                        }
+                        // Session ended: evict it and report unavailable. Do
+                        // not reconnect — the caller must observe the break.
+                        Some((_, handle)) if handle.is_closed() => {
+                            *guard = None;
+                            return Ok::<(u64, Result<(), TransportError>), TransportError>((
+                                0,
+                                Err(TransportError::ConnectionFailed(
+                                    "session closed since last use".into(),
+                                )),
+                            ));
+                        }
+                        Some(_) => {}
+                    }
+                    let (epoch, handle) = guard.as_ref().expect("session");
+                    let ping = handle.send_ping().await.map_err(map_russh_error);
+                    let probe = match ping {
+                        Ok(()) => {
+                            // russh's send_ping resolves its reply channel even
+                            // when the session is tearing down; only a session
+                            // that is still open proves the remote answered.
+                            if handle.is_closed() {
+                                Err(TransportError::ConnectionFailed(
+                                    "session closed during liveness probe".into(),
+                                ))
+                            } else {
+                                Ok(())
+                            }
+                        }
+                        Err(e) => Err(e),
+                    };
+                    Ok::<(u64, Result<(), TransportError>), TransportError>((*epoch, probe))
+                })
+                .await
+                .map_err(|_| TransportError::ExecutionTimeout {
+                    request: req_id.clone(),
+                    after_secs: remaining.as_secs().max(1),
+                    remote_terminated: false,
+                })?
+            })?
+        };
+        match probe {
+            Ok(()) => Ok(true),
+            Err(e) => {
+                if FailureClass::of(&e) == FailureClass::Transient {
+                    // Generation-matched eviction: a stale request's failure
+                    // must not drop a replacement connection.
+                    rt.block_on(async move {
+                        let mut guard = self.session.inner.lock().await;
+                        if guard.as_ref().map(|(g, _)| *g) == Some(epoch) {
+                            *guard = None;
+                        }
+                    });
+                }
+                match e {
+                    TransportError::ConnectionFailed(_)
+                    | TransportError::HostKeyUnknown { .. }
+                    | TransportError::HostKeyChanged { .. }
+                    | TransportError::HostKeyPolicyUnsupported(_)
+                    | TransportError::AuthenticationFailed(_) => Err(e),
+                    _ => Ok(false),
+                }
+            }
         }
     }
 
@@ -1075,6 +1184,8 @@ impl RemoteTransport for NativeTransport {
 mod tests {
     use super::*;
     use crate::transport::contract::test_support::shared_contract_suite;
+    use russh::server::{self, Auth, Session};
+    use tokio::sync::oneshot;
 
     fn cfg_with(host: &str, key: Option<&str>, jump: Option<&str>) -> Config {
         Config {
@@ -1133,7 +1244,7 @@ mod tests {
         assert_eq!(t2.session.connections.load(Ordering::Relaxed), 0);
         // The slot starts empty: the first operation establishes lazily.
         assert!(
-            t.session.inner.lock().unwrap().is_none(),
+            t.session.inner.blocking_lock().is_none(),
             "connection must be lazy (nothing established at construction)"
         );
     }
@@ -1496,6 +1607,375 @@ mod tests {
                 Err(TransportError::UnsupportedOperation(_))
             ),
             "stop_local_forward must be UnsupportedOperation on the native backend"
+        );
+    }
+
+    // ===== In-process SSH server harness =====
+    //
+    // These tests drive the real native transport against an in-process russh
+    // SSH server, so the behaviour assertions — connection reuse, concurrent
+    // channels, deadline-bounded lock waits, establishment timeouts and
+    // liveness probes — run against actual SSH wire traffic, not mocks.
+
+    #[derive(Clone, Default)]
+    struct ServerBehavior {
+        /// Delay the exec reply when the command equals this (key, delay) pair.
+        exec_delay_for: Option<(String, Duration)>,
+        /// Never complete authentication: connection establishment hangs.
+        hold_auth: bool,
+        /// Reply to every exec with this payload and exit status 0.
+        exec_reply: Option<Vec<u8>>,
+        /// Disconnect the session when an exec whose command equals this
+        /// arrives (simulates the remote going away mid-use).
+        disconnect_on_exec: Option<String>,
+    }
+
+    #[derive(Clone)]
+    struct TestHandler {
+        behavior: Arc<ServerBehavior>,
+    }
+
+    impl server::Handler for TestHandler {
+        type Error = russh::Error;
+
+        async fn auth_none(&mut self, _user: &str) -> Result<Auth, Self::Error> {
+            if self.behavior.hold_auth {
+                return std::future::pending::<Result<Auth, Self::Error>>().await;
+            }
+            Ok(Auth::reject())
+        }
+
+        async fn auth_publickey(
+            &mut self,
+            _user: &str,
+            _key: &russh::keys::PublicKey,
+        ) -> Result<Auth, Self::Error> {
+            if self.behavior.hold_auth {
+                return std::future::pending::<Result<Auth, Self::Error>>().await;
+            }
+            Ok(Auth::Accept)
+        }
+
+        async fn channel_open_session(
+            &mut self,
+            _channel: russh::Channel<russh::server::Msg>,
+            reply: server::ChannelOpenHandle,
+            _session: &mut Session,
+        ) -> Result<(), Self::Error> {
+            reply.accept().await;
+            Ok(())
+        }
+
+        async fn exec_request(
+            &mut self,
+            channel: russh::ChannelId,
+            data: &[u8],
+            session: &mut Session,
+        ) -> Result<(), Self::Error> {
+            let cmd = String::from_utf8_lossy(data).to_string();
+            if self
+                .behavior
+                .disconnect_on_exec
+                .as_ref()
+                .is_some_and(|needle| needle == &cmd)
+            {
+                session.disconnect(russh::Disconnect::ByApplication, "test shutdown", "")?;
+                return Ok(());
+            }
+            if let Some((needle, delay)) = &self.behavior.exec_delay_for {
+                if cmd == *needle {
+                    tokio::time::sleep(*delay).await;
+                }
+            }
+            match &self.behavior.exec_reply {
+                Some(payload) => {
+                    session.data(channel, payload.clone())?;
+                    session.exit_status_request(channel, 0)?;
+                    session.eof(channel)?;
+                    session.close(channel)?;
+                    Ok(())
+                }
+                None => std::future::pending::<Result<(), Self::Error>>().await,
+            }
+        }
+    }
+
+    impl Drop for TestServer {
+        fn drop(&mut self) {
+            self.stop();
+        }
+    }
+
+    struct TestServer {
+        port: u16,
+        pub_key: russh::keys::PublicKey,
+        shutdown_tx: Option<oneshot::Sender<()>>,
+        _runtime: tokio::runtime::Runtime,
+    }
+
+    impl TestServer {
+        fn start(behavior: ServerBehavior) -> Self {
+            let server_key =
+                russh::keys::PrivateKey::random(&mut rand::rng(), russh::keys::Algorithm::Ed25519)
+                    .expect("generate server ed25519 key");
+            let pub_key = server_key.public_key().clone();
+            let runtime = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .expect("server runtime");
+            let (port_tx, port_rx) = oneshot::channel();
+            let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+            let behavior = Arc::new(behavior);
+            runtime.spawn(async move {
+                let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
+                    .await
+                    .expect("bind test server");
+                let port = listener.local_addr().unwrap().port();
+                let _ = port_tx.send(port);
+                let config = Arc::new(server::Config {
+                    keys: vec![server_key],
+                    ..Default::default()
+                });
+                let mut sessions = Vec::new();
+                loop {
+                    tokio::select! {
+                        _ = &mut shutdown_rx => break,
+                        accepted = listener.accept() => {
+                            let (stream, _) = accepted.expect("accept client");
+                            let cfg = Arc::clone(&config);
+                            let bh = Arc::clone(&behavior);
+                            sessions.push(tokio::spawn(async move {
+                                let _ = server::run_stream(cfg, stream, TestHandler { behavior: bh })
+                                    .await;
+                            }));
+                        }
+                    }
+                }
+                drop(listener);
+                for s in sessions {
+                    s.abort();
+                }
+            });
+            let port = port_rx.blocking_recv().expect("test server port");
+            TestServer {
+                port,
+                pub_key: pub_key.clone(),
+                shutdown_tx: Some(shutdown_tx),
+                _runtime: runtime,
+            }
+        }
+
+        fn stop(&mut self) {
+            if let Some(tx) = self.shutdown_tx.take() {
+                let _ = tx.send(());
+            }
+        }
+    }
+
+    fn dl(secs: u64) -> Deadline {
+        Deadline::from_now(Duration::from_secs(secs))
+    }
+
+    /// Build a `NativeTransport` pointed at the in-process server, with a
+    /// freshly generated client identity and a known_hosts entry trusting the
+    /// server key. Returns the transport plus the temp dir that keeps the
+    /// client key file alive.
+    fn test_transport(
+        server: &TestServer,
+        keepalive: Duration,
+        keepalive_failures: u32,
+    ) -> (NativeTransport, tempfile::TempDir) {
+        let dir = tempfile::TempDir::new().expect("temp dir");
+        let key_path = dir.path().join("client_ed25519");
+        let client_key =
+            russh::keys::PrivateKey::random(&mut rand::rng(), russh::keys::Algorithm::Ed25519)
+                .expect("generate client ed25519 key");
+        let openssh = client_key
+            .to_openssh(russh::keys::ssh_key::LineEnding::LF)
+            .expect("encode client key");
+        std::fs::write(&key_path, openssh.as_bytes()).expect("write client key");
+
+        let mut kh = KnownHosts::memory();
+        let b64 = base64::engine::general_purpose::STANDARD
+            .encode(server.pub_key.to_bytes().expect("encode server host key"));
+        kh.trust("127.0.0.1", Some(server.port), &KeyType::SshEd25519, &b64)
+            .expect("trust server host key");
+
+        let session = Arc::new(SessionState::new().expect("session state"));
+        let t = NativeTransport {
+            config: NativeTransportConfig {
+                host: "127.0.0.1".into(),
+                user: Some("test".into()),
+                ssh_port: server.port,
+                jump_host: None,
+                key_path: Some(key_path),
+                known_hosts: vec![kh],
+                connect_timeout: Duration::from_secs(10),
+                keepalive: KeepalivePolicy {
+                    interval: keepalive,
+                    max_failures: keepalive_failures,
+                },
+                reconnect: ReconnectPolicy {
+                    max_attempts: 2,
+                    max_delay: Duration::from_secs(1),
+                    base: Duration::from_millis(50),
+                },
+            },
+            session,
+        };
+        (t, dir)
+    }
+
+    /// Real handshake reuse across sequential operations on one transport:
+    /// three operations, exactly one SSH connection.
+    #[test]
+    fn native_reuses_one_live_connection_across_operations() {
+        let server = TestServer::start(ServerBehavior {
+            exec_reply: Some(b"ok".to_vec()),
+            ..Default::default()
+        });
+        let (t, _dir) = test_transport(&server, Duration::from_secs(30), 3);
+        let rid = RequestId::new();
+        let r1 = t
+            .exec_command("echo", None, dl(10), &rid)
+            .expect("first exec");
+        assert_eq!(r1.stdout, b"ok");
+        let r2 = t
+            .exec_command("echo", None, dl(10), &rid)
+            .expect("second exec");
+        assert_eq!(r2.stdout, b"ok");
+        assert!(
+            t.test_connection(dl(10)).expect("liveness probe"),
+            "probe must succeed while the server is up"
+        );
+        assert_eq!(
+            t.session.connections.load(Ordering::Relaxed),
+            1,
+            "three operations must share exactly one real SSH connection"
+        );
+    }
+
+    /// P1-2 concurrency: a slow command on one channel must not block a fast
+    /// command — each operation opens its own channel and the handle lock is
+    /// released as soon as the channel exists.
+    #[test]
+    fn concurrent_commands_run_on_independent_channels() {
+        let server = TestServer::start(ServerBehavior {
+            exec_delay_for: Some(("slow".to_string(), Duration::from_millis(600))),
+            exec_reply: Some(b"ok".to_vec()),
+            ..Default::default()
+        });
+        let (t, _dir) = test_transport(&server, Duration::from_secs(30), 3);
+        let rid = RequestId::new();
+        t.exec_command("warm", None, dl(10), &rid).expect("warmup");
+        let slow_rid = rid.clone();
+        let slow = {
+            let t = t.clone();
+            std::thread::spawn(move || t.exec_command("slow", None, dl(10), &slow_rid))
+        };
+        // Give the slow command time to open its channel and start sleeping on
+        // the server, then run a fast command on a second channel.
+        std::thread::sleep(Duration::from_millis(150));
+        let started = std::time::Instant::now();
+        let fast = t
+            .exec_command("fast", None, dl(10), &rid)
+            .expect("fast exec");
+        let fast_elapsed = started.elapsed();
+        assert_eq!(fast.stdout, b"ok");
+        assert!(
+            fast_elapsed < Duration::from_millis(500),
+            "fast command must not wait for the slow command's channel (got {fast_elapsed:?})"
+        );
+        let slow_out = slow.join().expect("slow thread").expect("slow exec");
+        assert_eq!(slow_out.stdout, b"ok");
+        assert_eq!(
+            t.session.connections.load(Ordering::Relaxed),
+            1,
+            "both channels must share one connection"
+        );
+    }
+
+    /// P1-2 lock wait + P1-3 establishment budget: while one request is stuck
+    /// establishing (holding the handle lock), a second request with a short
+    /// deadline must return within its own budget instead of waiting for the
+    /// first to finish.
+    #[test]
+    fn lock_wait_and_establishment_respect_the_request_deadline() {
+        let server = TestServer::start(ServerBehavior {
+            hold_auth: true,
+            ..Default::default()
+        });
+        let (t, _dir) = test_transport(&server, Duration::from_secs(30), 3);
+        let rid = RequestId::new();
+        let stuck_rid = rid.clone();
+        let stuck = {
+            let t = t.clone();
+            std::thread::spawn(move || t.exec_command("a", None, dl(10), &stuck_rid))
+        };
+        std::thread::sleep(Duration::from_millis(300));
+        let started = std::time::Instant::now();
+        let short = t.exec_command("b", None, dl(1), &rid);
+        let elapsed = started.elapsed();
+        assert!(
+            elapsed < Duration::from_secs(2),
+            "waiting for the handle must be bounded by the request deadline (got {elapsed:?})"
+        );
+        assert!(
+            short.is_err(),
+            "establishment hangs under hold_auth, so the short request must time out"
+        );
+        let _ = stuck.join().expect("stuck thread");
+    }
+
+    /// P1-1 liveness: after the remote goes away, test_connection must stop
+    /// reporting healthy — the probe is a real ping/pong, not a cached
+    /// success based on the handle existing.
+    #[test]
+    fn test_connection_reports_unhealthy_after_remote_disconnect() {
+        let server = TestServer::start(ServerBehavior {
+            exec_reply: Some(b"ok".to_vec()),
+            disconnect_on_exec: Some("die".into()),
+            ..Default::default()
+        });
+        let (t, _dir) = test_transport(&server, Duration::from_secs(30), 3);
+        let rid = RequestId::new();
+        t.exec_command("warm", None, dl(10), &rid).expect("warmup");
+        assert!(
+            t.test_connection(dl(10)).expect("healthy probe"),
+            "probe is healthy while the server is up"
+        );
+        // The remote tears the session down mid-use; the exec fails, and the
+        // liveness probe afterwards must not report healthy.
+        let _ = t.exec_command("die", None, dl(5), &rid);
+        std::thread::sleep(Duration::from_millis(800));
+        let probe = t.test_connection(dl(3));
+        assert!(
+            probe != Ok(true),
+            "probe after remote disconnect must not report healthy: {probe:?}"
+        );
+    }
+
+    /// P1-1 background liveness: the shared multi-thread runtime keeps the
+    /// connection alive across an idle gap (longer than a short keepalive
+    /// interval would be) — no reconnect happens and the next probe succeeds.
+    #[test]
+    fn idle_connection_stays_alive_on_the_multi_thread_runtime() {
+        let server = TestServer::start(ServerBehavior {
+            exec_reply: Some(b"ok".to_vec()),
+            ..Default::default()
+        });
+        let (t, _dir) = test_transport(&server, Duration::from_secs(30), 3);
+        let rid = RequestId::new();
+        t.exec_command("warm", None, dl(10), &rid).expect("warmup");
+        std::thread::sleep(Duration::from_secs(2));
+        assert!(
+            t.test_connection(dl(5)).expect("probe after idle"),
+            "connection must stay usable after an idle gap"
+        );
+        assert_eq!(
+            t.session.connections.load(Ordering::Relaxed),
+            1,
+            "no reconnect: the idle connection was kept alive"
         );
     }
 }

--- a/src/transport/native.rs
+++ b/src/transport/native.rs
@@ -2216,19 +2216,31 @@ mod tests {
             exec_reply: Some(b"ok".to_vec()),
             ..Default::default()
         });
-        // 500 ms keepalive interval; idle for 1.6 s = >3 periods.
+        // 500 ms keepalive interval; idle across >3 periods.
         let (t, _dir) = test_transport(&server, Duration::from_millis(500), 3);
         let rid = RequestId::new();
         t.exec_command("warm", None, dl(10), &rid).expect("warmup");
+        // Let the warmup's channel teardown traffic (eof/close) drain before
+        // the baseline, so the observation cannot be attributed to it.
+        std::thread::sleep(Duration::from_millis(600));
         let before = server.bytes_received.load(Ordering::Relaxed);
         // No client operation: only the background keepalive loop may produce
-        // traffic on the wire.
-        std::thread::sleep(Duration::from_millis(1600));
+        // traffic. Sample across two consecutive keepalive periods and require
+        // sustained growth in each — a one-shot teardown burst can never
+        // satisfy both mid > before and after > mid.
+        std::thread::sleep(Duration::from_millis(600));
+        let mid = server.bytes_received.load(Ordering::Relaxed);
+        std::thread::sleep(Duration::from_millis(600));
         let after = server.bytes_received.load(Ordering::Relaxed);
         assert!(
-            after > before,
-            "the server must receive keepalive traffic while the transport is idle \
-             (before={before} after={after})"
+            mid > before,
+            "the server must receive keepalive traffic in the first idle period \
+             (before={before} mid={mid})"
+        );
+        assert!(
+            after > mid,
+            "keepalive traffic must continue across the second idle period \
+             (mid={mid} after={after})"
         );
         assert!(
             t.test_connection(dl(5)).expect("probe after idle"),

--- a/src/transport/native.rs
+++ b/src/transport/native.rs
@@ -619,13 +619,22 @@ impl NativeTransport {
         // another command can open its own channel and run concurrently.
         let result = f(channel, rt, deadline.remaining());
         if matches!(&result, Err(e) if FailureClass::of(e) == FailureClass::Transient) {
-            // Generation-matched eviction: never drop a replacement built by
-            // a concurrent request after our connection died.
-            rt.block_on(async move {
-                let mut guard = self.session.inner.lock().await;
-                if guard.as_ref().map(|(e, _)| *e) == Some(epoch) {
-                    *guard = None;
-                }
+            // Generation-matched eviction: never drop a replacement built by a
+            // concurrent request after our connection died. Bounded by the
+            // request's remaining deadline — a concurrent re-establishment
+            // holding the handle lock must never delay this request's error
+            // return. If the lock is not reachable in time the stale slot is
+            // left in place; the next operation re-detects it via is_closed()
+            // / lazy establishment, so failure marking stays effective.
+            let remaining = deadline.remaining();
+            let _ = rt.block_on(async move {
+                tokio::time::timeout(remaining, async move {
+                    let mut guard = self.session.inner.lock().await;
+                    if guard.as_ref().map(|(e, _)| *e) == Some(epoch) {
+                        *guard = None;
+                    }
+                })
+                .await
             });
         }
         result
@@ -932,12 +941,19 @@ impl RemoteTransport for NativeTransport {
             Err(e) => {
                 if FailureClass::of(&e) == FailureClass::Transient {
                     // Generation-matched eviction: a stale request's failure
-                    // must not drop a replacement connection.
-                    rt.block_on(async move {
-                        let mut guard = self.session.inner.lock().await;
-                        if guard.as_ref().map(|(g, _)| *g) == Some(epoch) {
-                            *guard = None;
-                        }
+                    // must not drop a replacement connection. Bounded by the
+                    // request's remaining deadline for the same reason as the
+                    // with_channel cleanup: never block the probe's error
+                    // return behind a concurrent re-establishment.
+                    let remaining = deadline.remaining();
+                    let _ = rt.block_on(async move {
+                        tokio::time::timeout(remaining, async move {
+                            let mut guard = self.session.inner.lock().await;
+                            if guard.as_ref().map(|(g, _)| *g) == Some(epoch) {
+                                *guard = None;
+                            }
+                        })
+                        .await
                     });
                 }
                 match e {
@@ -1185,6 +1201,12 @@ mod tests {
     use super::*;
     use crate::transport::contract::test_support::shared_contract_suite;
     use russh::server::{self, Auth, Session};
+    use std::io;
+    use std::pin::Pin;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
+    use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
     use tokio::sync::oneshot;
 
     fn cfg_with(host: &str, key: Option<&str>, jump: Option<&str>) -> Config {
@@ -1628,6 +1650,102 @@ mod tests {
         /// Disconnect the session when an exec whose command equals this
         /// arrives (simulates the remote going away mid-use).
         disconnect_on_exec: Option<String>,
+        /// Sleep, then disconnect, when the exec command equals this (key,
+        /// delay) pair — widens the failing exec's window so a test can take
+        /// the handle lock while the stale request is still in flight.
+        disconnect_delay_for: Option<(String, Duration)>,
+        /// When the exec command equals this, signal `started` and then block
+        /// on `release` before replying — a deterministic slow-command gate.
+        gate_on_exec: Option<(String, Gate)>,
+    }
+
+    /// Deterministic slow-command gate. The server signals `started` the
+    /// moment the gated command arrives, then waits on `release` before
+    /// replying. The test waits on `started` (so it knows the slow command is
+    /// actually in progress), runs a fast command, and only then releases the
+    /// slow one — no sleep-based timing guesses.
+    #[derive(Clone, Default)]
+    struct Gate {
+        started: Arc<(std::sync::Mutex<bool>, std::sync::Condvar)>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    impl Gate {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn signal_started(&self) {
+            let mut g = self.started.0.lock().unwrap();
+            *g = true;
+            self.started.1.notify_all();
+        }
+
+        fn wait_started(&self) {
+            let mut g = self.started.0.lock().unwrap();
+            while !*g {
+                g = self.started.1.wait(g).unwrap();
+            }
+        }
+
+        fn release(&self) {
+            self.release.notify_waiters();
+        }
+
+        async fn wait_release(&self) {
+            self.release.notified().await;
+        }
+    }
+
+    /// Wraps the server-side TCP stream and counts bytes read from the
+    /// client. SSH payloads are encrypted, so a count of *packets* is not
+    /// visible here, but during a quiet idle gap the only traffic a client
+    /// sends is keepalive global requests — a growing receive byte count is
+    /// direct evidence the keepalive loop is running on the background
+    /// runtime.
+    struct CountingStream<S> {
+        inner: S,
+        received: Arc<AtomicU64>,
+    }
+
+    impl<S> CountingStream<S> {
+        fn new(inner: S, received: Arc<AtomicU64>) -> Self {
+            Self { inner, received }
+        }
+    }
+
+    impl<S: AsyncRead + Unpin> AsyncRead for CountingStream<S> {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            let before = buf.filled().len();
+            let result = Pin::new(&mut self.inner).poll_read(cx, buf);
+            if result.is_ready() {
+                let n = buf.filled().len().saturating_sub(before);
+                self.received.fetch_add(n as u64, Ordering::Relaxed);
+            }
+            result
+        }
+    }
+
+    impl<S: AsyncWrite + Unpin> AsyncWrite for CountingStream<S> {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Pin::new(&mut self.inner).poll_write(cx, buf)
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.inner).poll_flush(cx)
+        }
+
+        fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.inner).poll_shutdown(cx)
+        }
     }
 
     #[derive(Clone)]
@@ -1682,6 +1800,36 @@ mod tests {
                 session.disconnect(russh::Disconnect::ByApplication, "test shutdown", "")?;
                 return Ok(());
             }
+            if let Some((needle, delay)) = &self.behavior.disconnect_delay_for {
+                if cmd == *needle {
+                    tokio::time::sleep(*delay).await;
+                    session.disconnect(russh::Disconnect::ByApplication, "test shutdown", "")?;
+                    return Ok(());
+                }
+            }
+            if let Some((needle, gate)) = &self.behavior.gate_on_exec {
+                if cmd == *needle {
+                    gate.signal_started();
+                    // Schedule the delayed reply on a separate task so the
+                    // gated command does not block the connection's request
+                    // handling (a real sshd services channels independently;
+                    // the test server must behave the same or the client-side
+                    // concurrency claim cannot be exercised).
+                    let handle = session.handle();
+                    let gate = gate.clone();
+                    let payload = self.behavior.exec_reply.clone();
+                    tokio::spawn(async move {
+                        gate.wait_release().await;
+                        if let Some(payload) = payload {
+                            let _ = handle.data(channel, payload).await;
+                            let _ = handle.exit_status_request(channel, 0).await;
+                            let _ = handle.eof(channel).await;
+                            let _ = handle.close(channel).await;
+                        }
+                    });
+                    return Ok(());
+                }
+            }
             if let Some((needle, delay)) = &self.behavior.exec_delay_for {
                 if cmd == *needle {
                     tokio::time::sleep(*delay).await;
@@ -1710,6 +1858,7 @@ mod tests {
         port: u16,
         pub_key: russh::keys::PublicKey,
         shutdown_tx: Option<oneshot::Sender<()>>,
+        bytes_received: Arc<AtomicU64>,
         _runtime: tokio::runtime::Runtime,
     }
 
@@ -1726,6 +1875,8 @@ mod tests {
             let (port_tx, port_rx) = oneshot::channel();
             let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
             let behavior = Arc::new(behavior);
+            let bytes_received = Arc::new(AtomicU64::new(0));
+            let br_total = Arc::clone(&bytes_received);
             runtime.spawn(async move {
                 let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
                     .await
@@ -1744,7 +1895,9 @@ mod tests {
                             let (stream, _) = accepted.expect("accept client");
                             let cfg = Arc::clone(&config);
                             let bh = Arc::clone(&behavior);
+                            let br = Arc::clone(&br_total);
                             sessions.push(tokio::spawn(async move {
+                                let stream = CountingStream::new(stream, br);
                                 let _ = server::run_stream(cfg, stream, TestHandler { behavior: bh })
                                     .await;
                             }));
@@ -1761,6 +1914,7 @@ mod tests {
                 port,
                 pub_key: pub_key.clone(),
                 shutdown_tx: Some(shutdown_tx),
+                bytes_received,
                 _runtime: runtime,
             }
         }
@@ -1857,11 +2011,18 @@ mod tests {
 
     /// P1-2 concurrency: a slow command on one channel must not block a fast
     /// command — each operation opens its own channel and the handle lock is
-    /// released as soon as the channel exists.
+    /// released as soon as the channel exists. The slow command is gated with
+    /// a synchronisation signal rather than a sleep: the test waits until the
+    /// server confirms the slow command is in flight, runs the fast command,
+    /// asserts it completes, and only then releases the slow command. A
+    /// serialising implementation would hold the handle lock until the slow
+    /// command finished, so the fast command could not complete before the
+    /// release.
     #[test]
     fn concurrent_commands_run_on_independent_channels() {
+        let gate = Arc::new(Gate::new());
         let server = TestServer::start(ServerBehavior {
-            exec_delay_for: Some(("slow".to_string(), Duration::from_millis(600))),
+            gate_on_exec: Some(("slow".to_string(), (*gate).clone())),
             exec_reply: Some(b"ok".to_vec()),
             ..Default::default()
         });
@@ -1873,9 +2034,10 @@ mod tests {
             let t = t.clone();
             std::thread::spawn(move || t.exec_command("slow", None, dl(10), &slow_rid))
         };
-        // Give the slow command time to open its channel and start sleeping on
-        // the server, then run a fast command on a second channel.
-        std::thread::sleep(Duration::from_millis(150));
+        // Deterministic: wait until the slow command has actually started on
+        // the server (its channel is open and the exec is being processed)
+        // before touching the fast command.
+        gate.wait_started();
         let started = std::time::Instant::now();
         let fast = t
             .exec_command("fast", None, dl(10), &rid)
@@ -1886,6 +2048,9 @@ mod tests {
             fast_elapsed < Duration::from_millis(500),
             "fast command must not wait for the slow command's channel (got {fast_elapsed:?})"
         );
+        // The slow command is still blocked: release it and only then may it
+        // complete — proving the fast command finished first.
+        gate.release();
         let slow_out = slow.join().expect("slow thread").expect("slow exec");
         assert_eq!(slow_out.stdout, b"ok");
         assert_eq!(
@@ -1927,6 +2092,91 @@ mod tests {
         let _ = stuck.join().expect("stuck thread");
     }
 
+    /// P1 failure-cleanup deadline: after a stale request's connection-level
+    /// failure, the generation-matched eviction must be bounded by the
+    /// request's remaining deadline — it must never block behind a concurrent
+    /// slow re-establishment holding the handle lock. The concurrent
+    /// re-establishment is simulated by holding the lock (the deterministic
+    /// equivalent of a connection stuck in authentication, as hold_auth would
+    /// produce), and the stale request's operation returns a transient
+    /// connection failure mid-flight. The stale request must return on its own
+    /// deadline — before the lock is released — and the closed handle must
+    /// still be replaced by the next operation even when the eviction was
+    /// skipped.
+    #[test]
+    fn stale_failure_cleanup_is_bounded_by_the_request_deadline() {
+        let server = TestServer::start(ServerBehavior {
+            exec_reply: Some(b"ok".to_vec()),
+            // "die" sleeps 800 ms, then disconnects — a real connection death.
+            disconnect_delay_for: Some(("die".to_string(), Duration::from_millis(800))),
+            ..Default::default()
+        });
+        let (t, _dir) = test_transport(&server, Duration::from_secs(30), 3);
+        let rid = RequestId::new();
+        t.exec_command("warm", None, dl(10), &rid).expect("warmup");
+        // A: drive with_channel directly; its operation kills the connection
+        // mid-flight (server disconnect) and then fails with a transient
+        // connection error — the path whose cleanup must respect the
+        // deadline. B takes the handle lock while A's operation is still in
+        // flight.
+        let (done_tx, done_rx) = std::sync::mpsc::channel::<()>();
+        let a_rid = rid.clone();
+        let a = {
+            let t = t.clone();
+            let done_tx = done_tx.clone();
+            std::thread::spawn(move || {
+                let result: Result<(), TransportError> =
+                    t.with_channel(dl(2), &a_rid, |channel, rt, _remaining| {
+                        // Real mid-use death: the server disconnects ~800 ms
+                        // after receiving "die".
+                        rt.block_on(async move {
+                            let mut ch = channel;
+                            let _ = ch.exec(false, "die".to_string()).await;
+                            let _ = tokio::time::timeout(Duration::from_millis(1500), async {
+                                while ch.wait().await.is_some() {}
+                            })
+                            .await;
+                        });
+                        Err(TransportError::ConnectionFailed(
+                            "simulated mid-use connection failure".into(),
+                        ))
+                    });
+                let _ = done_tx.send(());
+                result
+            })
+        };
+        // Take the handle lock while A's operation is in flight, simulating a
+        // concurrent re-establishment stuck in auth. Hold it well past A's
+        // deadline.
+        std::thread::sleep(Duration::from_millis(150));
+        let guard = t.session.inner.blocking_lock();
+        std::thread::sleep(Duration::from_secs(3));
+        let returned_early = done_rx.recv_timeout(Duration::from_millis(300)).is_ok();
+        drop(guard);
+        assert!(
+            returned_early,
+            "stale request's cleanup must be bounded by its remaining deadline and must not wait \
+             for the concurrent re-establishment to release the handle lock"
+        );
+        let a_res = a.join().expect("stale thread");
+        assert!(
+            a_res.is_err(),
+            "the stale request must surface its connection failure"
+        );
+        // Eviction may have been skipped (the lock was unreachable before the
+        // deadline); the dead handle must still be re-detected and replaced by
+        // the next operation — failure marking stays effective.
+        let final_res = t
+            .exec_command("final", None, dl(5), &rid)
+            .expect("next operation rebuilds");
+        assert_eq!(final_res.stdout, b"ok");
+        assert_eq!(
+            t.session.connections.load(Ordering::Relaxed),
+            2,
+            "the dead session must be replaced by a fresh connection"
+        );
+    }
+
     /// P1-1 liveness: after the remote goes away, test_connection must stop
     /// reporting healthy — the probe is a real ping/pong, not a cached
     /// success based on the handle existing.
@@ -1955,19 +2205,31 @@ mod tests {
         );
     }
 
-    /// P1-1 background liveness: the shared multi-thread runtime keeps the
-    /// connection alive across an idle gap (longer than a short keepalive
-    /// interval would be) — no reconnect happens and the next probe succeeds.
+    /// P1-1 background liveness: with a short keepalive interval, the shared
+    /// multi-thread runtime keeps sending keepalives while the transport is
+    /// idle — the server must observe incoming traffic during a quiet gap
+    /// longer than several keepalive periods, with no client-side operation
+    /// and no reconnect.
     #[test]
-    fn idle_connection_stays_alive_on_the_multi_thread_runtime() {
+    fn idle_connection_sends_keepalives_on_the_background_runtime() {
         let server = TestServer::start(ServerBehavior {
             exec_reply: Some(b"ok".to_vec()),
             ..Default::default()
         });
-        let (t, _dir) = test_transport(&server, Duration::from_secs(30), 3);
+        // 500 ms keepalive interval; idle for 1.6 s = >3 periods.
+        let (t, _dir) = test_transport(&server, Duration::from_millis(500), 3);
         let rid = RequestId::new();
         t.exec_command("warm", None, dl(10), &rid).expect("warmup");
-        std::thread::sleep(Duration::from_secs(2));
+        let before = server.bytes_received.load(Ordering::Relaxed);
+        // No client operation: only the background keepalive loop may produce
+        // traffic on the wire.
+        std::thread::sleep(Duration::from_millis(1600));
+        let after = server.bytes_received.load(Ordering::Relaxed);
+        assert!(
+            after > before,
+            "the server must receive keepalive traffic while the transport is idle \
+             (before={before} after={after})"
+        );
         assert!(
             t.test_connection(dl(5)).expect("probe after idle"),
             "connection must stay usable after an idle gap"

--- a/src/transport/tunnel.rs
+++ b/src/transport/tunnel.rs
@@ -1040,9 +1040,13 @@ mod tests {
     use super::is_ssh_executable;
     use super::{
         classify_ssh_pid, daemon_lifecycle, decide_stop, profiled_bridge_leaf, profiled_env_key,
-        setup_dir_for_profile, stop_saved_tunnel, verdict_to_decision, verify_ssh_pid,
-        wait_for_forward, PidVerdict, StopDecision, TunnelState, Verdict,
+        setup_dir_for_profile, verdict_to_decision, wait_for_forward, PidVerdict, StopDecision,
+        TunnelState, Verdict,
     };
+    // Used only by non-Windows tunnel tests (which are cfg'd out on Windows).
+    #[cfg(not(target_os = "windows"))]
+    use super::{stop_saved_tunnel, verify_ssh_pid};
+    #[cfg(not(target_os = "windows"))]
     use crate::config::Config;
     use serial_test::serial;
 

--- a/tests/skill_load.rs
+++ b/tests/skill_load.rs
@@ -74,6 +74,7 @@ impl Bridge {
             .unwrap()
     }
 
+    #[allow(dead_code)] // exercised only by the live Virtuoso probe variants
     fn file(&self) -> std::path::PathBuf {
         let path = self.dir.path().join("probe with spaces.ils");
         std::fs::write(&path, "procedure(vcliTestProbe() 42)\nt\n").unwrap();
@@ -91,6 +92,7 @@ impl Drop for Bridge {
     }
 }
 
+#[allow(dead_code)] // exercised only by the live Virtuoso probe variants
 fn assert_success(out: &Output) {
     assert!(
         out.status.success(),


### PR DESCRIPTION
﻿## 多连接池 P1-2：native SSH 会话复用（第三轮审阅收尾）

在 b840b4f（二轮审阅修复）基础上完成第三轮收尾：保活测试证据加强，交付描述修正。无新增架构范围。

### P1 — 失败清理受请求 deadline 约束

`with_channel()` 与 `test_connection()` 中 generation 匹配的失效清理，原来会在失败后**无超时地重新获取 handle 锁**：若并发请求正持锁进行长重连（如认证停滞），旧请求会一直等到远超自己 deadline 才返回。

现在清理用 `tokio::time::timeout(remaining, ...)` 包住锁获取，**旧请求的失效处理不会阻塞其超时返回**；generation 校验仍防止误删并发请求新建的连接。

**表述收紧**：清理超时后**没有留下独立失效标记**，只依靠下一次操作经 `is_closed()` 重检失效连接。新增回归测试证明的是「**已关闭的 handle 能被后续操作检测并重建**」，不是「所有连接级失败都能可靠失效」。

### P2 — 并发测试确定性门控（能挡住串行实现）

原测试用「慢命令延迟 600ms、等待 150ms、断言快命令 <500ms」，串行实现仍可能通过（~450ms 余量）。

现改为确定性 Gate：慢命令信号已开始（Condvar）后，阻塞其完成（Notify release），断言快命令先完成，再释放慢命令。测试 server 端把被门控的回复**调度到独立任务**（经 `Session::handle()` 外发 data/exit-status/eof/close），延迟回复不再阻塞同一连接其他 channel 的请求处理，与真实 sshd 的多 channel 独立服务一致。

### P2 — 空闲保活覆盖完整保活周期（第三轮加强）

原实现：keepalive 30s、只空闲 2s 后主动 probe；二轮改为 keepalive 500ms + 单次 1.6s 空闲 + 入站字节增长；第三轮加强为**基线在 warmup 的 channel 收尾流量排空后记录，并跨两个连续 keepalive 周期采样、分别断言增长**（`mid > before` 且 `after > mid`）。

**表述**：无客户端操作期间，连续两个采样窗口均观察到流量增长，为后台保活持续运行提供回归证据。另保留 probe 成功与连接复用断言。

### 验证

- 本机（Windows GNU）：`cargo test --features daemon --features native-ssh` 全绿（lib 912、集成 1064 等全部 0 failed）；`cargo clippy --all-targets -D warnings`、`cargo fmt --check` 通过
- 远程 Linux（192.168.1.111）：`cargo test --features daemon --features native-ssh --lib transport::native` 18/18 通过
- 远端 CI 10/10 全绿（三个平台 default 与 native-ssh 矩阵 + Build/Check & Lint/Security Audit/Test）

### 范围说明

本 PR 实现 native SSH 连接**跨请求复用、并发 channel、后台保活及请求 deadline**。完整 drain 与其他尚未覆盖的生命周期验收继续由 #80 跟踪，不据此关闭整个 #80。
