### PR TITLE
feat(session): migrate list/show to CommandContext with probe identity verification (P0-A)

### DIFF
--- a/src/commands/session.rs
+++ b/src/commands/session.rs
@@ -43,12 +43,40 @@ pub(crate) struct ProbeSkip {
 /// Shared entry point: resolve a probe endpoint for a session under the
 /// given context. Returns `Ok(endpoint)` if probing is allowed,
 /// `Err(skip)` otherwise (caller shows cached data).
+///
+/// Loads TunnelState internally; for batch callers (e.g. `list`) use
+/// `resolve_probe_endpoint_with_state` to avoid reloading the same state
+/// file for every session.
 pub(crate) fn resolve_probe_endpoint(
     ctx: &CommandContext,
     session: &SessionInfo,
 ) -> std::result::Result<ProbeEndpoint, ProbeSkip> {
+    let state = if ctx.config().is_remote() {
+        match TunnelState::load_with_profile(ctx.config().profile.as_deref()) {
+            Ok(Some(s)) => Some(s),
+            Ok(None) => None,
+            Err(_) => {
+                return Err(ProbeSkip {
+                    reason: "tunnel_state_error",
+                })
+            }
+        }
+    } else {
+        None
+    };
+    resolve_probe_endpoint_with_state(ctx, session, state.as_ref())
+}
+
+/// Like `resolve_probe_endpoint`, but accepts a pre-loaded `TunnelState`
+/// for efficiency. Used by `list()` which loads state once and reuses it
+/// across all sessions. `state` may be `None` (no tunnel exists).
+pub(crate) fn resolve_probe_endpoint_with_state(
+    ctx: &CommandContext,
+    session: &SessionInfo,
+    state: Option<&TunnelState>,
+) -> std::result::Result<ProbeEndpoint, ProbeSkip> {
     if ctx.config().is_remote() {
-        resolve_remote_tunnel(ctx, session)
+        resolve_remote_tunnel(ctx, session, state)
     } else {
         resolve_local_direct(ctx, session)
     }
@@ -101,9 +129,8 @@ fn resolve_local_direct(
 fn resolve_remote_tunnel(
     ctx: &CommandContext,
     session: &SessionInfo,
+    state: Option<&TunnelState>,
 ) -> std::result::Result<ProbeEndpoint, ProbeSkip> {
-    let cfg = ctx.config();
-
     // Step 1: session ownership.
     if ctx.target_id().is_some() && ctx.validate_session_ownership(session).is_err() {
         return Err(ProbeSkip {
@@ -111,17 +138,12 @@ fn resolve_remote_tunnel(
         });
     }
 
-    // Step 2: TunnelState load + basic checks.
-    let state = match TunnelState::load_with_profile(cfg.profile.as_deref()) {
-        Ok(Some(s)) => s,
-        Ok(None) => {
+    // Step 2: TunnelState basic checks (state is pre-loaded by caller).
+    let state = match state {
+        Some(s) => s,
+        None => {
             return Err(ProbeSkip {
                 reason: "no_tunnel",
-            })
-        }
-        Err(_) => {
-            return Err(ProbeSkip {
-                reason: "tunnel_state_error",
             })
         }
     };
@@ -153,7 +175,7 @@ fn resolve_remote_tunnel(
     }
 
     // Step 4: state matches current context.
-    if ctx.validate_tunnel_ownership(&state).is_err() {
+    if ctx.validate_tunnel_ownership(state).is_err() {
         return Err(ProbeSkip {
             reason: "tunnel_context_mismatch",
         });
@@ -220,12 +242,47 @@ fn resolve_remote_tunnel(
     Ok(ProbeEndpoint::RemoteTunnel { port: state.port })
 }
 
+/// Get the system hostname via libc::gethostname(2). Returns None on
+/// failure or if the hostname is empty. This is preferred over reading
+/// $HOSTNAME, which is not guaranteed to be set in every process
+/// environment (e.g. non-login shells, CI containers).
+fn system_hostname() -> Option<String> {
+    unsafe {
+        let mut buf = [0u8; 256];
+        if libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) != 0 {
+            return None;
+        }
+        let len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+        if len == 0 {
+            return None;
+        }
+        String::from_utf8(buf[..len].to_vec()).ok()
+    }
+}
+
+/// Compare two hostnames, allowing short-name vs FQDN equivalence.
+///
+/// - Exact match (case-sensitive, as hostnames are on Unix).
+/// - Short-name match: if either contains a dot, compare the part before
+///   the first dot. This lets "compute-eda-42" match
+///   "compute-eda-42.internal.corp".
+fn hostnames_match(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    let a_short = a.split('.').next().unwrap_or(a);
+    let b_short = b.split('.').next().unwrap_or(b);
+    !a_short.is_empty() && a_short == b_short
+}
+
 /// Check whether a session belongs to this machine, given the config.
 ///
 /// - If `cfg.remote_host` is set, the session is local only if its host
 ///   matches exactly.
 /// - If `cfg.remote_host` is unset, we check known local hostnames
-///   (`localhost`, `127.0.0.1`, `::1`) and the `HOSTNAME` env var.
+///   (`localhost`, `127.0.0.1`, `::1`), the system hostname (via
+///   libc::gethostname, with short/FQDN equivalence), and finally the
+///   `HOSTNAME` env var as a last resort.
 /// - Anything that cannot be confirmed is treated as NOT local (skip probe).
 fn is_local_session(cfg: &Config, session: &SessionInfo) -> bool {
     const LOCAL_HOSTNAMES: &[&str] = &["localhost", "127.0.0.1", "::1"];
@@ -238,9 +295,16 @@ fn is_local_session(cfg: &Config, session: &SessionInfo) -> bool {
         return true;
     }
 
-    // Fall back to HOSTNAME env var (commonly set on Linux/macOS).
-    if let Ok(sys_hostname) = std::env::var("HOSTNAME") {
-        if !sys_hostname.is_empty() && session.host == sys_hostname {
+    // System hostname (preferred — does not depend on process env).
+    if let Some(sys_host) = system_hostname() {
+        if !sys_host.is_empty() && hostnames_match(&sys_host, &session.host) {
+            return true;
+        }
+    }
+
+    // Fall back to HOSTNAME env var (may not be set in all environments).
+    if let Ok(env_host) = std::env::var("HOSTNAME") {
+        if !env_host.is_empty() && hostnames_match(&env_host, &session.host) {
             return true;
         }
     }
@@ -329,18 +393,19 @@ pub fn list(ctx: &CommandContext, format: OutputFormat) -> Result<Value> {
         .map(|s| {
             if has_target {
                 let endpoint_match = compute_endpoint_match(ctx, s);
-                let (tunnel_verified, probe_status) = match &tunnel_state {
-                    Some(state)
-                        if state.mode.as_deref() == Some("attached")
-                            && state.attached_session_id.as_deref() == Some(&s.id) =>
-                    {
-                        if tcp_reachable(state.port) {
-                            (true, "reachable")
-                        } else {
-                            (true, "unreachable")
-                        }
-                    }
-                    _ => (false, "not_probed"),
+                // Use the SHARED verification chain (same 6-step path as
+                // show). tunnel_verified=true only when the full chain
+                // passes, OR when the only failure is
+                // forward_port_unreachable (identity verified, port just
+                // down). Any earlier failure (wrong host, dead process,
+                // mismatched session id, …) → tunnel_verified=false.
+                let probe_result = resolve_probe_endpoint_with_state(ctx, s, tunnel_state.as_ref());
+                let (tunnel_verified, probe_status) = match probe_result {
+                    Ok(_) => (true, "reachable"),
+                    Err(ProbeSkip {
+                        reason: "forward_port_unreachable",
+                    }) => (true, "unreachable"),
+                    Err(_) => (false, "not_probed"),
                 };
                 json!({
                     "id": s.id,
@@ -526,6 +591,10 @@ pub fn show(ctx: &CommandContext, id: &str, _format: OutputFormat) -> Result<Val
     let endpoint_match = compute_endpoint_match(ctx, &s);
 
     // Phase 2: resolve a probe endpoint, then probe if allowed.
+    // daemon_responsive is Option<bool>: Some(_) = probe ran, None = skipped.
+    // daemon_user / daemon_version hold the LIVE probe values when probe
+    // succeeded; the output layer falls back to s.daemon_user / s.daemon_version
+    // (cached) when probe was skipped.
     let (
         daemon_user,
         daemon_user_warning,
@@ -565,7 +634,7 @@ pub fn show(ctx: &CommandContext, id: &str, _format: OutputFormat) -> Result<Val
             (
                 user,
                 user_warn,
-                alive,
+                Some(alive),
                 ver,
                 ver_warn,
                 false,
@@ -575,10 +644,11 @@ pub fn show(ctx: &CommandContext, id: &str, _format: OutputFormat) -> Result<Val
             )
         }
         Err(skip) => (
+            // Probe skipped: use cached values from the session file.
+            s.daemon_user.clone(),
             None,
-            None,
-            false,
-            None,
+            None, // responsive unknown — not "false"
+            s.daemon_version.clone(),
             None,
             true,
             Some(skip.reason),
@@ -591,8 +661,8 @@ pub fn show(ctx: &CommandContext, id: &str, _format: OutputFormat) -> Result<Val
     let cross_user_warning = check_cross_user(ctx.config(), &s, daemon_user.as_deref());
 
     // Stale-daemon hint only when the probe actually ran and the daemon
-    // didn't respond.
-    let stale_daemon_hint = if !probe_skipped && !daemon_responsive {
+    // didn't respond (daemon_responsive == Some(false)).
+    let stale_daemon_hint = if !probe_skipped && daemon_responsive == Some(false) {
         Some(
             "CIW daemon port is bound but the daemon is not responding to SKILL.\n\
              In the Virtuoso CIW, run:\n\
@@ -623,6 +693,10 @@ pub fn show(ctx: &CommandContext, id: &str, _format: OutputFormat) -> Result<Val
         || daemon_user_warning.is_some()
         || stale_daemon_hint.is_some();
 
+    // data_source: "live" when probe ran, "cached" when skipped (values
+    // come from the session file).
+    let data_source = if probe_skipped { "cached" } else { "live" };
+
     Ok(json!({
         "status": if has_warnings { "warning" } else { "success" },
         "session": {
@@ -636,6 +710,7 @@ pub fn show(ctx: &CommandContext, id: &str, _format: OutputFormat) -> Result<Val
             "daemon_responsive": daemon_responsive,
             "daemon_user": daemon_user,
             "daemon_version": daemon_version,
+            "data_source": data_source,
             "cli_version": env!("CARGO_PKG_VERSION"),
         },
         "probe": {
@@ -1350,6 +1425,306 @@ mod tests {
                 })
             ),
             "session host mismatch should return ownership_mismatch, got {r:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // hostnames_match — short-name / FQDN equivalence
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn hostnames_match_exact() {
+        assert!(hostnames_match("compute-eda-42", "compute-eda-42"));
+    }
+
+    #[test]
+    fn hostnames_match_short_vs_fqdn() {
+        assert!(hostnames_match(
+            "compute-eda-42",
+            "compute-eda-42.internal.corp"
+        ));
+        assert!(hostnames_match(
+            "compute-eda-42.internal.corp",
+            "compute-eda-42"
+        ));
+    }
+
+    #[test]
+    fn hostnames_match_different_hosts() {
+        assert!(!hostnames_match("compute-eda-42", "compute-eda-43"));
+        assert!(!hostnames_match(
+            "compute-eda-42.internal.corp",
+            "compute-eda-43.internal.corp"
+        ));
+    }
+
+    #[test]
+    fn hostnames_match_empty_short_name() {
+        // A hostname that is just ".domain" has empty short name — must not
+        // match everything.
+        assert!(!hostnames_match(".example.com", "anything"));
+    }
+
+    // ------------------------------------------------------------------
+    // resolve_probe_endpoint_with_state — same ID, wrong tunnel
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn with_state_same_id_but_wrong_remote_host_is_not_verified() {
+        // TunnelState has matching attached_session_id but points at a
+        // DIFFERENT remote host than the session. The shared chain must
+        // reject it (tunnel_host_mismatch) — list must NOT mark this
+        // tunnel_verified=true.
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        // State: same session ID, but remote_host is wrong.
+        let state = make_tunnel_state(
+            "remote-eda-99", // wrong host
+            40000,
+            14000,
+            std::process::id(),
+            Some(1),
+            Some(&s.id),
+            Some("attached"),
+        );
+
+        let r = resolve_probe_endpoint_with_state(&ctx, &s, Some(&state));
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "tunnel_host_mismatch"
+                })
+            ),
+            "wrong remote host must be rejected, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn with_state_same_id_but_wrong_remote_port_is_not_verified() {
+        // TunnelState has matching session_id and host, but remote_bridge_port
+        // differs from session.port. Must reject.
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        let state = make_tunnel_state(
+            "remote-eda-01",
+            40999, // wrong remote port
+            14000,
+            std::process::id(),
+            Some(1),
+            Some(&s.id),
+            Some("attached"),
+        );
+
+        let r = resolve_probe_endpoint_with_state(&ctx, &s, Some(&state));
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "tunnel_remote_port_mismatch"
+                })
+            ),
+            "wrong remote port must be rejected, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn with_state_dead_process_is_not_verified() {
+        // TunnelState passes host/port/id checks but the recorded PID is
+        // dead. Must reject with tunnel_process_dead.
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        let state = make_tunnel_state(
+            "remote-eda-01",
+            40000,
+            14000,
+            99999, // dead PID
+            Some(1),
+            Some(&s.id),
+            Some("attached"),
+        );
+
+        let r = resolve_probe_endpoint_with_state(&ctx, &s, Some(&state));
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "tunnel_process_dead"
+                })
+            ),
+            "dead PID must be rejected, got {r:?}"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // CacheDirGuard — redirect VB_CACHE_DIR for list/show integration tests
+    // ------------------------------------------------------------------
+
+    struct CacheDirGuard {
+        original: Option<String>,
+        _tempdir: tempfile::TempDir,
+    }
+
+    impl CacheDirGuard {
+        fn new() -> Self {
+            let original = std::env::var("VB_CACHE_DIR").ok();
+            let tempdir = tempfile::tempdir().expect("failed to create temp dir");
+            std::env::set_var("VB_CACHE_DIR", tempdir.path());
+            Self {
+                original,
+                _tempdir: tempdir,
+            }
+        }
+    }
+
+    impl Drop for CacheDirGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => std::env::set_var("VB_CACHE_DIR", v),
+                None => std::env::remove_var("VB_CACHE_DIR"),
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // list — integration tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn list_target_mode_does_not_delete_dead_session_files() {
+        // In target mode, list must show ALL cached sessions and NEVER
+        // delete files — even if the local port is unreachable.
+        let _cache = CacheDirGuard::new();
+        let _state = StateDirGuard::new();
+
+        // Create a session file with an unreachable port.
+        let mut s = session();
+        s.port = 1; // unreachable
+        s.save_to_session_file();
+
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let result = list(&ctx, OutputFormat::Json).expect("list should succeed");
+
+        // The session should appear in the list.
+        let sessions = result["sessions"].as_array().expect("sessions array");
+        assert_eq!(sessions.len(), 1, "dead session should still be listed");
+        assert_eq!(sessions[0]["id"], s.id);
+
+        // probe_status should be not_probed (tunnel_verified=false).
+        assert_eq!(sessions[0]["probe_status"], "not_probed");
+        assert_eq!(sessions[0]["tunnel_verified"], false);
+
+        // File must still exist (not deleted).
+        let path = SessionInfo::sessions_dir().join(format!("{}.json", s.id));
+        assert!(path.exists(), "session file must NOT be deleted by list");
+    }
+
+    #[test]
+    #[serial]
+    fn list_target_mode_shows_unattached_remote_session() {
+        // A remote session that has no attached tunnel must still appear
+        // in target-mode list, with tunnel_verified=false and
+        // probe_status=not_probed.
+        let _cache = CacheDirGuard::new();
+        let _state = StateDirGuard::new();
+
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+        s.save_to_session_file();
+
+        // No TunnelState saved → unattached.
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let result = list(&ctx, OutputFormat::Json).expect("list should succeed");
+
+        let sessions = result["sessions"].as_array().expect("sessions array");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0]["tunnel_verified"], false);
+        assert_eq!(sessions[0]["probe_status"], "not_probed");
+        // endpoint_match should be "match" (host+port match the target).
+        assert_eq!(sessions[0]["endpoint_match"], "match");
+    }
+
+    // ------------------------------------------------------------------
+    // show — integration tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn show_skipped_probe_preserves_cached_metadata() {
+        // When probe is skipped (no tunnel), show must return the cached
+        // daemon_user / daemon_version from the session file, with
+        // data_source="cached" and daemon_responsive=null.
+        let _cache = CacheDirGuard::new();
+        let _state = StateDirGuard::new();
+
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+        s.daemon_user = Some("cacheduser".into());
+        s.daemon_version = Some("1.2.3-cached".into());
+        s.save_to_session_file();
+
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let result = show(&ctx, &s.id, OutputFormat::Json).expect("show should succeed");
+
+        // Cached values must be present.
+        assert_eq!(result["session"]["daemon_user"], "cacheduser");
+        assert_eq!(result["session"]["daemon_version"], "1.2.3-cached");
+        assert_eq!(result["session"]["data_source"], "cached");
+
+        // daemon_responsive must be null (not false — we never probed).
+        assert!(
+            result["session"]["daemon_responsive"].is_null(),
+            "daemon_responsive should be null when probe skipped, got {}",
+            result["session"]["daemon_responsive"]
+        );
+
+        // Probe must be marked skipped.
+        assert_eq!(result["probe"]["skipped"], true);
+        assert_eq!(result["probe"]["skip_reason"], "no_tunnel");
+    }
+
+    #[test]
+    #[serial]
+    fn show_skipped_probe_does_not_mutate_session_file() {
+        // When probe is skipped, show must NOT write back to the session
+        // file (no mutation).
+        let _cache = CacheDirGuard::new();
+        let _state = StateDirGuard::new();
+
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+        s.daemon_user = Some("originaluser".into());
+        s.save_to_session_file();
+
+        let path = SessionInfo::sessions_dir().join(format!("{}.json", s.id));
+        let before = std::fs::read_to_string(&path).expect("read before");
+
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let _ = show(&ctx, &s.id, OutputFormat::Json).expect("show should succeed");
+
+        let after = std::fs::read_to_string(&path).expect("read after");
+        assert_eq!(
+            before, after,
+            "session file must NOT be mutated when probe is skipped"
         );
     }
 }

--- a/src/commands/session.rs
+++ b/src/commands/session.rs
@@ -1,69 +1,432 @@
 use crate::client::bridge::VirtuosoClient;
 use crate::config::Config;
+use crate::context::CommandContext;
 use crate::error::{Result, VirtuosoError};
-use crate::models::SessionInfo;
+use crate::models::{SessionInfo, TunnelState};
 use crate::output::OutputFormat;
-use crate::transport::tunnel::SSHClient;
+use crate::transport::identity::{IdentityError, ProcessIdentity};
+use crate::transport::tunnel::{classify_ssh_pid, PidVerdict, SSHClient};
 use serde_json::{json, Value};
 
-pub fn list(format: OutputFormat) -> Result<Value> {
-    // In remote mode, sync session files from remote host first.
-    // Best effort: failures are silent so local cache still works.
-    if let Ok(cfg) = Config::from_env() {
-        if cfg.is_remote() {
-            if let Ok(client) = SSHClient::from_env(cfg.keep_remote_files) {
-                let _ = SessionInfo::sync_from_remote(client.transport().as_ref());
-            }
+// ---------------------------------------------------------------------------
+// Shared probe resolution (used by both `list` and `show`)
+//
+// A single function decides whether a session may be probed online, and if
+// so, which local port to connect to. Two paths:
+//   - Local direct: config is local AND the session belongs to this machine.
+//   - Remote tunnel: a 6-step verification chain confirms the TunnelState
+//     points at this session, matches the current context, and the forward
+//     process is still alive and verifiable.
+//
+// Any failure returns `ProbeSkip` — never an error — so the caller can
+// always fall back to showing cached metadata (phase 1 of `show`).
+// ---------------------------------------------------------------------------
+
+/// An endpoint that may be probed (TCP connect + SKILL queries).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ProbeEndpoint {
+    /// Local direct connection: the session runs on this machine, use its
+    /// own `port`.
+    Local { port: u16 },
+    /// Remote tunnel: the session runs on a remote host, use the verified
+    /// local forward port from `TunnelState`.
+    RemoteTunnel { port: u16 },
+}
+
+/// Why probing was skipped. The `reason` string is surfaced in JSON output
+/// as `probe_skip_reason` so users can diagnose why no live data was shown.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ProbeSkip {
+    pub reason: &'static str,
+}
+
+/// Shared entry point: resolve a probe endpoint for a session under the
+/// given context. Returns `Ok(endpoint)` if probing is allowed,
+/// `Err(skip)` otherwise (caller shows cached data).
+pub(crate) fn resolve_probe_endpoint(
+    ctx: &CommandContext,
+    session: &SessionInfo,
+) -> std::result::Result<ProbeEndpoint, ProbeSkip> {
+    if ctx.config().is_remote() {
+        resolve_remote_tunnel(ctx, session)
+    } else {
+        resolve_local_direct(ctx, session)
+    }
+}
+
+/// Local direct path: config has no remote_host, AND the session belongs to
+/// this machine. We cannot rely solely on `!cfg.is_remote()` — a public
+/// session cache may contain remote records, and legacy mode skips ownership
+/// validation, so we must independently confirm the session is local.
+fn resolve_local_direct(
+    ctx: &CommandContext,
+    session: &SessionInfo,
+) -> std::result::Result<ProbeEndpoint, ProbeSkip> {
+    let cfg = ctx.config();
+
+    // Step L1: confirm the session belongs to this machine.
+    if !is_local_session(cfg, session) {
+        return Err(ProbeSkip {
+            reason: "local_ownership_unverified",
+        });
+    }
+
+    // Step L2: ownership validation when a target is selected.
+    if ctx.target_id().is_some() && ctx.validate_session_ownership(session).is_err() {
+        return Err(ProbeSkip {
+            reason: "ownership_mismatch",
+        });
+    }
+
+    // Step L3: local port must be reachable.
+    if !tcp_reachable(session.port) {
+        return Err(ProbeSkip {
+            reason: "local_port_unreachable",
+        });
+    }
+
+    Ok(ProbeEndpoint::Local { port: session.port })
+}
+
+/// Remote tunnel path: 6-step verification chain. Every step must pass; any
+/// failure skips probing (cached view only).
+///
+/// 1. Session ownership matches the selected target.
+/// 2. TunnelState exists, is "attached", and its attached_session_id matches.
+/// 3. TunnelState's remote host and remote port directly match the session.
+/// 4. TunnelState matches the current context (validate_tunnel_ownership).
+/// 5. The recorded forward process is alive, verifiable as ssh, and its
+///    start identity matches (no PID reuse).
+/// 6. The local forward port is reachable.
+fn resolve_remote_tunnel(
+    ctx: &CommandContext,
+    session: &SessionInfo,
+) -> std::result::Result<ProbeEndpoint, ProbeSkip> {
+    let cfg = ctx.config();
+
+    // Step 1: session ownership.
+    if ctx.target_id().is_some() && ctx.validate_session_ownership(session).is_err() {
+        return Err(ProbeSkip {
+            reason: "ownership_mismatch",
+        });
+    }
+
+    // Step 2: TunnelState load + basic checks.
+    let state = match TunnelState::load_with_profile(cfg.profile.as_deref()) {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            return Err(ProbeSkip {
+                reason: "no_tunnel",
+            })
+        }
+        Err(_) => {
+            return Err(ProbeSkip {
+                reason: "tunnel_state_error",
+            })
+        }
+    };
+
+    if state.mode.as_deref() != Some("attached") {
+        return Err(ProbeSkip {
+            reason: "tunnel_not_attached",
+        });
+    }
+
+    if state.attached_session_id.as_deref() != Some(&session.id) {
+        return Err(ProbeSkip {
+            reason: "session_id_mismatch",
+        });
+    }
+
+    // Step 3: state ↔ session direct correspondence (same remote host + port).
+    if state.remote_host != session.host {
+        return Err(ProbeSkip {
+            reason: "tunnel_host_mismatch",
+        });
+    }
+
+    let state_remote_port = state.remote_bridge_port.or(state.attached_remote_port);
+    if state_remote_port != Some(session.port) {
+        return Err(ProbeSkip {
+            reason: "tunnel_remote_port_mismatch",
+        });
+    }
+
+    // Step 4: state matches current context.
+    if ctx.validate_tunnel_ownership(&state).is_err() {
+        return Err(ProbeSkip {
+            reason: "tunnel_context_mismatch",
+        });
+    }
+
+    // Step 5: forward process identity.
+    if state.pid == 0 {
+        return Err(ProbeSkip {
+            reason: "tunnel_no_pid",
+        });
+    }
+
+    let expected_identity = match state.start_identity {
+        Some(id) if id > 0 => id,
+        _ => {
+            return Err(ProbeSkip {
+                reason: "tunnel_identity_unverified",
+            })
+        }
+    };
+
+    let actual_identity = match ProcessIdentity::of_pid(state.pid) {
+        Ok(id) => id,
+        Err(IdentityError::NoSuchProcess(_)) => {
+            return Err(ProbeSkip {
+                reason: "tunnel_process_dead",
+            })
+        }
+        Err(_) => {
+            return Err(ProbeSkip {
+                reason: "tunnel_identity_unreadable",
+            })
+        }
+    };
+
+    // Verify the process is actually an ssh executable (reuse existing logic).
+    match classify_ssh_pid(state.pid) {
+        PidVerdict::VerifiedSsh => {}
+        PidVerdict::Gone => {
+            return Err(ProbeSkip {
+                reason: "tunnel_process_dead",
+            })
+        }
+        PidVerdict::NotVerifiable { .. } => {
+            return Err(ProbeSkip {
+                reason: "tunnel_process_not_ssh",
+            })
         }
     }
 
-    let mut sessions = SessionInfo::list()
+    if actual_identity.start_identity != expected_identity {
+        return Err(ProbeSkip {
+            reason: "tunnel_process_reused",
+        });
+    }
+
+    // Step 6: local forward port reachable.
+    if !tcp_reachable(state.port) {
+        return Err(ProbeSkip {
+            reason: "forward_port_unreachable",
+        });
+    }
+
+    Ok(ProbeEndpoint::RemoteTunnel { port: state.port })
+}
+
+/// Check whether a session belongs to this machine, given the config.
+///
+/// - If `cfg.remote_host` is set, the session is local only if its host
+///   matches exactly.
+/// - If `cfg.remote_host` is unset, we check known local hostnames
+///   (`localhost`, `127.0.0.1`, `::1`) and the `HOSTNAME` env var.
+/// - Anything that cannot be confirmed is treated as NOT local (skip probe).
+fn is_local_session(cfg: &Config, session: &SessionInfo) -> bool {
+    const LOCAL_HOSTNAMES: &[&str] = &["localhost", "127.0.0.1", "::1"];
+
+    if let Some(host) = &cfg.remote_host {
+        return session.host == *host;
+    }
+
+    if LOCAL_HOSTNAMES.contains(&session.host.as_str()) {
+        return true;
+    }
+
+    // Fall back to HOSTNAME env var (commonly set on Linux/macOS).
+    if let Ok(sys_hostname) = std::env::var("HOSTNAME") {
+        if !sys_hostname.is_empty() && session.host == sys_hostname {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// TCP reachability check with an explicit 200ms timeout. Used by both
+/// local and remote probe paths.
+fn tcp_reachable(port: u16) -> bool {
+    use std::net::TcpStream;
+    use std::time::Duration;
+    TcpStream::connect_timeout(
+        &format!("127.0.0.1:{port}").parse().unwrap(),
+        Duration::from_millis(200),
+    )
+    .is_ok()
+}
+
+/// List active Virtuoso sessions.
+///
+/// Behaviour differs by mode:
+///
+/// **Legacy (no target selected):** filter to locally-alive sessions (TCP
+/// reachable on `127.0.0.1:port`). Files are **never deleted** here —
+/// deletion is `session cleanup`'s job.
+///
+/// **Target mode:** show **all** cached sessions (including unattached /
+/// remote-only) with three independent status fields:
+/// - `endpoint_match`: `"match"` / `"mismatch"` / `"unchecked"` — does the
+///   session's host+port match the selected target?
+/// - `tunnel_verified`: `true` / `false` — is there an attached tunnel whose
+///   `attached_session_id` points at this session?
+/// - `probe_status`: `"reachable"` / `"unreachable"` / `"not_probed"` — only
+///   probed when `tunnel_verified` is true; otherwise `"not_probed"` (we do
+///   NOT equate "local port unreachable" with "remote daemon dead").
+///
+/// Remote sync uses the resolved `ctx.config()` — never re-reads env.
+/// Sync failures are surfaced as `sync_status: "failed"` but the cached
+/// list is still returned.
+pub fn list(ctx: &CommandContext, format: OutputFormat) -> Result<Value> {
+    let cfg = ctx.config();
+
+    // Remote sync: use the SAME immutable config as the rest of the invocation.
+    let sync_status: &str = if cfg.is_remote() {
+        match SSHClient::from_config(cfg, cfg.keep_remote_files) {
+            Ok(client) => {
+                if SessionInfo::sync_from_remote(client.transport().as_ref()).is_ok() {
+                    "ok"
+                } else {
+                    "failed"
+                }
+            }
+            Err(_) => "failed",
+        }
+    } else {
+        "ok"
+    };
+
+    let sessions = SessionInfo::list()
         .map_err(|e| VirtuosoError::Execution(format!("failed to read sessions: {e}")))?;
 
-    let sessions_dir = SessionInfo::sessions_dir();
-    sessions.retain(|s| {
-        if s.is_alive() {
-            true
-        } else {
-            let _ = std::fs::remove_file(sessions_dir.join(format!("{}.json", s.id)));
-            false
-        }
-    });
+    let has_target = ctx.target_id().is_some();
 
+    // Legacy: filter to locally-alive, but NEVER delete files.
+    // Target: show all cached sessions (no filtering).
+    let displayed: Vec<&SessionInfo> = if has_target {
+        sessions.iter().collect()
+    } else {
+        sessions.iter().filter(|s| s.is_alive()).collect()
+    };
+
+    // Load TunnelState once for target mode (performance: don't reload per
+    // session).
+    let tunnel_state = if has_target {
+        TunnelState::load_with_profile(cfg.profile.as_deref())
+            .ok()
+            .flatten()
+    } else {
+        None
+    };
+
+    // Build per-session JSON entries.
+    let session_entries: Vec<Value> = displayed
+        .iter()
+        .map(|s| {
+            if has_target {
+                let endpoint_match = compute_endpoint_match(ctx, s);
+                let (tunnel_verified, probe_status) = match &tunnel_state {
+                    Some(state)
+                        if state.mode.as_deref() == Some("attached")
+                            && state.attached_session_id.as_deref() == Some(&s.id) =>
+                    {
+                        if tcp_reachable(state.port) {
+                            (true, "reachable")
+                        } else {
+                            (true, "unreachable")
+                        }
+                    }
+                    _ => (false, "not_probed"),
+                };
+                json!({
+                    "id": s.id,
+                    "port": s.port,
+                    "pid": s.pid,
+                    "host": s.host,
+                    "user": s.user,
+                    "created": s.created,
+                    "endpoint_match": endpoint_match,
+                    "tunnel_verified": tunnel_verified,
+                    "probe_status": probe_status,
+                })
+            } else {
+                json!({
+                    "id": s.id,
+                    "port": s.port,
+                    "pid": s.pid,
+                    "host": s.host,
+                    "user": s.user,
+                    "created": s.created,
+                })
+            }
+        })
+        .collect();
+
+    // JSON output.
     if format == OutputFormat::Json {
+        let mut result = json!({
+            "status": "success",
+            "count": displayed.len(),
+            "sync_status": sync_status,
+            "sessions": session_entries,
+        });
+        if sync_status == "failed" {
+            result["note"] = json!("remote sync failed; showing cached sessions only");
+        }
+        return Ok(result);
+    }
+
+    // Table output.
+    if displayed.is_empty() {
+        println!("No active Virtuoso sessions found.");
+        println!("Start Virtuoso and run RBStart() in CIW to register a session.");
         return Ok(json!({
             "status": "success",
-            "count": sessions.len(),
-            "sessions": sessions.iter().map(|s| json!({
-                "id": s.id,
-                "port": s.port,
-                "pid": s.pid,
-                "host": s.host,
-                "user": s.user,
-                "created": s.created,
-            })).collect::<Vec<_>>(),
+            "count": 0,
+            "sync_status": sync_status
         }));
     }
 
-    if sessions.is_empty() {
-        println!("No active Virtuoso sessions found.");
-        println!("Start Virtuoso and run RBStart() in CIW to register a session.");
-        return Ok(json!({"status": "success", "count": 0}));
-    }
-
-    println!(
-        "{:<20} {:>6}  {:>7}  {:<12}  CREATED",
-        "SESSION ID", "PORT", "PID", "HOST"
-    );
-    println!("{}", "-".repeat(72));
-    for s in &sessions {
+    if has_target {
         println!(
-            "{:<20} {:>6}  {:>7}  {:<12}  {}",
-            s.id, s.port, s.pid, s.host, s.created
+            "{:<20} {:>6}  {:<14}  {:<10}  {:<12}  CREATED",
+            "SESSION ID", "PORT", "HOST", "ENDPOINT", "PROBE"
         );
+        println!("{}", "-".repeat(90));
+        for entry in &session_entries {
+            println!(
+                "{:<20} {:>6}  {:<14}  {:<10}  {:<12}  {}",
+                entry["id"].as_str().unwrap_or(""),
+                entry["port"].as_u64().unwrap_or(0),
+                entry["host"].as_str().unwrap_or(""),
+                entry["endpoint_match"].as_str().unwrap_or(""),
+                entry["probe_status"].as_str().unwrap_or(""),
+                entry["created"].as_str().unwrap_or(""),
+            );
+        }
+    } else {
+        println!(
+            "{:<20} {:>6}  {:>7}  {:<12}  CREATED",
+            "SESSION ID", "PORT", "PID", "HOST"
+        );
+        println!("{}", "-".repeat(72));
+        for s in &displayed {
+            println!(
+                "{:<20} {:>6}  {:>7}  {:<12}  {}",
+                s.id, s.port, s.pid, s.host, s.created
+            );
+        }
     }
 
-    Ok(json!({"status": "success", "count": sessions.len()}))
+    Ok(json!({
+        "status": "success",
+        "count": displayed.len(),
+        "sync_status": sync_status
+    }))
 }
 
 pub fn current() -> Result<Value> {
@@ -142,60 +505,94 @@ pub fn history(id: &str, only_skill: bool, only_cmd: bool, limit: usize) -> Resu
     }))
 }
 
-pub fn show(id: &str, _format: OutputFormat) -> Result<Value> {
+/// Show details for a specific session.
+///
+/// Two-phase behaviour:
+///
+/// **Phase 1 (always):** load the session file and present cached metadata.
+/// Errors here are real (file missing / corrupt → `NotFound`).
+///
+/// **Phase 2 (only when `resolve_probe_endpoint` succeeds):** connect to the
+/// verified local port, query the daemon for `$USER` / version / liveness,
+/// and write fresh values back to the session file. Any verification failure
+/// (ownership mismatch, no tunnel, dead process, corrupt state, …) sets
+/// `probe_skipped: true` with a `probe_skip_reason` — the cached view is
+/// still returned, never an error.
+pub fn show(ctx: &CommandContext, id: &str, _format: OutputFormat) -> Result<Value> {
+    // Phase 1: load session. File missing / corrupt is a real error.
     let s = SessionInfo::load(id)
         .map_err(|e| VirtuosoError::NotFound(format!("session '{id}' not found: {e}")))?;
 
-    // Best-effort liveness + identity probes.
-    //   - `is_alive()` is just a TCP-connect probe; cheap and tells us
-    //     whether the daemon port is bound.
-    //   - `daemon_alive()` is a SKILL-level probe (no-op `plus(1 1)`);
-    //     catches "port bound but daemon is wedged" cases. Replaces a
-    //     broken `ipcIsProcessRunning()` probe (which needs a process
-    //     handle argument and returns nil when called without one).
-    //   - `get_daemon_user()` queries the daemon's Unix $USER so we can
-    //     warn about SSH-tunnel-to-wrong-user misconfigurations.
-    let port_open = s.is_alive();
+    let endpoint_match = compute_endpoint_match(ctx, &s);
+
+    // Phase 2: resolve a probe endpoint, then probe if allowed.
     let (
         daemon_user,
         daemon_user_warning,
         daemon_responsive,
         daemon_version,
         daemon_version_warning,
-    ) = if port_open {
-        let client = VirtuosoClient::new("127.0.0.1", s.port, 3);
-        let user_result = client.get_daemon_user();
-        let version_result = client.get_daemon_version();
-        let alive = client.daemon_alive();
-        let ver = version_result.as_ref().unwrap_or(&None).clone();
-        let ver_warn = match &version_result {
-            Ok(Some(v)) => check_version_skew(v),
-            Ok(None) => None, // daemon did not report a version — don't warn
-            Err(e) => Some(format!("daemon version query failed: {e}")),
-        };
-        match user_result {
-            Ok(user_opt) => (user_opt, None, alive, ver, ver_warn),
-            Err(e) => (
-                None,
-                Some(format!("daemon user query failed: {e}")),
+        probe_skipped,
+        probe_skip_reason,
+        probe_source,
+        probe_port,
+    ) = match resolve_probe_endpoint(ctx, &s) {
+        Ok(endpoint) => {
+            let port = match &endpoint {
+                ProbeEndpoint::Local { port } => *port,
+                ProbeEndpoint::RemoteTunnel { port } => *port,
+            };
+            let source = match &endpoint {
+                ProbeEndpoint::Local { .. } => "local",
+                ProbeEndpoint::RemoteTunnel { .. } => "remote_tunnel",
+            };
+
+            let client = VirtuosoClient::new("127.0.0.1", port, 3);
+            let user_result = client.get_daemon_user();
+            let version_result = client.get_daemon_version();
+            let alive = client.daemon_alive();
+            let ver = version_result.as_ref().unwrap_or(&None).clone();
+            let ver_warn = match &version_result {
+                Ok(Some(v)) => check_version_skew(v),
+                Ok(None) => None,
+                Err(e) => Some(format!("daemon version query failed: {e}")),
+            };
+            let (user, user_warn) = match user_result {
+                Ok(user_opt) => (user_opt, None),
+                Err(e) => (None, Some(format!("daemon user query failed: {e}"))),
+            };
+
+            (
+                user,
+                user_warn,
                 alive,
                 ver,
                 ver_warn,
-            ),
+                false,
+                None,
+                Some(source),
+                Some(port),
+            )
         }
-    } else {
-        (None, None, false, None, None)
+        Err(skip) => (
+            None,
+            None,
+            false,
+            None,
+            None,
+            true,
+            Some(skip.reason),
+            None,
+            None,
+        ),
     };
 
-    // Cross-user check: if user has configured VB_REMOTE_USER_<profile>
-    // (or plain VB_REMOTE_USER) and the daemon reports a different Unix
-    // user, refuse to call this a healthy session.
-    let cross_user_warning = check_cross_user(&s, daemon_user.as_deref());
+    // Cross-user check uses the resolved config (never re-reads env).
+    let cross_user_warning = check_cross_user(ctx.config(), &s, daemon_user.as_deref());
 
-    // Stale-daemon recovery hint: when the port is open but the daemon is
-    // not responding to SKILL, the user is looking at a port held by
-    // another instance. Tell them how to clear it.
-    let stale_daemon_hint = if port_open && !daemon_responsive {
+    // Stale-daemon hint only when the probe actually ran and the daemon
+    // didn't respond.
+    let stale_daemon_hint = if !probe_skipped && !daemon_responsive {
         Some(
             "CIW daemon port is bound but the daemon is not responding to SKILL.\n\
              In the Virtuoso CIW, run:\n\
@@ -208,11 +605,9 @@ pub fn show(id: &str, _format: OutputFormat) -> Result<Value> {
         None
     };
 
-    // Cache daemon_user + daemon_version back into the session file so
-    // subsequent `session show` invocations and `session list` rows can
-    // surface them without re-querying. The write is best-effort; failure
-    // is silently ignored (we already have fresh data in the JSON response).
-    if daemon_user.is_some() || daemon_version.is_some() {
+    // Write back only when the probe succeeded and produced fresh data.
+    // Skipped probes never mutate the cache.
+    if !probe_skipped && (daemon_user.is_some() || daemon_version.is_some()) {
         let mut s_mut = s.clone();
         if let Some(u) = daemon_user.as_ref() {
             s_mut.daemon_user = Some(u.clone());
@@ -237,11 +632,17 @@ pub fn show(id: &str, _format: OutputFormat) -> Result<Value> {
             "host": s.host,
             "user": s.user,
             "created": s.created,
-            "alive": port_open,
+            "endpoint_match": endpoint_match,
             "daemon_responsive": daemon_responsive,
             "daemon_user": daemon_user,
             "daemon_version": daemon_version,
             "cli_version": env!("CARGO_PKG_VERSION"),
+        },
+        "probe": {
+            "skipped": probe_skipped,
+            "skip_reason": probe_skip_reason,
+            "source": probe_source,
+            "port": probe_port,
         },
         "warnings": {
             "daemon_user": daemon_user_warning,
@@ -250,6 +651,21 @@ pub fn show(id: &str, _format: OutputFormat) -> Result<Value> {
             "stale_daemon": stale_daemon_hint,
         }
     }))
+}
+
+/// Compute the endpoint match status for a session under the current context.
+///
+/// - `"unchecked"` — no target selected (legacy mode); ownership is not verified.
+/// - `"match"` — target selected and session host (+ port when explicit) matches.
+/// - `"mismatch"` — target selected but session does not match.
+fn compute_endpoint_match(ctx: &CommandContext, session: &SessionInfo) -> &'static str {
+    if ctx.target_id().is_none() {
+        return "unchecked";
+    }
+    match ctx.validate_session_ownership(session) {
+        Ok(_) => "match",
+        Err(_) => "mismatch",
+    }
 }
 
 /// Compare the daemon's reported version (from `RBDVersion` global) with the
@@ -268,47 +684,41 @@ fn check_version_skew(daemon_version: &str) -> Option<String> {
     ))
 }
 
-/// Compare the daemon's Unix user with the configured `VB_REMOTE_USER[<profile>]`.
+/// Compare the daemon's Unix user with the configured `remote_user`.
+///
 /// Returns `Some(warning)` if a mismatch is detected, `None` otherwise.
-/// Set `VB_ALLOW_CROSS_USER_DAEMON=1` to suppress the warning.
+/// Set `allow_cross_user_daemon: true` in config (env: `VB_ALLOW_CROSS_USER_DAEMON=1`,
+/// or target config field) to suppress the warning.
+///
+/// Uses the resolved `Config` — never re-reads environment variables.
+/// `Config::from_env()` already handles the `VB_REMOTE_USER_<profile>` →
+/// `VB_REMOTE_USER` fallback, so this function simply uses `cfg.remote_user`.
 fn check_cross_user(
-    session: &crate::models::SessionInfo,
+    cfg: &Config,
+    session: &SessionInfo,
     daemon_user: Option<&str>,
 ) -> Option<String> {
-    let profile = std::env::var("VB_PROFILE").ok();
-    let expected = std::env::var(format!(
-        "VB_REMOTE_USER{}",
-        profile
-            .as_deref()
-            .filter(|p| !p.is_empty())
-            .map(|p| format!("_{p}"))
-            .unwrap_or_default()
-    ))
-    .ok()
-    .or_else(|| std::env::var("VB_REMOTE_USER").ok())
-    .map(|s| s.trim().to_string())
-    .filter(|s| !s.is_empty())?;
+    let expected = cfg
+        .remote_user
+        .as_deref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())?;
 
     let daemon_user = daemon_user?;
     if daemon_user == expected {
         return None;
     }
-    if std::env::var("VB_ALLOW_CROSS_USER_DAEMON")
-        .ok()
-        .filter(|v| !v.is_empty())
-        .map(|v| {
-            matches!(
-                v.trim().to_ascii_lowercase().as_str(),
-                "1" | "true" | "yes" | "on"
-            )
-        })
-        .unwrap_or(false)
-    {
+
+    // allow_cross_user_daemon only suppresses the warning — it does NOT
+    // bypass target/session ownership validation (that happens in
+    // resolve_probe_endpoint, independently).
+    if cfg.allow_cross_user_daemon {
         return None;
     }
+
     Some(format!(
-        "daemon Unix user {daemon_user:?} does not match configured VB_REMOTE_USER {expected:?} \
-         for session {sid}. Set VB_ALLOW_CROSS_USER_DAEMON=1 to override intentionally.",
+        "daemon Unix user {daemon_user:?} does not match configured remote_user {expected:?} \
+         for session {sid}. Set allow_cross_user_daemon: true (or VB_ALLOW_CROSS_USER_DAEMON=1) to override intentionally.",
         sid = session.id
     ))
 }
@@ -332,31 +742,56 @@ mod tests {
         }
     }
 
-    /// Helper: clear all relevant env vars before each test that mutates them.
-    fn clear_remote_user_env() {
-        std::env::remove_var("VB_REMOTE_USER");
-        std::env::remove_var("VB_REMOTE_USER_default");
-        std::env::remove_var("VB_REMOTE_USER_testprofile");
-        std::env::remove_var("VB_PROFILE");
-        std::env::remove_var("VB_ALLOW_CROSS_USER_DAEMON");
+    /// Test helper: construct a Config with only the fields check_cross_user
+    /// cares about. All other fields are set to safe defaults. This avoids
+    /// mutating process environment (no #[serial] needed).
+    fn test_config(remote_user: Option<&str>, allow_cross: bool) -> Config {
+        Config {
+            profile: None,
+            remote_host: Some("test-host".into()),
+            remote_user: remote_user.map(|s| s.to_string()),
+            port: 40000,
+            port_explicit: true,
+            jump_host: None,
+            jump_user: None,
+            ssh_port: None,
+            ssh_key: None,
+            ssh_config: None,
+            ssh_backend: None,
+            disable_control_master: false,
+            timeout: 30,
+            read_timeout: 30,
+            keep_remote_files: false,
+            spectre_cmd: "spectre".into(),
+            spectre_args: vec![],
+            spectre_max_workers: 4,
+            ssh_max_sessions: 10,
+            ssh_max_bulk_sessions: 2,
+            ssh_reconnect_max_attempts: 3,
+            ssh_reconnect_max_delay: 30,
+            ssh_keepalive_interval: 0,
+            ssh_keepalive_failures: 3,
+            transport_shutdown_grace: 5,
+            cadence_cshrc: None,
+            spectre_bin: None,
+            roles: crate::config::RemoteRoles::default(),
+            transport_daemon_socket: None,
+            transport_daemon_token: None,
+            allow_cross_user_daemon: allow_cross,
+        }
     }
 
     #[test]
-    #[serial]
     fn cross_user_match_returns_none() {
-        clear_remote_user_env();
-        std::env::set_var("VB_REMOTE_USER", "meow");
-        let r = check_cross_user(&session(), Some("meow"));
+        let cfg = test_config(Some("meow"), false);
+        let r = check_cross_user(&cfg, &session(), Some("meow"));
         assert!(r.is_none());
-        clear_remote_user_env();
     }
 
     #[test]
-    #[serial]
     fn cross_user_mismatch_returns_warning() {
-        clear_remote_user_env();
-        std::env::set_var("VB_REMOTE_USER", "alice");
-        let r = check_cross_user(&session(), Some("bob"));
+        let cfg = test_config(Some("alice"), false);
+        let r = check_cross_user(&cfg, &session(), Some("bob"));
         let w = r.expect("expected warning for user mismatch");
         assert!(
             w.contains("\"bob\""),
@@ -367,86 +802,61 @@ mod tests {
             "warning should name configured user: {w}"
         );
         assert!(
-            w.contains("VB_ALLOW_CROSS_USER_DAEMON=1"),
+            w.contains("allow_cross_user_daemon"),
             "warning should mention override: {w}"
         );
         assert!(
             w.contains("meowu-meow-40567"),
             "warning should name session: {w}"
         );
-        clear_remote_user_env();
     }
 
     #[test]
-    #[serial]
     fn cross_user_mismatch_suppressed_by_override() {
-        clear_remote_user_env();
-        std::env::set_var("VB_REMOTE_USER", "alice");
-        std::env::set_var("VB_ALLOW_CROSS_USER_DAEMON", "1");
-        let r = check_cross_user(&session(), Some("bob"));
-        assert!(r.is_none(), "VB_ALLOW_CROSS_USER_DAEMON=1 should suppress");
-        clear_remote_user_env();
+        let cfg = test_config(Some("alice"), true);
+        let r = check_cross_user(&cfg, &session(), Some("bob"));
+        assert!(r.is_none(), "allow_cross_user_daemon=true should suppress");
     }
 
     #[test]
-    #[serial]
-    fn cross_user_mismatch_override_truthy_values() {
-        for v in ["true", "yes", "on", "TRUE", "Yes", "  on  "] {
-            clear_remote_user_env();
-            std::env::set_var("VB_REMOTE_USER", "alice");
-            std::env::set_var("VB_ALLOW_CROSS_USER_DAEMON", v);
-            let r = check_cross_user(&session(), Some("bob"));
-            assert!(r.is_none(), "override {v:?} should suppress warning");
-        }
-        clear_remote_user_env();
-    }
-
-    #[test]
-    #[serial]
-    fn cross_user_no_env_var_returns_none() {
-        clear_remote_user_env();
-        // No VB_REMOTE_USER set
-        let r = check_cross_user(&session(), Some("anyone"));
+    fn cross_user_no_remote_user_returns_none() {
+        // Config has no remote_user — nothing to compare against.
+        let cfg = test_config(None, false);
+        let r = check_cross_user(&cfg, &session(), Some("anyone"));
         assert!(r.is_none());
     }
 
     #[test]
-    #[serial]
     fn cross_user_no_daemon_user_returns_none() {
-        clear_remote_user_env();
-        std::env::set_var("VB_REMOTE_USER", "meow");
+        let cfg = test_config(Some("meow"), false);
         // daemon_user is None — we don't know, so don't warn
-        let r = check_cross_user(&session(), None);
+        let r = check_cross_user(&cfg, &session(), None);
         assert!(r.is_none());
     }
 
     #[test]
-    #[serial]
-    fn cross_user_profile_scoped_env_var() {
-        clear_remote_user_env();
-        std::env::set_var("VB_PROFILE", "testprofile");
-        std::env::set_var("VB_REMOTE_USER_testprofile", "alice");
-        // Profile-scoped env should trigger check
-        let r = check_cross_user(&session(), Some("bob"));
-        assert!(r.is_some(), "profile-scoped env var should trigger check");
-
-        // When profile-scoped is set but matches, no warning
-        let r = check_cross_user(&session(), Some("alice"));
-        assert!(r.is_none());
-        clear_remote_user_env();
-    }
-
-    #[test]
-    #[serial]
-    fn cross_user_empty_env_var_is_treated_as_unset() {
-        clear_remote_user_env();
-        std::env::set_var("VB_REMOTE_USER", "   ");
-        let r = check_cross_user(&session(), Some("bob"));
+    fn cross_user_whitespace_remote_user_treated_as_unset() {
+        let cfg = test_config(Some("   "), false);
+        let r = check_cross_user(&cfg, &session(), Some("bob"));
         assert!(
             r.is_none(),
-            "whitespace-only env var should be treated as unset"
+            "whitespace-only remote_user should be treated as unset"
         );
-        clear_remote_user_env();
+    }
+
+    #[test]
+    fn cross_user_override_does_not_bypass_ownership() {
+        // allow_cross_user_daemon only suppresses the cross-user WARNING.
+        // It does NOT affect ownership validation (which happens in
+        // resolve_probe_endpoint, independently). This test verifies the
+        // function still returns None (suppressed) when override is on,
+        // confirming the override is scoped to warning suppression only.
+        let cfg = test_config(Some("alice"), true);
+        let r = check_cross_user(&cfg, &session(), Some("bob"));
+        assert!(r.is_none(), "override suppresses warning");
+        // The config still records the mismatch — ownership is a separate concern.
+        assert_eq!(cfg.remote_user.as_deref(), Some("alice"));
+        assert!(cfg.allow_cross_user_daemon);
     }
 
     // ------------------------------------------------------------------
@@ -499,6 +909,447 @@ mod tests {
         assert!(
             check_version_skew("?").is_some(),
             "'?' placeholder should produce a skew warning"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // resolve_probe_endpoint — behaviour acceptance tests
+    // ------------------------------------------------------------------
+
+    /// RAII guard: set VB_STATE_DIR to a temp dir for the duration of a
+    /// test, restore the original value afterwards. This lets tests save
+    /// and load TunnelState without polluting the user's real state dir.
+    struct StateDirGuard {
+        original: Option<String>,
+        _tempdir: tempfile::TempDir,
+    }
+
+    impl StateDirGuard {
+        fn new() -> Self {
+            let original = std::env::var("VB_STATE_DIR").ok();
+            let tempdir = tempfile::tempdir().expect("failed to create temp dir");
+            std::env::set_var("VB_STATE_DIR", tempdir.path());
+            Self {
+                original,
+                _tempdir: tempdir,
+            }
+        }
+    }
+
+    impl Drop for StateDirGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => std::env::set_var("VB_STATE_DIR", v),
+                None => std::env::remove_var("VB_STATE_DIR"),
+            }
+        }
+    }
+
+    /// Helper: construct a TunnelState with the given fields. All other
+    /// fields are set to safe defaults.
+    fn make_tunnel_state(
+        remote_host: &str,
+        remote_port: u16,
+        local_port: u16,
+        pid: u32,
+        start_identity: Option<u64>,
+        attached_session_id: Option<&str>,
+        mode: Option<&str>,
+    ) -> crate::models::TunnelState {
+        crate::models::TunnelState {
+            version: crate::models::CURRENT_STATE_VERSION,
+            port: local_port,
+            pid,
+            remote_host: remote_host.into(),
+            setup_path: None,
+            profile: None,
+            backend: None,
+            daemon_nonce: None,
+            executable_path: None,
+            start_identity,
+            ipc_endpoint: None,
+            token_path: None,
+            local_forward: None,
+            start_time_unix_ms: None,
+            health: None,
+            config_digest: None,
+            mode: mode.map(|s| s.into()),
+            attached_remote_port: Some(remote_port),
+            remote_bridge_port: Some(remote_port),
+            attached_session_id: attached_session_id.map(|s| s.into()),
+        }
+    }
+
+    /// Helper: construct a remote Config + CommandContext for testing.
+    fn remote_ctx(remote_host: &str, port: u16) -> CommandContext {
+        let mut cfg = test_config(None, false);
+        cfg.remote_host = Some(remote_host.into());
+        cfg.port = port;
+        cfg.port_explicit = true;
+        CommandContext::new(cfg, Some("test-target".into())).expect("ctx")
+    }
+
+    #[test]
+    fn probe_local_direct_skipped_when_session_is_remote() {
+        // Local config (no remote_host) + a session whose host is a remote
+        // machine → must NOT probe (could connect to a wrong local service).
+        let mut cfg = test_config(None, false);
+        cfg.remote_host = None; // truly local config
+        let ctx = CommandContext::new(cfg, None).expect("ctx");
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "local_ownership_unverified"
+                })
+            ),
+            "remote session in local config should be skipped, got {r:?}"
+        );
+    }
+
+    #[test]
+    fn probe_local_direct_skipped_when_port_unreachable() {
+        // Local config + local session + port not bound → skip.
+        let mut cfg = test_config(None, false);
+        cfg.remote_host = None; // truly local config
+        let ctx = CommandContext::new(cfg, None).expect("ctx");
+        let mut s = session();
+        s.host = "localhost".into();
+        s.port = 1; // effectively never bound
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "local_port_unreachable"
+                })
+            ),
+            "unreachable local port should be skipped, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn probe_remote_no_tunnel_returns_no_tunnel() {
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "no_tunnel"
+                })
+            ),
+            "no tunnel state should return no_tunnel, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn probe_remote_tunnel_deployed_not_attached() {
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        let state = make_tunnel_state(
+            "remote-eda-01",
+            40000,
+            14000,
+            12345,
+            Some(999),
+            Some(&s.id),
+            Some("deployed"),
+        );
+        state.save_with_profile(None).expect("save state");
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "tunnel_not_attached"
+                })
+            ),
+            "deployed tunnel should return tunnel_not_attached, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn probe_remote_session_id_mismatch() {
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        let state = make_tunnel_state(
+            "remote-eda-01",
+            40000,
+            14000,
+            12345,
+            Some(999),
+            Some("different-session-id"),
+            Some("attached"),
+        );
+        state.save_with_profile(None).expect("save state");
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "session_id_mismatch"
+                })
+            ),
+            "different attached_session_id should return session_id_mismatch, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn probe_remote_host_mismatch() {
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        // State points at a DIFFERENT remote host than the session.
+        let state = make_tunnel_state(
+            "remote-eda-02",
+            40000,
+            14000,
+            12345,
+            Some(999),
+            Some(&s.id),
+            Some("attached"),
+        );
+        state.save_with_profile(None).expect("save state");
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "tunnel_host_mismatch"
+                })
+            ),
+            "state host mismatch should return tunnel_host_mismatch, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn probe_remote_remote_port_mismatch() {
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        // State's remote_bridge_port differs from session.port.
+        let state = make_tunnel_state(
+            "remote-eda-01",
+            40099, // wrong port
+            14000,
+            12345,
+            Some(999),
+            Some(&s.id),
+            Some("attached"),
+        );
+        state.save_with_profile(None).expect("save state");
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "tunnel_remote_port_mismatch"
+                })
+            ),
+            "state remote port mismatch should return tunnel_remote_port_mismatch, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn probe_remote_no_pid() {
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        let state = make_tunnel_state(
+            "remote-eda-01",
+            40000,
+            14000,
+            0, // no PID
+            Some(999),
+            Some(&s.id),
+            Some("attached"),
+        );
+        state.save_with_profile(None).expect("save state");
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "tunnel_no_pid"
+                })
+            ),
+            "pid=0 should return tunnel_no_pid, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn probe_remote_identity_unverified_when_start_identity_missing() {
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        let state = make_tunnel_state(
+            "remote-eda-01",
+            40000,
+            14000,
+            std::process::id(),
+            None, // no start_identity
+            Some(&s.id),
+            Some("attached"),
+        );
+        state.save_with_profile(None).expect("save state");
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "tunnel_identity_unverified"
+                })
+            ),
+            "missing start_identity should return tunnel_identity_unverified, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn probe_remote_process_dead_for_nonexistent_pid() {
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        let state = make_tunnel_state(
+            "remote-eda-01",
+            40000,
+            14000,
+            99999, // PID that (almost certainly) doesn't exist
+            Some(1),
+            Some(&s.id),
+            Some("attached"),
+        );
+        state.save_with_profile(None).expect("save state");
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "tunnel_process_dead"
+                })
+            ),
+            "nonexistent PID should return tunnel_process_dead, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn probe_remote_current_process_is_not_ssh() {
+        // The current test process is not ssh — classify_ssh_pid should
+        // return NotVerifiable, causing tunnel_process_not_ssh.
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-01".into();
+        s.port = 40000;
+
+        let my_pid = std::process::id();
+        let my_identity = crate::transport::identity::ProcessIdentity::of_pid(my_pid)
+            .map(|id| id.start_identity)
+            .unwrap_or(1);
+
+        let state = make_tunnel_state(
+            "remote-eda-01",
+            40000,
+            14000,
+            my_pid,
+            Some(my_identity),
+            Some(&s.id),
+            Some("attached"),
+        );
+        state.save_with_profile(None).expect("save state");
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "tunnel_process_not_ssh"
+                })
+            ),
+            "current process (not ssh) should return tunnel_process_not_ssh, got {r:?}"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn probe_remote_ownership_mismatch_skipped_before_tunnel_check() {
+        // Session host doesn't match target → ownership_mismatch, even if a
+        // tunnel state exists.
+        let _guard = StateDirGuard::new();
+        let ctx = remote_ctx("remote-eda-01", 40000);
+        let mut s = session();
+        s.host = "remote-eda-99".into(); // wrong host
+        s.port = 40000;
+
+        let state = make_tunnel_state(
+            "remote-eda-99",
+            40000,
+            14000,
+            12345,
+            Some(999),
+            Some(&s.id),
+            Some("attached"),
+        );
+        state.save_with_profile(None).expect("save state");
+
+        let r = resolve_probe_endpoint(&ctx, &s);
+        assert!(
+            matches!(
+                r,
+                Err(ProbeSkip {
+                    reason: "ownership_mismatch"
+                })
+            ),
+            "session host mismatch should return ownership_mismatch, got {r:?}"
         );
     }
 }

--- a/src/commands/session.rs
+++ b/src/commands/session.rs
@@ -242,34 +242,70 @@ fn resolve_remote_tunnel(
     Ok(ProbeEndpoint::RemoteTunnel { port: state.port })
 }
 
-/// Get the system hostname via libc::gethostname(2). Returns None on
-/// failure or if the hostname is empty. This is preferred over reading
-/// $HOSTNAME, which is not guaranteed to be set in every process
-/// environment (e.g. non-login shells, CI containers).
+/// Get the system hostname in a cross-platform way.
+///
+/// - **Unix** (Linux, macOS, BSD): `libc::gethostname(2)`.
+/// - **Windows**: `%COMPUTERNAME%` env var (libc crate does not provide
+///   `gethostname` on Windows).
+/// - **Other / fallback**: `$HOSTNAME` env var.
+///
+/// Returns None on failure or if the hostname is empty.
 fn system_hostname() -> Option<String> {
-    unsafe {
-        let mut buf = [0u8; 256];
-        if libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) != 0 {
-            return None;
+    #[cfg(unix)]
+    {
+        unsafe {
+            let mut buf = [0u8; 256];
+            if libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) != 0 {
+                return None;
+            }
+            let len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+            if len == 0 {
+                return None;
+            }
+            String::from_utf8(buf[..len].to_vec()).ok()
         }
-        let len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
-        if len == 0 {
-            return None;
-        }
-        String::from_utf8(buf[..len].to_vec()).ok()
+    }
+    #[cfg(windows)]
+    {
+        std::env::var("COMPUTERNAME").ok().filter(|s| !s.is_empty())
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        std::env::var("HOSTNAME").ok().filter(|s| !s.is_empty())
     }
 }
 
-/// Compare two hostnames, allowing short-name vs FQDN equivalence.
+/// Returns true if `s` parses as an IP address (IPv4 or IPv6). IP addresses
+/// must always be compared exactly — no short-name matching.
+fn is_ip_address(s: &str) -> bool {
+    s.parse::<std::net::IpAddr>().is_ok()
+}
+
+/// Compare two hostnames with strict matching rules.
 ///
-/// - Exact match (case-sensitive, as hostnames are on Unix).
-/// - Short-name match: if either contains a dot, compare the part before
-///   the first dot. This lets "compute-eda-42" match
-///   "compute-eda-42.internal.corp".
+/// - **Exact match** always wins.
+/// - **IP addresses** (either side) must match exactly — no truncation.
+/// - **Two fully-qualified names** (both contain a dot) must match exactly.
+///   `compute-42.prod.example` does NOT match `compute-42.test.example`.
+/// - **Short name vs FQDN**: if exactly one side has no dot (a short
+///   hostname), compare the short side against the first label of the FQDN.
+///   `compute-42` matches `compute-42.internal.corp`.
 fn hostnames_match(a: &str, b: &str) -> bool {
     if a == b {
         return true;
     }
+    // IP addresses: exact match only.
+    if is_ip_address(a) || is_ip_address(b) {
+        return false;
+    }
+    let a_has_dot = a.contains('.');
+    let b_has_dot = b.contains('.');
+    // Both are FQDNs: exact match only (already failed above).
+    if a_has_dot && b_has_dot {
+        return false;
+    }
+    // At least one side is a short hostname (no dot). Allow first-label
+    // comparison.
     let a_short = a.split('.').next().unwrap_or(a);
     let b_short = b.split('.').next().unwrap_or(b);
     !a_short.is_empty() && a_short == b_short
@@ -280,9 +316,12 @@ fn hostnames_match(a: &str, b: &str) -> bool {
 /// - If `cfg.remote_host` is set, the session is local only if its host
 ///   matches exactly.
 /// - If `cfg.remote_host` is unset, we check known local hostnames
-///   (`localhost`, `127.0.0.1`, `::1`), the system hostname (via
-///   libc::gethostname, with short/FQDN equivalence), and finally the
-///   `HOSTNAME` env var as a last resort.
+///   (`localhost`, `127.0.0.1`, `::1`), then the system hostname (via
+///   `system_hostname()`, with strict `hostnames_match()` rules). If the
+///   system hostname is available but does NOT match, we return false
+///   immediately — `$HOSTNAME` is not allowed to override an authoritative
+///   system-name mismatch.
+/// - `$HOSTNAME` is consulted only when the system hostname is unavailable.
 /// - Anything that cannot be confirmed is treated as NOT local (skip probe).
 fn is_local_session(cfg: &Config, session: &SessionInfo) -> bool {
     const LOCAL_HOSTNAMES: &[&str] = &["localhost", "127.0.0.1", "::1"];
@@ -295,14 +334,16 @@ fn is_local_session(cfg: &Config, session: &SessionInfo) -> bool {
         return true;
     }
 
-    // System hostname (preferred — does not depend on process env).
+    // System hostname (authoritative — does not depend on process env).
+    // If available and non-empty, its verdict is final: a mismatch here is
+    // NOT overridden by $HOSTNAME below.
     if let Some(sys_host) = system_hostname() {
-        if !sys_host.is_empty() && hostnames_match(&sys_host, &session.host) {
-            return true;
+        if !sys_host.is_empty() {
+            return hostnames_match(&sys_host, &session.host);
         }
     }
 
-    // Fall back to HOSTNAME env var (may not be set in all environments).
+    // $HOSTNAME fallback — only when system hostname is unavailable.
     if let Ok(env_host) = std::env::var("HOSTNAME") {
         if !env_host.is_empty() && hostnames_match(&env_host, &session.host) {
             return true;
@@ -400,11 +441,23 @@ pub fn list(ctx: &CommandContext, format: OutputFormat) -> Result<Value> {
                 // down). Any earlier failure (wrong host, dead process,
                 // mismatched session id, …) → tunnel_verified=false.
                 let probe_result = resolve_probe_endpoint_with_state(ctx, s, tunnel_state.as_ref());
+                // Distinguish local direct vs remote tunnel:
+                // - Local direct: tunnel_verified=false (no tunnel exists),
+                //   probe_status=reachable/unreachable based on port check.
+                // - Remote tunnel: tunnel_verified=true only when the full
+                //   6-step chain passes (or the only failure is
+                //   forward_port_unreachable, meaning identity verified but
+                //   port is down).
+                // - Any other failure → tunnel_verified=false, not_probed.
                 let (tunnel_verified, probe_status) = match probe_result {
-                    Ok(_) => (true, "reachable"),
+                    Ok(ProbeEndpoint::Local { .. }) => (false, "reachable"),
+                    Ok(ProbeEndpoint::RemoteTunnel { .. }) => (true, "reachable"),
                     Err(ProbeSkip {
                         reason: "forward_port_unreachable",
                     }) => (true, "unreachable"),
+                    Err(ProbeSkip {
+                        reason: "local_port_unreachable",
+                    }) => (false, "unreachable"),
                     Err(_) => (false, "not_probed"),
                 };
                 json!({
@@ -1064,6 +1117,15 @@ mod tests {
         CommandContext::new(cfg, Some("test-target".into())).expect("ctx")
     }
 
+    /// Helper: construct a local-target CommandContext (no remote_host).
+    fn local_ctx() -> CommandContext {
+        let mut cfg = test_config(None, false);
+        cfg.remote_host = None;
+        cfg.port = 0;
+        cfg.port_explicit = false;
+        CommandContext::new(cfg, Some("local-target".into())).expect("ctx")
+    }
+
     #[test]
     fn probe_local_direct_skipped_when_session_is_remote() {
         // Local config (no remote_host) + a session whose host is a remote
@@ -1465,6 +1527,36 @@ mod tests {
         assert!(!hostnames_match(".example.com", "anything"));
     }
 
+    #[test]
+    fn hostnames_match_different_domains_same_short_label() {
+        // Two FQDNs with the same first label but different domains must
+        // NOT match. compute-42.prod.example ≠ compute-42.test.example.
+        assert!(!hostnames_match(
+            "compute-42.prod.example",
+            "compute-42.test.example"
+        ));
+        assert!(!hostnames_match(
+            "compute-42.prod.example",
+            "compute-42.prod.other"
+        ));
+    }
+
+    #[test]
+    fn hostnames_match_different_ips() {
+        // IP addresses must match exactly — no first-octet truncation.
+        assert!(!hostnames_match("192.168.1.1", "192.168.1.2"));
+        assert!(!hostnames_match("10.0.0.1", "10.0.0.2"));
+        // IP vs hostname with same first label must not match.
+        assert!(!hostnames_match("192.168.1.1", "192"));
+    }
+
+    #[test]
+    fn hostnames_match_short_vs_fqdn_same_label() {
+        // A short hostname DOES match an FQDN whose first label is the same.
+        assert!(hostnames_match("compute-42", "compute-42.internal.corp"));
+        assert!(hostnames_match("compute-42.internal.corp", "compute-42"));
+    }
+
     // ------------------------------------------------------------------
     // resolve_probe_endpoint_with_state — same ID, wrong tunnel
     // ------------------------------------------------------------------
@@ -1659,6 +1751,64 @@ mod tests {
         assert_eq!(sessions[0]["probe_status"], "not_probed");
         // endpoint_match should be "match" (host+port match the target).
         assert_eq!(sessions[0]["endpoint_match"], "match");
+    }
+
+    #[test]
+    #[serial]
+    fn list_local_target_marks_direct_connection_not_tunnel() {
+        // A local target (no remote_host) with a reachable local session must
+        // show tunnel_verified=false (no SSH tunnel exists — this is a direct
+        // local connection) and probe_status=reachable.
+        let _cache = CacheDirGuard::new();
+
+        // Bind a real listener to simulate a local daemon port.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let port = listener.local_addr().expect("local addr").port();
+
+        let mut s = session();
+        s.host = "localhost".into();
+        s.port = port;
+        s.save_to_session_file();
+
+        let ctx = local_ctx();
+        let result = list(&ctx, OutputFormat::Json).expect("list should succeed");
+
+        let sessions = result["sessions"].as_array().expect("sessions array");
+        assert_eq!(sessions.len(), 1, "local session should be listed");
+        // Local direct connection: tunnel_verified must be false.
+        assert_eq!(
+            sessions[0]["tunnel_verified"], false,
+            "local direct connection must not be marked tunnel_verified"
+        );
+        assert_eq!(
+            sessions[0]["probe_status"], "reachable",
+            "reachable local port should show probe_status=reachable"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn list_local_target_unreachable_port_shows_unreachable() {
+        // A local target with an unreachable local port must show
+        // tunnel_verified=false and probe_status=unreachable (not
+        // not_probed — we did attempt the probe).
+        let _cache = CacheDirGuard::new();
+
+        let mut s = session();
+        s.host = "localhost".into();
+        s.port = 1; // effectively never bound
+        s.save_to_session_file();
+
+        let ctx = local_ctx();
+        let result = list(&ctx, OutputFormat::Json).expect("list should succeed");
+
+        let sessions = result["sessions"].as_array().expect("sessions array");
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0]["tunnel_verified"], false);
+        assert_eq!(
+            sessions[0]["probe_status"], "unreachable",
+            "unreachable local port should show probe_status=unreachable, not not_probed"
+        );
     }
 
     // ------------------------------------------------------------------

--- a/src/commands/tunnel.rs
+++ b/src/commands/tunnel.rs
@@ -1120,6 +1120,7 @@ mod backend_diagnostics_tests {
             roles: crate::config::RemoteRoles::default(),
             transport_daemon_socket: None,
             transport_daemon_token: None,
+            allow_cross_user_daemon: false,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -174,6 +174,12 @@ pub struct Config {
     /// Auth token for the transport daemon IPC connection (VB_TRANSPORT_DAEMON_TOKEN).
     /// Must match the token the daemon was started with. Unix-only.
     pub transport_daemon_token: Option<String>,
+    /// If true, suppress the cross-user daemon warning when the daemon's Unix
+    /// $USER differs from the configured `remote_user`. Set via
+    /// `VB_ALLOW_CROSS_USER_DAEMON=1` (env/profile) or `allow_cross_user_daemon: true`
+    /// in a target config. Does NOT bypass target/session ownership validation —
+    /// only silences the informational cross-user warning.
+    pub allow_cross_user_daemon: bool,
 }
 
 impl std::fmt::Debug for Config {
@@ -425,6 +431,14 @@ impl Config {
             },
             transport_daemon_socket: Self::env_with_profile("VB_TRANSPORT_DAEMON_SOCKET", profile),
             transport_daemon_token: Self::env_with_profile("VB_TRANSPORT_DAEMON_TOKEN", profile),
+            allow_cross_user_daemon: Self::env_with_profile("VB_ALLOW_CROSS_USER_DAEMON", profile)
+                .map(|v| {
+                    matches!(
+                        v.trim().to_ascii_lowercase().as_str(),
+                        "1" | "true" | "yes" | "on"
+                    )
+                })
+                .unwrap_or(false),
         })
     }
 
@@ -497,6 +511,7 @@ impl Config {
             roles: RemoteRoles::default(),
             transport_daemon_socket: target.transport_daemon_socket.clone(),
             transport_daemon_token: target.transport_daemon_token.clone(),
+            allow_cross_user_daemon: target.allow_cross_user_daemon.unwrap_or(false),
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2723,8 +2723,8 @@ fn main() {
         Commands::Symbol(cmd) => dispatch_symbol(cmd),
         Commands::Library(LibraryCmd::List) => commands::library::list(),
         Commands::Session(cmd) => match cmd {
-            SessionCmd::List => commands::session::list(format),
-            SessionCmd::Show { id } => commands::session::show(&id, format),
+            SessionCmd::List => commands::session::list(ctx.as_ref().unwrap(), format),
+            SessionCmd::Show { id } => commands::session::show(ctx.as_ref().unwrap(), &id, format),
             SessionCmd::Current => commands::session::current(),
             SessionCmd::Cleanup => commands::session::cleanup(),
             SessionCmd::History {

--- a/src/target/mod.rs
+++ b/src/target/mod.rs
@@ -66,6 +66,10 @@ pub struct TargetConfig {
     pub transport_daemon_socket: Option<String>,
     /// Transport daemon auth token
     pub transport_daemon_token: Option<String>,
+    /// If true, suppress the cross-user daemon warning when the daemon's Unix
+    /// $USER differs from `remote_user`. Does NOT bypass ownership validation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allow_cross_user_daemon: Option<bool>,
     /// Human-readable description
     pub description: Option<String>,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -53,6 +53,7 @@ mod config_tests {
             roles: crate::config::RemoteRoles::default(),
             transport_daemon_socket: None,
             transport_daemon_token: None,
+            allow_cross_user_daemon: false,
         }
     }
 

--- a/src/transport/backend.rs
+++ b/src/transport/backend.rs
@@ -223,6 +223,7 @@ mod tests {
             roles: crate::config::RemoteRoles::default(),
             transport_daemon_socket: None,
             transport_daemon_token: None,
+            allow_cross_user_daemon: false,
         }
     }
 

--- a/src/transport/lifecycle.rs
+++ b/src/transport/lifecycle.rs
@@ -417,6 +417,7 @@ mod tests {
             roles: Default::default(),
             transport_daemon_socket: None,
             transport_daemon_token: None,
+            allow_cross_user_daemon: false,
         }
     }
 

--- a/src/transport/native.rs
+++ b/src/transport/native.rs
@@ -1241,6 +1241,7 @@ mod tests {
             roles: Default::default(),
             transport_daemon_socket: None,
             transport_daemon_token: None,
+            allow_cross_user_daemon: false,
         }
     }
 

--- a/src/transport/pool.rs
+++ b/src/transport/pool.rs
@@ -479,6 +479,7 @@ mod tests {
             roles: Default::default(),
             transport_daemon_socket: None,
             transport_daemon_token: None,
+            allow_cross_user_daemon: false,
         }
     }
 

--- a/src/transport/scheduler.rs
+++ b/src/transport/scheduler.rs
@@ -689,6 +689,7 @@ mod tests {
             roles: Default::default(),
             transport_daemon_socket: None,
             transport_daemon_token: None,
+            allow_cross_user_daemon: false,
         }
     }
 

--- a/src/transport/x11.rs
+++ b/src/transport/x11.rs
@@ -5507,6 +5507,7 @@ mod tests {
             },
             transport_daemon_socket: None,
             transport_daemon_token: None,
+            allow_cross_user_daemon: false,
         }
     }
 

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -149,6 +149,7 @@ fn test_config_digest_distinguishes_port_explicit() {
         roles: Default::default(),
         transport_daemon_socket: None,
         transport_daemon_token: None,
+        allow_cross_user_daemon: false,
     };
     let mut explicit = base.clone();
     explicit.port_explicit = true;


### PR DESCRIPTION
## 变更范围

P0-A 身份闭环阶段：将 `session list` / `session show` 从 `Config::from_env()` / 直接读环境变量迁移到接收 `&CommandContext`，实现配置一次解析 + 探测路径身份校验。

tunnel 命令族迁移已完成并合入主线；本 PR 是下一个命令族。

## 提交链（基于 7804baa）

| 提交 | 内容 |
|------|------|
| `0635d2e` | 初始迁移：list/show 收 `&CommandContext`，共享探测判定函数，`allow_cross_user_daemon` 配置 |
| `cd4479c` | 审查修复：共享验证链（list/show 同一实现）、缓存元数据回退、系统主机名获取 |
| `b937f17` | 审查修复：平台适配（cfg(unix)/cfg(windows)）、主机名严格匹配（IP/FQDN/短名区分）、本地直连状态区分 |

## 核心设计

- **共享探测判定**：`resolve_probe_endpoint(ctx, session)` 返回 `ProbeEndpoint::Local` 或 `ProbeEndpoint::RemoteTunnel`，list/show 共用同一验证链
- **远端隧道路径 6 步验证**：session 归属 → TunnelState attached+session_id 匹配 → state↔session 主机/端口匹配 → state↔context 归属 → 转发进程身份（PID+启动时间+可执行文件）→ 本地转发端口可达
- **本地直连路径**：配置为本地 AND session 属于本机（系统主机名验证），使用本地端口探测
- **show 两阶段**：缓存元数据始终展示；在线探测+回写仅在验证通过时执行；`daemon_responsive: Option<bool>`（null=未探测）
- **list 三状态**：`endpoint_match` / `tunnel_verified` / `probe_status`；不再删除 session 文件
- **`allow_cross_user_daemon`**：Config + TargetConfig 新增字段，环境变量 `VB_ALLOW_CROSS_USER_DAEMON`；仅抑制用户不匹配警告，不跳过归属校验；不入 digest

## 本地验证

| 检查 | 结果 |
|------|------|
| `cargo check --all-targets`（macOS） | 通过 |
| `cargo check --target x86_64-pc-windows-gnu` | 通过（交叉编译检查，未覆盖 --all-targets/运行/native-ssh） |
| `cargo clippy --all-targets -- -D warnings` | 通过 |
| `rustfmt --edition 2021 --check` | 通过 |
| `cargo test --lib`（全量 #1） | 966 passed, 3 failed |
| `cargo test --lib`（全量 #2） | 968 passed, 1 failed |
| `cargo test --lib -- --test-threads=1 wait_for_forward` | 6/6 通过 |

## 已知失败与基线对照

| 测试 | main 全量 | 本分支全量 #1 | 本分支全量 #2 | 结论 |
|------|-----------|---------------|---------------|------|
| `wait_for_forward_rejects_unrelated_listener_when_ssh_fails_late` | 失败 | 失败 | 失败 | 基线已有该失败；根因未定 |
| `wait_for_forward_fails_when_child_dies_despite_port_open` | 通过 | 失败 | 通过 | 未稳定复现，回归与否尚未确定 |
| `wait_for_forward_succeeds_when_ssh_reports_the_bind` | 通过 | 失败 | 通过 | 未稳定复现，回归与否尚未确定 |

三个失败均位于 `src/transport/tunnel.rs`，本 PR 未修改该文件。`rejects_unrelated_listener` 在 main 同失败，确认基线已有；另外两个偶发失败重跑通过，不能排除本分支提高失败概率，待 CI 多平台数据验证。

## 待 CI 验证

- Linux/macOS/Windows × default/native-ssh 矩阵（`integration.yml`）
- Ubuntu 默认特性的 fmt/clippy/test/build/audit（`ci.yml`）

## 范围说明

- 仅迁移 `session list` / `session show`
- `session current` / `cleanup` / `history` / `heartbeat` 仍为全局缓存语义，暂不扩展
- P0-B（真实 SSH 长连接复用）继续暂缓
- 不修改 `src/transport/tunnel.rs`