### PR TITLE
docs(skill): add SSH connection throttling etiquette

### DIFF
--- a/.claude/skills/virtuoso-gui-debug/SKILL.md
+++ b/.claude/skills/virtuoso-gui-debug/SKILL.md
@@ -66,6 +66,32 @@ ssh ubuntu-docker "cat /tmp/virtuoso-daemon.log | grep PORT"
 - DISPLAY: `:5.0`
 - Session ID: `dean-user1-<PORT>`
 
+## SSH Connection Etiquette
+
+Rapid-fire `ssh` invocations from automation (one connection per command) can trip the remote
+sshd's connection protection (`MaxStartups` / Fail2ban), which shows up as:
+
+```
+ssh_exchange_identification: Connection closed by remote host
+```
+
+This is a **client-side connection-frequency issue, NOT a vcli bug**. vcli talks to the daemon
+over TCP (the session port from `vcli session list`), not SSH, so vcli never contributes to
+connection throttling.
+
+Mitigation:
+
+- **Batch commands**: pack multiple operations into one ssh call (e.g. one base64-encoded
+  script) instead of one ssh per command.
+- **Reuse connections**: for many sequential calls use SSH ControlMaster, e.g.
+  `ssh -o ControlMaster=auto -o ControlPath=/tmp/vcli-ssh-%r@%h:%p ...`.
+- **Back off on rejection**: after `Connection closed by remote host`, wait 60–120s before
+  retrying; the throttle is temporary.
+- **Prefer one round-trip**: for complex commands, base64-encode the script to avoid quoting
+  issues: `echo <b64> | base64 -d | bash`.
+- **Don't misread the symptom**: the remote session (daemon/vcli) keeps working during the
+  throttle; only the ssh control channel is refused.
+
 ## vcli GUI Debug 快速指南
 
 ### 一、连接 Session


### PR DESCRIPTION
## Summary
Document SSH connection throttling etiquette in `virtuoso-gui-debug` SKILL.md.

## Background
Rapid-fire ssh invocations from automation (one connection per command) can trip remote sshd
connection protection (`MaxStartups` / Fail2ban), surfacing as
`ssh_exchange_identification: Connection closed by remote host`.

This is a client-side connection-frequency issue, **NOT a vcli bug**: vcli talks to the daemon
over TCP (the session port from `vcli session list`), never SSH. The new section documents the
symptom, clarifies ownership, and lists mitigations (batch commands, ControlMaster reuse,
backoff on rejection, base64 one-shot scripts).

## Changes
- `SKILL.md`: new "SSH Connection Etiquette" section (+26 lines), placed after Auto-Discovery.

## Validation
- Docs-only change; no Rust or skill script code touched.
- Skill test suite unaffected (no scripts/tests modified).