### PR TITLE
feat(config): add vcli config check with per-key provenance (#73)

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,0 +1,192 @@
+use crate::config::{Config, ConfigReport, ConfigSource};
+use crate::error::Result;
+use crate::output::OutputFormat;
+use serde_json::{json, Value};
+
+/// `vcli config check` — explain every resolved value's provenance.
+///
+/// Reads the same environment / file / target path the live `Config::from_env`
+/// would use and produces a [`ConfigReport`] keyed off `[profile.<active>]`
+/// and target branches. `--format json` produces a flat, jq-friendly document;
+/// the default table mode prints a human-readable ledger.
+///
+/// `--require-explicit` flips the exit code to non-zero when any field came
+/// from a built-in default (no env, no file, no target) — useful in CI
+/// pipelines that should refuse to deploy a "green" build whose daemon
+/// actually has no config. The JSON `status` field mirrors this: `"fail"`
+/// only when `--require-explicit` saw at least one Default source.
+///
+/// Implementation note: the report is built by [`Config::build_report`], which
+/// re-probes the same layered lookup the runtime uses. There is no separate
+/// "check" resolution path to drift out of sync with production behavior.
+pub fn check(format: OutputFormat, require_explicit: bool) -> Result<Value> {
+    let profile = Config::resolve_profile();
+    let report = Config::build_report(profile.as_deref())?;
+    let status = status_for(&report, require_explicit);
+
+    let value = match format {
+        OutputFormat::Json => json!({
+            "status": status,
+            "profile": report.profile,
+            "active_target": report.active_target,
+            "config_file": report.config_file,
+            "precedence": report.precedence,
+            "entries": entries_json(&report),
+            "warnings": report.warnings,
+            // main() reads "dry_run" to pick DRY_RUN_OK (10) over SUCCESS (0);
+            // we re-use that mechanism so `--require-explicit` propagates a
+            // non-zero exit without dragging a second channel through the
+            // dispatch result. The status string above remains the
+            // human-readable signal; this is the exit-code driver.
+            "dry_run": status == "fail",
+        }),
+        OutputFormat::Table => render_table(&report, status),
+    };
+    Ok(value)
+}
+
+/// One JSON entry per resolved key, with its source layer and a sub-object
+/// that names the exact env var / file / target that produced it.
+///
+/// Shape was chosen so `jq '.entries[] | select(.key == "VB_TIMEOUT")'` is a
+/// useful one-liner during incident response.
+fn entries_json(report: &ConfigReport) -> Value {
+    Value::Array(
+        report
+            .entries
+            .iter()
+            .map(|e| {
+                let mut obj = serde_json::Map::new();
+                obj.insert("key".into(), Value::String(e.key.to_string()));
+                obj.insert("value".into(), Value::String(e.value.clone()));
+                obj.insert(
+                    "source".into(),
+                    serde_json::to_value(&e.source).unwrap_or(Value::Null),
+                );
+                obj.insert(
+                    "source_label".into(),
+                    Value::String(source_label(&e.source)),
+                );
+                Value::Object(obj)
+            })
+            .collect(),
+    )
+}
+
+/// Short, human-readable tag of a [`ConfigSource`] — used in the table renderer.
+fn source_label(src: &ConfigSource) -> String {
+    match src {
+        ConfigSource::EnvProfile { var } => format!("env[{var}]"),
+        ConfigSource::Env { var } => format!("env[{var}]"),
+        ConfigSource::FileProfile { file } => {
+            format!("file[profile]={}", file.display())
+        }
+        ConfigSource::FileGlobal { file } => format!("file[global]={}", file.display()),
+        ConfigSource::Target { target } => format!("target[{target}]"),
+        ConfigSource::Default { default } => format!("default={default}"),
+    }
+}
+
+fn status_for(report: &ConfigReport, require_explicit: bool) -> &'static str {
+    if !report.warnings.is_empty() {
+        "warn"
+    } else if require_explicit && !report.all_explicit() {
+        "fail"
+    } else {
+        "ok"
+    }
+}
+
+/// Render the report as a left-aligned key/value ledger with a trailing
+/// precedence block. Designed for terminal scrollback — wide values are
+/// preserved verbatim because transport-daemon tokens and SSH key paths
+/// cannot be truncated without misleading the reader.
+fn render_table(report: &ConfigReport, status: &'static str) -> Value {
+    let mut lines: Vec<String> = Vec::new();
+
+    let header = match (&report.profile, &report.active_target) {
+        (Some(p), Some(t)) => format!("profile: {p}    active_target: {t}"),
+        (Some(p), None) => format!("profile: {p}"),
+        (None, Some(t)) => format!("active_target: {t}"),
+        (None, None) => "profile: (none)    active_target: (none)".to_string(),
+    };
+    lines.push(header);
+
+    if let Some(ref f) = report.config_file {
+        lines.push(format!("config_file: {}", f.display()));
+    } else {
+        lines.push("config_file: (not present)".to_string());
+    }
+
+    // Column widths derived from the longest actual content so a wide SSH
+    // key path doesn't push the source column off the screen on a narrow
+    // terminal but a short value doesn't leave ugly gaps either.
+    let key_width = report
+        .entries
+        .iter()
+        .map(|e| e.key.len())
+        .max()
+        .unwrap_or(20)
+        .max(20);
+    let val_width = report
+        .entries
+        .iter()
+        .map(|e| e.value.len())
+        .max()
+        .unwrap_or(10)
+        .min(60);
+
+    lines.push(String::new());
+    lines.push(format!(
+        "{:<key_w$}  {:<val_w$}  source",
+        "key",
+        "value",
+        key_w = key_width,
+        val_w = val_width
+    ));
+    lines.push(format!(
+        "{}  {}  {}",
+        "-".repeat(key_width),
+        "-".repeat(val_width),
+        "-".repeat(20)
+    ));
+    for e in &report.entries {
+        let truncated = if e.value.len() > val_width {
+            format!("{}…", &e.value[..val_width.saturating_sub(1)])
+        } else {
+            e.value.clone()
+        };
+        lines.push(format!(
+            "{:<key_w$}  {:<val_w$}  {source}",
+            e.key,
+            truncated,
+            source = source_label(&e.source),
+            key_w = key_width,
+            val_w = val_width
+        ));
+    }
+
+    if !report.warnings.is_empty() {
+        lines.push(String::new());
+        lines.push("warnings:".to_string());
+        for w in &report.warnings {
+            lines.push(format!("  • {w}"));
+        }
+    }
+
+    lines.push(String::new());
+    lines.push("precedence (highest first):".to_string());
+    for (i, p) in report.precedence.iter().enumerate() {
+        lines.push(format!("  {}. {p}", i + 1));
+    }
+
+    // The match arm returns a JSON Value so the framework can apply the same
+    // --format plumbing as the JSON path. We wrap the rendered text in a
+    // single field so `output::print_value` knows what to print.
+    Value::Object({
+        let mut obj = serde_json::Map::new();
+        obj.insert("rendered".into(), Value::String(lines.join("\n")));
+        obj.insert("status".into(), Value::String(status.to_string()));
+        obj
+    })
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod cell;
+pub mod config;
 pub mod design;
 pub mod diag;
 pub mod init;

--- a/src/config.rs
+++ b/src/config.rs
@@ -445,6 +445,10 @@ fn report_transport_daemon_token(cfg: &Config) -> String {
     }
 }
 
+fn report_allow_cross_user_daemon(cfg: &Config) -> String {
+    cfg.allow_cross_user_daemon.to_string()
+}
+
 // ----- Validators (mirror the runtime parsers in from_env_resolve) ----------
 
 fn v_text(_raw: &str) -> std::result::Result<(), String> {
@@ -474,6 +478,19 @@ fn v_bool(raw: &str) -> std::result::Result<(), String> {
         Ok(())
     } else {
         Err(format!("expected true/false/1/0, got {raw:?}"))
+    }
+}
+/// Mirrors [`Layers::flag_truthy`]: `VB_ALLOW_CROSS_USER_DAEMON` shipped
+/// accepting `yes` / `on`, so those spellings are valid here even though
+/// [`v_bool`] stays strict for every other flag. An unrecognised value is
+/// reported as invalid (the runtime silently treats it as "off"), so a typo
+/// surfaces here instead of hiding.
+fn v_truthy(raw: &str) -> std::result::Result<(), String> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" | "0" | "false" | "no" | "off" => Ok(()),
+        other => Err(format!(
+            "expected true/false/1/0/yes/no/on/off, got {other:?}"
+        )),
     }
 }
 fn v_shlex(raw: &str) -> std::result::Result<(), String> {
@@ -521,6 +538,7 @@ const KEY_SPECS: &[KeySpec] = &[
     KeySpec { key: "VB_REMOTE_SCRATCH_ROOT", default: "",          display: report_remote_scratch_root,    validate: v_text },
     KeySpec { key: "VB_TRANSPORT_DAEMON_SOCKET", default: "",      display: report_transport_daemon_socket, validate: v_text },
     KeySpec { key: "VB_TRANSPORT_DAEMON_TOKEN", default: "",       display: report_transport_daemon_token, validate: v_text },
+    KeySpec { key: "VB_ALLOW_CROSS_USER_DAEMON", default: "false", display: report_allow_cross_user_daemon, validate: v_truthy },
 ];
 
 /// Build the report from a `TargetConfig`.
@@ -604,6 +622,7 @@ fn target_provides(key: &str, t: &crate::target::TargetConfig) -> bool {
         "VB_SPECTRE_BIN" => t.spectre_bin.is_some(),
         "VB_TRANSPORT_DAEMON_SOCKET" => t.transport_daemon_socket.is_some(),
         "VB_TRANSPORT_DAEMON_TOKEN" => t.transport_daemon_token.is_some(),
+        "VB_ALLOW_CROSS_USER_DAEMON" => t.allow_cross_user_daemon.is_some(),
         // TargetConfig has no equivalent for these — `from_target` always
         // returns hard-coded constants here, so they cannot be attributed to
         // the target.
@@ -629,7 +648,6 @@ fn matches_default(key: &str, value: &str) -> bool {
         .map(|s| s.default == value)
         .unwrap_or(false)
 }
-
 
 impl Layers<'_> {
     /// Profile-specific env, then general env, then the file.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::config_file::ConfigFile;
 use crate::error::{Result, VirtuosoError};
+use serde::Serialize;
 use std::env;
 use std::path::PathBuf;
 
@@ -250,22 +251,451 @@ struct Layers<'a> {
     file: Option<&'a ConfigFile>,
 }
 
+/// Which layer a resolved value came from.
+///
+/// Used by [`Config::build_report`] — the heart of `vcli config check` —
+/// so a user can ask "why did this 30-second timeout become 120?" and get an
+/// answer that names the actual env var, the exact `[profile.<name>]` section
+/// or the defaulting code path.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(tag = "layer", rename_all = "snake_case")]
+pub enum ConfigSource {
+    /// `<KEY>_<PROFILE>` environment variable. `var` is the full env-var name.
+    EnvProfile { var: String },
+    /// `<KEY>` environment variable. `var` is the env-var name.
+    Env { var: String },
+    /// `config.toml` `[profile.<PROFILE>]` section. `file` is the absolute
+    /// path of the parsed file (so a user can `vim` it).
+    FileProfile { file: PathBuf },
+    /// `config.toml` global section.
+    FileGlobal { file: PathBuf },
+    /// An active `targets.yaml` entry whose field overrode this setting.
+    /// `target` is the target name as set by `--target` / `VB_TARGET` /
+    /// `active_target` in `targets.yaml`.
+    Target { target: String },
+    /// No higher-precedence layer supplied a value; `default` documents the
+    /// constant the resolver fell through to.
+    Default { default: String },
+}
+
+/// One resolved key, with its value and provenance.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfigEntry {
+    pub key: &'static str,
+    pub value: String,
+    pub source: ConfigSource,
+}
+
+/// Aggregated report of the resolved configuration.
+///
+/// Always carries enough context to reproduce the resolution: the active
+/// profile, the file that was read (if any), the active target (if any),
+/// and a per-key [`ConfigEntry`]. JSON-stable so `vcli config check --format
+/// json` round-trips through `jq` without surprises.
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfigReport {
+    pub profile: Option<String>,
+    pub active_target: Option<String>,
+    pub config_file: Option<PathBuf>,
+    /// Resolution precedence, highest first, with the key spelling each layer
+    /// expects. Surfaced in `--format json` so a user can verify the order
+    /// without reading code.
+    pub precedence: [&'static str; 4],
+    pub entries: Vec<ConfigEntry>,
+    /// Soft warnings the report noticed (e.g. a deprecated `~/.vcli/.env`
+    /// fallback being read). Empty when nothing to warn about. Failures
+    /// here don't elevate the process exit code — they are advisory.
+    pub warnings: Vec<String>,
+}
+
+impl ConfigReport {
+    /// `Ok(true)` when every entry has a non-default source; `Ok(false)` when
+    /// at least one field fell through to a hard-coded default. `Err` when
+    /// the user passed `--require-explicit` and a default was the only
+    /// source. Distinguishing this from "the default is correct for my
+    /// workflow" is the whole point of `config check`.
+    pub fn all_explicit(&self) -> bool {
+        self.entries
+            .iter()
+            .all(|e| !matches!(e.source, ConfigSource::Default { .. }))
+    }
+}
+
+/// Static description of one configuration key.
+///
+/// `default` is the literal the resolver falls through to. `display` formats
+/// the resolved value for the report (so a `bool` reads `true`/`false`, a
+/// `u16` port reads `65432`, and a `Vec<String>` reads `[]` or joined with
+/// single spaces). `validate` re-runs the same parser the runtime uses so a
+/// malformed env var (e.g. `VB_TIMEOUT=abc`) is flagged in the report
+/// instead of silently passing through.
+struct KeySpec {
+    key: &'static str,
+    default: &'static str,
+    display: fn(&Config) -> String,
+    validate: fn(&str) -> std::result::Result<(), String>,
+}
+
+fn report_remote_host(cfg: &Config) -> String {
+    cfg.remote_host.clone().unwrap_or_default()
+}
+fn report_remote_user(cfg: &Config) -> String {
+    cfg.remote_user.clone().unwrap_or_default()
+}
+fn report_port(cfg: &Config) -> String {
+    cfg.port.to_string()
+}
+fn report_jump_host(cfg: &Config) -> String {
+    cfg.jump_host.clone().unwrap_or_default()
+}
+fn report_jump_user(cfg: &Config) -> String {
+    cfg.jump_user.clone().unwrap_or_default()
+}
+fn report_ssh_port(cfg: &Config) -> String {
+    cfg.ssh_port
+        .map(|p| p.to_string())
+        .unwrap_or_else(|| "22".into())
+}
+fn report_ssh_key(cfg: &Config) -> String {
+    cfg.ssh_key.clone().unwrap_or_default()
+}
+fn report_ssh_config(cfg: &Config) -> String {
+    cfg.ssh_config.clone().unwrap_or_default()
+}
+fn report_ssh_backend(cfg: &Config) -> String {
+    cfg.ssh_backend.clone().unwrap_or_default()
+}
+fn report_disable_control_master(cfg: &Config) -> String {
+    cfg.disable_control_master.to_string()
+}
+fn report_timeout(cfg: &Config) -> String {
+    cfg.timeout.to_string()
+}
+fn report_read_timeout(cfg: &Config) -> String {
+    cfg.read_timeout.to_string()
+}
+fn report_keep_remote_files(cfg: &Config) -> String {
+    cfg.keep_remote_files.to_string()
+}
+fn report_spectre_cmd(cfg: &Config) -> String {
+    cfg.spectre_cmd.clone()
+}
+fn report_spectre_args(cfg: &Config) -> String {
+    if cfg.spectre_args.is_empty() {
+        String::new()
+    } else {
+        cfg.spectre_args.join(" ")
+    }
+}
+fn report_spectre_max_workers(cfg: &Config) -> String {
+    cfg.spectre_max_workers.to_string()
+}
+fn report_ssh_max_sessions(cfg: &Config) -> String {
+    cfg.ssh_max_sessions.to_string()
+}
+fn report_ssh_max_bulk_sessions(cfg: &Config) -> String {
+    cfg.ssh_max_bulk_sessions.to_string()
+}
+fn report_ssh_reconnect_max_attempts(cfg: &Config) -> String {
+    cfg.ssh_reconnect_max_attempts.to_string()
+}
+fn report_ssh_reconnect_max_delay(cfg: &Config) -> String {
+    cfg.ssh_reconnect_max_delay.to_string()
+}
+fn report_ssh_keepalive_interval(cfg: &Config) -> String {
+    cfg.ssh_keepalive_interval.to_string()
+}
+fn report_ssh_keepalive_failures(cfg: &Config) -> String {
+    cfg.ssh_keepalive_failures.to_string()
+}
+fn report_transport_shutdown_grace(cfg: &Config) -> String {
+    cfg.transport_shutdown_grace.to_string()
+}
+fn report_cadence_cshrc(cfg: &Config) -> String {
+    cfg.cadence_cshrc.clone().unwrap_or_default()
+}
+fn report_spectre_bin(cfg: &Config) -> String {
+    cfg.spectre_bin.clone().unwrap_or_default()
+}
+fn report_gui_host(cfg: &Config) -> String {
+    cfg.roles.gui_host.clone().unwrap_or_default()
+}
+fn report_deploy_host(cfg: &Config) -> String {
+    cfg.roles.deploy_host.clone().unwrap_or_default()
+}
+fn report_daemon_host(cfg: &Config) -> String {
+    cfg.roles.daemon_host.clone().unwrap_or_default()
+}
+fn report_spectre_host(cfg: &Config) -> String {
+    cfg.roles.spectre_host.clone().unwrap_or_default()
+}
+fn report_remote_scratch_root(cfg: &Config) -> String {
+    cfg.roles.scratch_root.clone().unwrap_or_default()
+}
+fn report_transport_daemon_socket(cfg: &Config) -> String {
+    cfg.transport_daemon_socket.clone().unwrap_or_default()
+}
+fn report_transport_daemon_token(cfg: &Config) -> String {
+    // The token is sensitive; show only "set" / "unset" to avoid leaking it
+    // through a config-check snapshot or terminal scrollback.
+    if cfg.transport_daemon_token.is_some() {
+        "***set***".to_string()
+    } else {
+        String::new()
+    }
+}
+
+// ----- Validators (mirror the runtime parsers in from_env_resolve) ----------
+
+fn v_text(_raw: &str) -> std::result::Result<(), String> {
+    Ok(())
+}
+fn v_u16(raw: &str) -> std::result::Result<(), String> {
+    raw.parse::<u16>()
+        .map(|_| ())
+        .map_err(|e| format!("expected u16, got {raw:?}: {e}"))
+}
+fn v_u32(raw: &str) -> std::result::Result<(), String> {
+    raw.parse::<u32>()
+        .map(|_| ())
+        .map_err(|e| format!("expected u32, got {raw:?}: {e}"))
+}
+fn v_u64(raw: &str) -> std::result::Result<(), String> {
+    raw.parse::<u64>()
+        .map(|_| ())
+        .map_err(|e| format!("expected u64, got {raw:?}: {e}"))
+}
+fn v_bool(raw: &str) -> std::result::Result<(), String> {
+    if raw == "1"
+        || raw == "0"
+        || raw.eq_ignore_ascii_case("true")
+        || raw.eq_ignore_ascii_case("false")
+    {
+        Ok(())
+    } else {
+        Err(format!("expected true/false/1/0, got {raw:?}"))
+    }
+}
+fn v_shlex(raw: &str) -> std::result::Result<(), String> {
+    shlex::split(raw)
+        .map(|_| ())
+        .ok_or_else(|| format!("invalid shell syntax: {raw:?}"))
+}
+
+/// The exhaustive list of configuration keys this report covers.
+///
+/// Order = display order. New keys added to [`Config`] should land here too —
+/// the report is the user's authoritative way to verify resolution, and a
+/// missing key would silently mis-attribute a value.
+#[rustfmt::skip]
+const KEY_SPECS: &[KeySpec] = &[
+    KeySpec { key: "VB_REMOTE_HOST",         default: "",          display: report_remote_host,            validate: v_text },
+    KeySpec { key: "VB_REMOTE_USER",         default: "",          display: report_remote_user,            validate: v_text },
+    KeySpec { key: "VB_PORT",                default: "0",         display: report_port,                   validate: v_u16 },
+    KeySpec { key: "VB_JUMP_HOST",           default: "",          display: report_jump_host,              validate: v_text },
+    KeySpec { key: "VB_JUMP_USER",           default: "",          display: report_jump_user,              validate: v_text },
+    KeySpec { key: "VB_SSH_PORT",            default: "22",        display: report_ssh_port,               validate: v_u16 },
+    KeySpec { key: "VB_SSH_KEY",             default: "",          display: report_ssh_key,                validate: v_text },
+    KeySpec { key: "VB_SSH_CONFIG",          default: "",          display: report_ssh_config,             validate: v_text },
+    KeySpec { key: "VB_SSH_BACKEND",         default: "openssh",   display: report_ssh_backend,            validate: v_text },
+    KeySpec { key: "VB_DISABLE_CONTROL_MASTER", default: "false",  display: report_disable_control_master, validate: v_bool },
+    KeySpec { key: "VB_TIMEOUT",             default: "30",        display: report_timeout,                validate: v_u64 },
+    KeySpec { key: "VB_READ_TIMEOUT",        default: "120",       display: report_read_timeout,           validate: v_u64 },
+    KeySpec { key: "VB_KEEP_REMOTE_FILES",   default: "false",     display: report_keep_remote_files,      validate: v_bool },
+    KeySpec { key: "VB_SPECTRE_CMD",         default: "spectre",   display: report_spectre_cmd,            validate: v_text },
+    KeySpec { key: "VB_SPECTRE_ARGS",        default: "",          display: report_spectre_args,           validate: v_shlex },
+    KeySpec { key: "VB_SPECTRE_MAX_WORKERS", default: "8",         display: report_spectre_max_workers,    validate: v_u32 },
+    KeySpec { key: "VB_SSH_MAX_SESSIONS",    default: "10",        display: report_ssh_max_sessions,       validate: v_u64 },
+    KeySpec { key: "VB_SSH_MAX_BULK_SESSIONS", default: "2",       display: report_ssh_max_bulk_sessions,  validate: v_u64 },
+    KeySpec { key: "VB_SSH_RECONNECT_MAX_ATTEMPTS", default: "8",  display: report_ssh_reconnect_max_attempts, validate: v_u32 },
+    KeySpec { key: "VB_SSH_RECONNECT_MAX_DELAY",   default: "30", display: report_ssh_reconnect_max_delay,   validate: v_u64 },
+    KeySpec { key: "VB_SSH_KEEPALIVE_INTERVAL",   default: "30", display: report_ssh_keepalive_interval,   validate: v_u64 },
+    KeySpec { key: "VB_SSH_KEEPALIVE_FAILURES",   default: "3",  display: report_ssh_keepalive_failures,   validate: v_u32 },
+    KeySpec { key: "VB_TRANSPORT_SHUTDOWN_GRACE", default: "10",  display: report_transport_shutdown_grace, validate: v_u64 },
+    KeySpec { key: "VB_CADENCE_CSHRC",       default: "",          display: report_cadence_cshrc,          validate: v_text },
+    KeySpec { key: "VB_SPECTRE_BIN",         default: "",          display: report_spectre_bin,            validate: v_text },
+    KeySpec { key: "VB_GUI_HOST",            default: "",          display: report_gui_host,               validate: v_text },
+    KeySpec { key: "VB_DEPLOY_HOST",         default: "",          display: report_deploy_host,            validate: v_text },
+    KeySpec { key: "VB_DAEMON_HOST",         default: "",          display: report_daemon_host,            validate: v_text },
+    KeySpec { key: "VB_SPECTRE_HOST",        default: "",          display: report_spectre_host,           validate: v_text },
+    KeySpec { key: "VB_REMOTE_SCRATCH_ROOT", default: "",          display: report_remote_scratch_root,    validate: v_text },
+    KeySpec { key: "VB_TRANSPORT_DAEMON_SOCKET", default: "",      display: report_transport_daemon_socket, validate: v_text },
+    KeySpec { key: "VB_TRANSPORT_DAEMON_TOKEN", default: "",       display: report_transport_daemon_token, validate: v_text },
+];
+
+/// Build the report from a `TargetConfig`.
+///
+/// Mirrors [`Self::from_target`] field-for-field so the report and the
+/// runtime agree: a `None` target field is attributed to the matching
+/// `from_env_resolve` default (so the user sees "this value comes from the
+/// legacy default, not from the target"); a `Some` value is attributed to
+/// the target itself.
+fn build_report_from_target(
+    target: &crate::target::TargetConfig,
+    target_name: &str,
+    mut report: ConfigReport,
+) -> ConfigReport {
+    // We compute a synthetic Config from the target (with defaults applied)
+    // so the display closures agree with the runtime path byte-for-byte.
+    let cfg =
+        Config::from_target(target, target_name).expect("target validates port at from_target");
+    for spec in KEY_SPECS {
+        let value = (spec.display)(&cfg);
+        // Per-field attribution: if the *target* had this field set, the value
+        // came from the target. If the target had `None` and the synthetic
+        // config shows the constant default, attribute it to "default".
+        let target_provided = target_provides(spec.key, target);
+        let source = if target_provided {
+            ConfigSource::Target {
+                target: target_name.to_string(),
+            }
+        } else if value.is_empty() && matches_default(spec.key, &value) {
+            // An empty string when the default *is* empty — the user really
+            // didn't set this anywhere.
+            ConfigSource::Default {
+                default: spec.default.to_string(),
+            }
+        } else {
+            ConfigSource::Default {
+                default: spec.default.to_string(),
+            }
+        };
+        report.entries.push(ConfigEntry {
+            key: spec.key,
+            value,
+            source,
+        });
+    }
+    report
+}
+
+/// Did the active target explicitly set this key?
+///
+/// `from_target` flattens a `TargetConfig` into a `Config` by applying
+/// defaults to `None` fields; the only way to attribute a value to "the
+/// target" is to ask whether the underlying `TargetConfig` carried it. This
+/// list mirrors [`crate::target::TargetConfig`] field-for-field — when the
+/// schema drifts, this must drift with it.
+fn target_provides(key: &str, t: &crate::target::TargetConfig) -> bool {
+    match key {
+        "VB_REMOTE_HOST" => t.remote_host.is_some(),
+        "VB_REMOTE_USER" => t.remote_user.is_some(),
+        "VB_PORT" => t.port.is_some(),
+        "VB_JUMP_HOST" => t.jump_host.is_some(),
+        "VB_JUMP_USER" => t.jump_user.is_some(),
+        "VB_SSH_PORT" => t.ssh_port.is_some(),
+        "VB_SSH_KEY" => t.ssh_key.is_some(),
+        "VB_SSH_CONFIG" => t.ssh_config.is_some(),
+        "VB_SSH_BACKEND" => t.ssh_backend.is_some(),
+        "VB_DISABLE_CONTROL_MASTER" => t.disable_control_master.is_some(),
+        "VB_TIMEOUT" => t.timeout.is_some(),
+        "VB_READ_TIMEOUT" => t.read_timeout.is_some(),
+        "VB_KEEP_REMOTE_FILES" => t.keep_remote_files.is_some(),
+        "VB_SPECTRE_CMD" => t.spectre_cmd.is_some(),
+        "VB_SPECTRE_ARGS" => t.spectre_args.is_some(),
+        "VB_SPECTRE_MAX_WORKERS" => t.spectre_max_workers.is_some(),
+        "VB_SSH_MAX_SESSIONS" => t.ssh_max_sessions.is_some(),
+        "VB_SSH_MAX_BULK_SESSIONS" => t.ssh_max_bulk_sessions.is_some(),
+        "VB_SSH_RECONNECT_MAX_ATTEMPTS" => t.ssh_reconnect_max_attempts.is_some(),
+        "VB_SSH_RECONNECT_MAX_DELAY" => t.ssh_reconnect_max_delay.is_some(),
+        "VB_SSH_KEEPALIVE_INTERVAL" => t.ssh_keepalive_interval.is_some(),
+        "VB_SSH_KEEPALIVE_FAILURES" => t.ssh_keepalive_failures.is_some(),
+        "VB_CADENCE_CSHRC" => t.cadence_cshrc.is_some(),
+        "VB_SPECTRE_BIN" => t.spectre_bin.is_some(),
+        "VB_TRANSPORT_DAEMON_SOCKET" => t.transport_daemon_socket.is_some(),
+        "VB_TRANSPORT_DAEMON_TOKEN" => t.transport_daemon_token.is_some(),
+        // TargetConfig has no equivalent for these — `from_target` always
+        // returns hard-coded constants here, so they cannot be attributed to
+        // the target.
+        "VB_TRANSPORT_SHUTDOWN_GRACE"
+        | "VB_GUI_HOST"
+        | "VB_DEPLOY_HOST"
+        | "VB_DAEMON_HOST"
+        | "VB_SPECTRE_HOST"
+        | "VB_REMOTE_SCRATCH_ROOT" => false,
+        _ => false,
+    }
+}
+
+/// Compare the resolved value to the static default for a key.
+///
+/// Used to detect "the value equals the constant default — that came from
+/// the default, not from anywhere higher up." Empty-string equality is the
+/// common case (e.g. `remote_host` defaults to `""`).
+fn matches_default(key: &str, value: &str) -> bool {
+    KEY_SPECS
+        .iter()
+        .find(|s| s.key == key)
+        .map(|s| s.default == value)
+        .unwrap_or(false)
+}
+
+
 impl Layers<'_> {
     /// Profile-specific env, then general env, then the file.
     fn raw(&self, key: &str) -> Option<String> {
+        self.raw_with_source(key).map(|(v, _)| v)
+    }
+
+    /// Same precedence as [`Layers::raw`], but reports which layer actually
+    /// produced the value. Used by `Config::build_report` so `vcli config check`
+    /// can answer "where did this resolved value come from?" — a 30-second
+    /// timeout silently becoming 120 is the exact failure mode #73 was opened
+    /// to surface.
+    ///
+    /// Precedence, highest first (RFC #83, §3 — `vcli config check`):
+    /// 1. `<KEY>_<PROFILE>` environment variable
+    /// 2. `<KEY>` environment variable
+    /// 3. `config.toml` `[profile.<PROFILE>]` section
+    /// 4. `config.toml` global section
+    fn raw_with_source(&self, key: &str) -> Option<(String, ConfigSource)> {
         if let Some(p) = self.profile {
-            if let Ok(v) = env::var(format!("{key}_{p}")) {
+            let profile_key = format!("{key}_{p}");
+            if let Ok(v) = env::var(&profile_key) {
                 if !v.is_empty() {
-                    return Some(v);
+                    return Some((v, ConfigSource::EnvProfile { var: profile_key }));
                 }
             }
         }
         if let Ok(v) = env::var(key) {
             if !v.is_empty() {
-                return Some(v);
+                return Some((
+                    v,
+                    ConfigSource::Env {
+                        var: key.to_string(),
+                    },
+                ));
             }
         }
-        self.file.and_then(|f| f.get(key, self.profile))
+        if let Some(file) = self.file {
+            // Probe whether the *profile section* itself owns the key, not
+            // whether `ConfigFile::get` returns a value. `get` falls through
+            // to global on a miss — if we trusted it, an absent profile key
+            // would be misattributed as FileProfile instead of FileGlobal.
+            let profile_owns = self
+                .profile
+                .is_some_and(|p| file.profile_section_has(key, p));
+            if profile_owns {
+                let v = file
+                    .get(key, self.profile)
+                    .expect("profile_section_has said the value is there");
+                return Some((
+                    v,
+                    ConfigSource::FileProfile {
+                        file: crate::config_file::path(),
+                    },
+                ));
+            }
+            if let Some(v) = file.get(key, None) {
+                return Some((
+                    v,
+                    ConfigSource::FileGlobal {
+                        file: crate::config_file::path(),
+                    },
+                ));
+            }
+        }
+        None
     }
 
     fn text(&self, key: &str) -> Option<String> {
@@ -662,6 +1092,124 @@ impl Config {
         hex::encode(hasher.finalize())
     }
 
+    /// Build a per-key provenance report for `vcli config check`.
+    ///
+    /// The report re-runs [`Layers::raw_with_source`] against the same
+    /// `profile` and the file already loaded by the live resolution path, so
+    /// what it shows **is what the runtime config will actually use** — no
+    /// drift between the report and the next `vcli …` invocation. Two entry
+    /// modes are honored:
+    ///
+    /// * **target mode** (`VB_TARGET` set and the target exists): every field
+    ///   traces back to the `targets.yaml` entry; `Layer::Target { .. }`
+    ///   records the target name. None of the file layers participate — that
+    ///   is intentional, mirroring [`Self::from_env_resolve`]'s early return.
+    /// * **legacy mode** (no `VB_TARGET`, or unknown target): the full
+    ///   four-layer precedence is consulted.
+    ///
+    /// Returns [`VirtuosoError::Config`] when reading or parsing the file
+    /// fails — same hard-error policy as the live path.
+    pub fn build_report(profile: Option<&str>) -> Result<ConfigReport> {
+        let mut report = ConfigReport {
+            profile: profile.map(|s| s.to_string()),
+            active_target: None,
+            config_file: None,
+            precedence: [
+                "<KEY>_<PROFILE> env",
+                "<KEY> env",
+                "config.toml [profile.<PROFILE>]",
+                "config.toml global",
+            ],
+            entries: Vec::with_capacity(KEY_SPECS.len()),
+            warnings: Vec::new(),
+        };
+
+        // Active target detection — mirrors from_env_resolve's honor_vb_target
+        // branch. We never *consume* it here; we only report whether one is
+        // driving the resolution so the user can see "your 30-second timeout
+        // came from the prod target, not from any VB_… env var".
+        if let Ok(name) = std::env::var("VB_TARGET") {
+            if !name.is_empty() {
+                report.active_target = Some(name);
+            }
+        }
+
+        // Surface the deprecated ~/.vcli/.env VB_PROFILE= fallback so the
+        // report tells users their profile moved. Cheap (one fopen); we only
+        // warn when the file exists with a non-empty VB_PROFILE=.
+        if let Some(home) = dirs::home_dir() {
+            let legacy_env = home.join(".vcli").join(".env");
+            if legacy_env.is_file() {
+                if let Ok(content) = std::fs::read_to_string(&legacy_env) {
+                    if content.lines().any(|l| {
+                        let t = l.trim();
+                        t.starts_with("VB_PROFILE=") && !t["VB_PROFILE=".len()..].trim().is_empty()
+                    }) {
+                        report.warnings.push(format!(
+                            "{}: VB_PROFILE= is a deprecated fallback. Run `vcli profile bind \
+                             <name> --user` (or export VB_PROFILE in your shell) — this file \
+                             will stop being read in a future release.",
+                            legacy_env.display()
+                        ));
+                    }
+                }
+            }
+        }
+
+        if let Some(ref target_name) = report.active_target.clone() {
+            // Target mode: load the target and trace every key to it.
+            let manager = crate::target::TargetManager::load()
+                .map_err(|e| VirtuosoError::Config(format!("failed to load targets: {e}")))?;
+            let target = manager.get(target_name).ok_or_else(|| {
+                VirtuosoError::Config(format!("target '{}' not found", target_name))
+            })?;
+            return Ok(build_report_from_target(target, target_name, report));
+        }
+
+        // Legacy mode: walk the four-layer precedence for every known key.
+        let file = ConfigFile::load()?;
+        report.config_file = file.as_ref().map(|_| crate::config_file::path());
+        let lz = Layers {
+            profile,
+            file: file.as_ref(),
+        };
+        for spec in KEY_SPECS {
+            let (raw, source) = match lz.raw_with_source(spec.key) {
+                Some((v, s)) => (v, s),
+                None => (
+                    spec.default.to_string(),
+                    ConfigSource::Default {
+                        default: spec.default.to_string(),
+                    },
+                ),
+            };
+            // Apply the same scalar validators as the live path so a value
+            // that would fail at runtime shows up here *with the same error
+            // message*. We surface parse failures as warnings rather than
+            // aborting — the user is asking "what would happen?", not
+            // "tunnel now".
+            match (spec.validate)(&raw) {
+                Ok(()) => report.entries.push(ConfigEntry {
+                    key: spec.key,
+                    value: raw.clone(),
+                    source,
+                }),
+                Err(e) => {
+                    report.entries.push(ConfigEntry {
+                        key: spec.key,
+                        value: raw.clone(),
+                        source,
+                    });
+                    report.warnings.push(format!(
+                        "{}: {e} — this value would fail to parse at runtime",
+                        spec.key
+                    ));
+                }
+            }
+        }
+        Ok(report)
+    }
+
     pub fn is_remote(&self) -> bool {
         self.remote_host.is_some()
     }
@@ -703,4 +1251,324 @@ pub fn find_project_root() -> Option<PathBuf> {
         }
     }
     None
+}
+
+#[cfg(test)]
+mod report_tests {
+    //! Unit tests for [`Config::build_report`].
+    //!
+    //! Every test that touches the env or the filesystem must hold an
+    //! `EnvGuard` that resets `VB_CONFIG_DIR`, every `VB_*` variable we read
+    //! directly, and clears the test env so the report actually observes the
+    //! state the test sets up. Without the guard, a developer machine with a
+    //! `~/.vcli/config.toml` would silently override the test fixture and the
+    //! assertion would drift.
+
+    use super::*;
+    use serial_test::serial;
+
+    /// Save and restore the keys this module's resolution actually consults.
+    ///
+    /// We don't blanket-clear every `VB_*` — that would mask real bugs in the
+    /// report's ability to attribute values. We restore whatever was set on
+    /// entry, blank the env for the duration of the test, and only seed the
+    /// specific keys the test exercises. The `Drop` impl restores the saved
+    /// state so a failing assertion doesn't poison the next test.
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<String>)>,
+        saved_profile: Option<String>,
+        saved_target: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn new(keys: &[&'static str]) -> Self {
+            let mut saved: Vec<(&'static str, Option<String>)> =
+                keys.iter().map(|k| (*k, std::env::var(k).ok())).collect();
+            // Always preserve these — they belong to the framework, not the
+            // caller's choice, and we want them unchanged even if the test
+            // didn't mention them.
+            for k in ["VB_PROFILE", "VB_TARGET"].iter() {
+                if !saved.iter().any(|(name, _)| *name == *k) {
+                    saved.push((k, std::env::var(k).ok()));
+                }
+            }
+            let saved_profile = std::env::var("VB_PROFILE").ok();
+            let saved_target = std::env::var("VB_TARGET").ok();
+            for k in keys {
+                std::env::remove_var(k);
+            }
+            std::env::remove_var("VB_PROFILE");
+            std::env::remove_var("VB_TARGET");
+            Self {
+                saved,
+                saved_profile,
+                saved_target,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in &self.saved {
+                match v {
+                    Some(value) => std::env::set_var(k, value),
+                    None => std::env::remove_var(k),
+                }
+            }
+            match &self.saved_profile {
+                Some(v) => std::env::set_var("VB_PROFILE", v),
+                None => std::env::remove_var("VB_PROFILE"),
+            }
+            match &self.saved_target {
+                Some(v) => std::env::set_var("VB_TARGET", v),
+                None => std::env::remove_var("VB_TARGET"),
+            }
+        }
+    }
+
+    /// Point `VB_CONFIG_DIR` at a fresh empty tempdir so `ConfigFile::load()`
+    /// observes `Ok(None)` and the report runs the "no file" branch. The
+    /// guard restores the prior `VB_CONFIG_DIR` (or removes it if unset).
+    fn isolate_config_dir() -> (tempfile::TempDir, Option<std::ffi::OsString>) {
+        let prev = std::env::var_os("VB_CONFIG_DIR");
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("VB_CONFIG_DIR", dir.path());
+        (dir, prev)
+    }
+
+    struct ConfigDirGuard(Option<std::ffi::OsString>);
+
+    impl Drop for ConfigDirGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(v) => std::env::set_var("VB_CONFIG_DIR", v),
+                None => std::env::remove_var("VB_CONFIG_DIR"),
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn report_with_no_env_and_no_file_attributes_everything_to_default() {
+        let _env = EnvGuard::new(&["VB_REMOTE_HOST", "VB_TIMEOUT"]);
+        let (_tmp, prev) = isolate_config_dir();
+        let _restore = ConfigDirGuard(prev);
+        let report = Config::build_report(None).expect("build_report");
+        let remote_host = report
+            .entries
+            .iter()
+            .find(|e| e.key == "VB_REMOTE_HOST")
+            .expect("entry exists");
+        assert_eq!(remote_host.value, "");
+        assert!(matches!(remote_host.source, ConfigSource::Default { .. }));
+        let timeout = report
+            .entries
+            .iter()
+            .find(|e| e.key == "VB_TIMEOUT")
+            .expect("entry exists");
+        assert_eq!(timeout.value, "30");
+        assert!(matches!(timeout.source, ConfigSource::Default { .. }));
+        assert!(!report.all_explicit());
+    }
+
+    #[test]
+    #[serial]
+    fn report_attributes_env_var_to_env_layer() {
+        let _env = EnvGuard::new(&["VB_REMOTE_HOST"]);
+        let (_tmp, prev) = isolate_config_dir();
+        let _restore = ConfigDirGuard(prev);
+        std::env::set_var("VB_REMOTE_HOST", "eda-from-env");
+        let report = Config::build_report(None).expect("build_report");
+        let e = report
+            .entries
+            .iter()
+            .find(|e| e.key == "VB_REMOTE_HOST")
+            .expect("entry exists");
+        assert_eq!(e.value, "eda-from-env");
+        match &e.source {
+            ConfigSource::Env { var } => assert_eq!(var, "VB_REMOTE_HOST"),
+            other => panic!("expected Env source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn report_prefers_profile_specific_env_over_global_env() {
+        let _env = EnvGuard::new(&["VB_REMOTE_HOST"]);
+        let (_tmp, prev) = isolate_config_dir();
+        let _restore = ConfigDirGuard(prev);
+        std::env::set_var("VB_REMOTE_HOST", "global-host");
+        std::env::set_var("VB_REMOTE_HOST_prod", "profile-host");
+        let report = Config::build_report(Some("prod")).expect("build_report");
+        let e = report
+            .entries
+            .iter()
+            .find(|e| e.key == "VB_REMOTE_HOST")
+            .expect("entry exists");
+        assert_eq!(e.value, "profile-host");
+        match &e.source {
+            ConfigSource::EnvProfile { var } => assert_eq!(var, "VB_REMOTE_HOST_prod"),
+            other => panic!("expected EnvProfile source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn report_attributes_file_global_when_no_env_present() {
+        let _env = EnvGuard::new(&["VB_REMOTE_HOST"]);
+        let (tmp, prev) = isolate_config_dir();
+        let _restore = ConfigDirGuard(prev);
+        // runtime_paths::config_subdir joins `vcli/` under VB_CONFIG_DIR.
+        // Match the live layout so ConfigFile::load() finds the file we
+        // write — it doesn't auto-create parent directories.
+        std::fs::create_dir_all(tmp.path().join("vcli")).expect("mkdir");
+        std::fs::write(
+            tmp.path().join("vcli/config.toml"),
+            r#"remote_host = "eda-from-file""#,
+        )
+        .expect("write config");
+        let report = Config::build_report(None).expect("build_report");
+        let e = report
+            .entries
+            .iter()
+            .find(|e| e.key == "VB_REMOTE_HOST")
+            .expect("entry exists");
+        assert_eq!(e.value, "eda-from-file");
+        assert!(matches!(e.source, ConfigSource::FileGlobal { .. }));
+    }
+
+    #[test]
+    #[serial]
+    fn report_prefers_file_profile_section_over_file_global() {
+        let _env = EnvGuard::new(&["VB_REMOTE_HOST", "VB_REMOTE_HOST_prod"]);
+        let (tmp, prev) = isolate_config_dir();
+        let _restore = ConfigDirGuard(prev);
+        std::fs::create_dir_all(tmp.path().join("vcli")).expect("mkdir");
+        std::fs::write(
+            tmp.path().join("vcli/config.toml"),
+            r#"
+remote_host = "eda-global"
+
+[profile.prod]
+remote_host = "eda-prod"
+"#,
+        )
+        .expect("write config");
+        let report = Config::build_report(Some("prod")).expect("build_report");
+        let e = report
+            .entries
+            .iter()
+            .find(|e| e.key == "VB_REMOTE_HOST")
+            .expect("entry exists");
+        assert_eq!(e.value, "eda-prod");
+        assert!(matches!(e.source, ConfigSource::FileProfile { .. }));
+    }
+
+    #[test]
+    #[serial]
+    fn report_flags_unparseable_value_as_warning() {
+        let _env = EnvGuard::new(&["VB_TIMEOUT"]);
+        let (_tmp, prev) = isolate_config_dir();
+        let _restore = ConfigDirGuard(prev);
+        std::env::set_var("VB_TIMEOUT", "not-a-number");
+        let report = Config::build_report(None).expect("build_report");
+        let e = report
+            .entries
+            .iter()
+            .find(|e| e.key == "VB_TIMEOUT")
+            .expect("entry exists");
+        // The raw value is still surfaced so the user can see what was set;
+        // the warning tells them it would fail at runtime.
+        assert_eq!(e.value, "not-a-number");
+        assert!(matches!(e.source, ConfigSource::Env { .. }));
+        assert!(
+            report
+                .warnings
+                .iter()
+                .any(|w| w.contains("VB_TIMEOUT") && w.contains("parse")),
+            "expected parse warning, got: {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn report_target_mode_attributes_explicit_target_field_to_target() {
+        let _env = EnvGuard::new(&["VB_REMOTE_HOST"]);
+        let (_tmp, prev) = isolate_config_dir();
+        let _restore = ConfigDirGuard(prev);
+        // Write a targets.yaml with one explicit target.
+        let target_yaml = r#"
+active_target: prod
+targets:
+  prod:
+    remote_host: target-host
+    port: 65535
+"#;
+        std::fs::write(_tmp.path().join("targets.yaml"), target_yaml).expect("write targets");
+        std::env::set_var("VB_TARGETS_FILE", _tmp.path().join("targets.yaml"));
+        std::env::set_var("VB_TARGET", "prod");
+        // Manually invoking build_report here is tricky because the active
+        // target is detected via VB_TARGET but the target loader uses
+        // VB_TARGETS_FILE — we still need to guard that variable too.
+        let report = Config::build_report(None).expect("build_report");
+        assert_eq!(report.active_target.as_deref(), Some("prod"));
+        let e = report
+            .entries
+            .iter()
+            .find(|e| e.key == "VB_REMOTE_HOST")
+            .expect("entry exists");
+        assert_eq!(e.value, "target-host");
+        assert!(matches!(&e.source, ConfigSource::Target { target } if target == "prod"));
+        // Clean up the VB_TARGETS_FILE we added — Drop on EnvGuard doesn't
+        // know about it because it's not in the spec list.
+        std::env::remove_var("VB_TARGETS_FILE");
+    }
+
+    #[test]
+    #[serial]
+    fn report_legacy_env_dotenv_fallback_emits_warning() {
+        let _env = EnvGuard::new(&["VB_REMOTE_HOST"]);
+        // Pretend `~/.vcli/.env` exists with VB_PROFILE=set, by setting HOME
+        // to a tempdir. dirs::home_dir() reads $HOME on unix so this works
+        // for the macOS / Linux runner; the cfg gate below skips Windows
+        // where dirs::home_dir ignores HOME.
+        let prev_home = std::env::var_os("HOME");
+        let dir = tempfile::tempdir().expect("home");
+        std::fs::create_dir_all(dir.path().join(".vcli")).expect("mkdir");
+        std::fs::write(dir.path().join(".vcli/.env"), "VB_PROFILE=stale-binding\n")
+            .expect("write env");
+        std::env::set_var("HOME", dir.path());
+        // Force a fresh config dir so the file lookup is consistent.
+        let (_cfg, prev_cfg) = isolate_config_dir();
+        let _restore = ConfigDirGuard(prev_cfg);
+        let report = Config::build_report(None).expect("build_report");
+        match prev_home {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+        assert!(
+            report.warnings.iter().any(|w| w.contains("deprecated")),
+            "expected deprecated .env fallback warning, got: {:?}",
+            report.warnings
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn all_explicit_is_true_when_no_default_sources() {
+        // Shield every key the report consults. The body of the test sets
+        // each one to a non-empty value; without an explicit shield list,
+        // EnvGuard::Drop would only restore the original value for keys the
+        // test passed to `new`, leaking "x" into the rest of the suite.
+        let all_keys: Vec<&'static str> = KEY_SPECS.iter().map(|s| s.key).collect();
+        let _env = EnvGuard::new(&all_keys);
+        let (_tmp, prev) = isolate_config_dir();
+        let _restore = ConfigDirGuard(prev);
+        for k in KEY_SPECS.iter().map(|s| s.key) {
+            std::env::set_var(k, "x");
+        }
+        let report = Config::build_report(None).expect("build_report");
+        assert!(report.all_explicit(), "every entry must be non-default");
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1545,12 +1545,14 @@ targets:
 
     #[test]
     #[serial]
+    // `dirs::home_dir()` honours `$HOME` on unix only; on Windows it reads
+    // `USERPROFILE`, so pointing `HOME` at a tempdir would not make the
+    // `.env` visible and the warning would never fire.
+    #[cfg(unix)]
     fn report_legacy_env_dotenv_fallback_emits_warning() {
         let _env = EnvGuard::new(&["VB_REMOTE_HOST"]);
         // Pretend `~/.vcli/.env` exists with VB_PROFILE=set, by setting HOME
-        // to a tempdir. dirs::home_dir() reads $HOME on unix so this works
-        // for the macOS / Linux runner; the cfg gate below skips Windows
-        // where dirs::home_dir ignores HOME.
+        // to a tempdir.
         let prev_home = std::env::var_os("HOME");
         let dir = tempfile::tempdir().expect("home");
         std::fs::create_dir_all(dir.path().join(".vcli")).expect("mkdir");

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -251,6 +251,22 @@ impl ConfigFile {
         false
     }
 
+    /// Whether the key is present in **only** the named profile section.
+    ///
+    /// `has(key, Some(profile))` falls through to the global section when the
+    /// profile section lacks the key — the behaviour you want when *reading*,
+    /// but the wrong question when you need to attribute a value to its actual
+    /// layer for `vcli config check`. The report uses this accessor to decide
+    /// between [`crate::config::ConfigSource::FileProfile`] and `FileGlobal`.
+    #[allow(dead_code)]
+    pub(crate) fn profile_section_has(&self, key: &str, profile: &str) -> bool {
+        let friendly = file_key(key);
+        let env = env_var_for(&friendly);
+        self.profiles
+            .get(profile)
+            .is_some_and(|section| section.contains_key(&friendly) || section.contains_key(&env))
+    }
+
     /// Set a key in the global section, or in `[profile.<name>]`.
     pub fn set(&mut self, profile: Option<&str>, key: &str, value: &str) {
         let scalar = Scalar::Text(value.to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,10 @@ enum Commands {
         if_not_exists: bool,
     },
 
+    /// Inspect and validate the resolved configuration
+    #[command(subcommand)]
+    Config(ConfigCmd),
+
     /// Manage multiple Virtuoso targets (multi-host connection pools)
     #[command(subcommand)]
     Target(TargetCmd),
@@ -325,6 +329,31 @@ enum ProfileCmd {
         /// Clear ./.vcli-profile
         #[arg(long, conflicts_with_all = &["venv", "user"])]
         local: bool,
+    },
+}
+
+#[derive(Subcommand)]
+enum ConfigCmd {
+    /// Explain where each resolved value came from (env / file / target / default)
+    #[command(
+        long_about = "Show the resolved configuration and the source of every value.\n\n\
+            Walks the same layered lookup the runtime uses (VB_<KEY>_<PROFILE> -> \
+            VB_<KEY> -> config.toml [profile.<active>] -> config.toml global -> \
+            built-in default, or a targets.yaml entry when --target is set), and \
+            reports which layer produced each field. Use this when 'why is my \
+            timeout 120 seconds?' needs an answer that doesn't require reading code.\n\n\
+            Examples:\n  \
+            vcli config check\n  \
+            vcli config check --format json | jq '.entries[] | select(.key == \"VB_TIMEOUT\")'\n  \
+            vcli config check --require-explicit  # exit non-zero when any field fell to a default"
+    )]
+    Check {
+        /// Exit non-zero if any resolved value came from a built-in default.
+        /// Useful in CI: a "missing env config" reviewer can run this and
+        /// refuse to merge a green build that didn't actually configure the
+        /// daemon.
+        #[arg(long)]
+        require_explicit: bool,
     },
 }
 
@@ -1750,6 +1779,12 @@ fn dispatch_tunnel(
     }
 }
 
+fn dispatch_config(cmd: ConfigCmd, format: OutputFormat) -> error::Result<serde_json::Value> {
+    match cmd {
+        ConfigCmd::Check { require_explicit } => commands::config::check(format, require_explicit),
+    }
+}
+
 fn dispatch_profile(
     cmd: ProfileCmd,
     cli_profile: Option<String>,
@@ -2591,7 +2626,7 @@ fn main() {
     use crate::target::resolve::{resolve_from_selection, resolve_selection, Selection};
     let needs_config = !matches!(
         &cli.command,
-        Commands::Target(_) | Commands::Profile(_) | Commands::Init { .. }
+        Commands::Target(_) | Commands::Profile(_) | Commands::Init { .. } | Commands::Config(_)
     );
     let ctx: Option<crate::context::CommandContext> = if needs_config {
         let selection = match resolve_selection(cli.target.as_deref(), cli.profile.as_deref()) {
@@ -2697,6 +2732,7 @@ fn main() {
 
     let result = match cli.command {
         Commands::Init { if_not_exists } => commands::init::run(if_not_exists),
+        Commands::Config(cmd) => dispatch_config(cmd, format),
         Commands::Target(cmd) => dispatch_target(cmd, format),
         // Compiled only with `native-ssh`; other builds have no such subcommand
         // at all, so there is nothing to dispatch. `run_with` blocks forever

--- a/tests/config_check.rs
+++ b/tests/config_check.rs
@@ -1,0 +1,252 @@
+//! Integration tests for `vcli config check`.
+//!
+//! The check command rebuilds the same layered lookup the live `Config`
+//! uses and reports which layer won per key. The contract these tests pin:
+//!
+//! 1. **JSON shape is stable.** Downstream tools (`jq` filters, dashboards)
+//!    depend on `entries[]` carrying `key`, `value`, `source.layer`,
+//!    `source.<variant-attrs>`, and `source_label` — adding a field is
+//!    fine, renaming or removing one is a breaking change.
+//! 2. **Source attribution is correct.** Each precedence layer (env-profile,
+//!    env-global, file-profile, file-global, target, default) must be
+//!    reachable and correctly identified.
+//! 3. **Parse failures are warnings, not silent.** A typo like
+//!    `VB_TIMEOUT=abc` produces a value + a warning, never an exit error —
+//!    that's how users learn the value would fail at runtime without
+//!    having to run a real command.
+//!
+//! Every test is `#[serial]` (the env is shared process state) and shields
+//! every variable whose presence would shift attribution. The `Drop` on
+//! `EnvGuard` restores the original state so a failed assertion doesn't
+//! poison subsequent tests.
+
+use std::ffi::OsString;
+
+struct EnvGuard {
+    restored: Vec<(String, Option<OsString>)>,
+}
+
+impl EnvGuard {
+    fn set(key: &str, val: &str) -> Self {
+        let old = std::env::var_os(key);
+        std::env::set_var(key, val);
+        Self {
+            restored: vec![(key.to_string(), old)],
+        }
+    }
+    fn add(&mut self, key: &str) {
+        let old = std::env::var_os(key);
+        std::env::remove_var(key);
+        self.restored.push((key.to_string(), old));
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, val) in self.restored.drain(..) {
+            match val {
+                Some(v) => std::env::set_var(&key, v),
+                None => std::env::remove_var(&key),
+            }
+        }
+    }
+}
+
+fn isolate_config_dir() -> (tempfile::TempDir, Option<OsString>) {
+    let prev = std::env::var_os("VB_CONFIG_DIR");
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::env::set_var("VB_CONFIG_DIR", dir.path());
+    (dir, prev)
+}
+
+struct ConfigDirRestore(Option<OsString>);
+
+impl Drop for ConfigDirRestore {
+    fn drop(&mut self) {
+        match &self.0 {
+            Some(v) => std::env::set_var("VB_CONFIG_DIR", v),
+            None => std::env::remove_var("VB_CONFIG_DIR"),
+        }
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn check_json_shape_lists_every_known_key_with_a_source() {
+    let mut env = EnvGuard::set("VB_CONFIG_DIR", "");
+    env.add("VB_REMOTE_HOST");
+    env.add("VB_TIMEOUT");
+    env.add("VB_TARGETS_FILE");
+    env.add("VB_TARGET");
+    let (_tmp, prev) = isolate_config_dir();
+    let _restore = ConfigDirRestore(prev);
+
+    let report = virtuoso_cli::config::Config::build_report(None).expect("build_report");
+
+    // Every entry must have a non-empty key, a string value, a layer
+    // discriminator, and a label. JSON-shape contract for downstream tools.
+    for e in &report.entries {
+        assert!(!e.key.is_empty(), "key must be non-empty");
+        let serialized = serde_json::to_value(&e.source).expect("ConfigSource serializes");
+        let layer = serialized
+            .get("layer")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+        assert!(!layer.is_empty(), "source.layer must be present: {e:?}");
+    }
+
+    // Spot-check that the report includes both connection-identity and
+    // transport-scheduler fields — a missing key would silently drift.
+    let keys: Vec<&str> = report.entries.iter().map(|e| e.key).collect();
+    assert!(keys.contains(&"VB_REMOTE_HOST"), "remote_host missing");
+    assert!(keys.contains(&"VB_TIMEOUT"), "timeout missing");
+    assert!(
+        keys.contains(&"VB_SSH_KEEPALIVE_FAILURES"),
+        "scheduler field missing"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn check_env_layer_wins_over_file_layer() {
+    let mut env = EnvGuard::set("VB_CONFIG_DIR", "");
+    env.add("VB_REMOTE_HOST");
+    env.add("VB_TARGETS_FILE");
+    env.add("VB_TARGET");
+    let (tmp, prev) = isolate_config_dir();
+    let _restore = ConfigDirRestore(prev);
+    std::fs::create_dir_all(tmp.path().join("vcli")).expect("mkdir vcli");
+    std::fs::write(
+        tmp.path().join("vcli/config.toml"),
+        r#"remote_host = "eda-from-file""#,
+    )
+    .expect("write config");
+    // env var beats file even when file is set:
+    std::env::set_var("VB_REMOTE_HOST", "eda-from-env");
+
+    let report = virtuoso_cli::config::Config::build_report(None).expect("build_report");
+    let e = report
+        .entries
+        .iter()
+        .find(|e| e.key == "VB_REMOTE_HOST")
+        .expect("entry exists");
+    assert_eq!(e.value, "eda-from-env");
+    let src = serde_json::to_value(&e.source).expect("serialize");
+    assert_eq!(src["layer"], "env");
+    assert_eq!(src["var"], "VB_REMOTE_HOST");
+}
+
+#[test]
+#[serial_test::serial]
+fn check_file_layer_wins_over_default() {
+    let mut env = EnvGuard::set("VB_CONFIG_DIR", "");
+    env.add("VB_TIMEOUT");
+    env.add("VB_TARGETS_FILE");
+    env.add("VB_TARGET");
+    let (tmp, prev) = isolate_config_dir();
+    let _restore = ConfigDirRestore(prev);
+    std::fs::create_dir_all(tmp.path().join("vcli")).expect("mkdir vcli");
+    std::fs::write(tmp.path().join("vcli/config.toml"), r#"timeout = "45""#).expect("write");
+
+    let report = virtuoso_cli::config::Config::build_report(None).expect("build_report");
+    let e = report
+        .entries
+        .iter()
+        .find(|e| e.key == "VB_TIMEOUT")
+        .expect("entry exists");
+    assert_eq!(e.value, "45");
+    let src = serde_json::to_value(&e.source).expect("serialize");
+    assert!(
+        src["layer"] == "file_profile" || src["layer"] == "file_global",
+        "expected file layer, got {src}"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn check_malformed_value_becomes_warning_not_error() {
+    let mut env = EnvGuard::set("VB_CONFIG_DIR", "");
+    env.add("VB_PORT");
+    env.add("VB_TARGETS_FILE");
+    env.add("VB_TARGET");
+    let (_tmp, prev) = isolate_config_dir();
+    let _restore = ConfigDirRestore(prev);
+    std::env::set_var("VB_PORT", "not-a-number");
+
+    let report = virtuoso_cli::config::Config::build_report(None).expect("build_report");
+    let e = report
+        .entries
+        .iter()
+        .find(|e| e.key == "VB_PORT")
+        .expect("entry exists");
+    // Value still surfaced (so the user can see what they set); warning
+    // tells them it would fail to parse at runtime.
+    assert_eq!(e.value, "not-a-number");
+    let src = serde_json::to_value(&e.source).expect("serialize");
+    assert_eq!(src["layer"], "env");
+    assert!(
+        report.warnings.iter().any(|w| w.contains("VB_PORT")),
+        "expected VB_PORT parse warning, got {:?}",
+        report.warnings
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn check_empty_profile_section_falls_through_to_global() {
+    // Regression: a profile section that omits a key must NOT shadow the
+    // global value with "absent". `ConfigFile::get` already returns the
+    // global when the profile section has nothing for the key — this test
+    // pins that behaviour for the report too.
+    let mut env = EnvGuard::set("VB_CONFIG_DIR", "");
+    env.add("VB_REMOTE_HOST");
+    env.add("VB_REMOTE_HOST_prod"); // profile-suffix variant — must also be shielded
+    env.add("VB_TARGETS_FILE");
+    env.add("VB_TARGET");
+    let (tmp, prev) = isolate_config_dir();
+    let _restore = ConfigDirRestore(prev);
+    std::fs::create_dir_all(tmp.path().join("vcli")).expect("mkdir");
+    std::fs::write(
+        tmp.path().join("vcli/config.toml"),
+        r#"
+remote_host = "global-host"
+
+[profile.prod]
+timeout = "60"
+"#,
+    )
+    .expect("write");
+
+    let report = virtuoso_cli::config::Config::build_report(Some("prod")).expect("build_report");
+    let e = report
+        .entries
+        .iter()
+        .find(|e| e.key == "VB_REMOTE_HOST")
+        .expect("entry exists");
+    assert_eq!(e.value, "global-host");
+    let src = serde_json::to_value(&e.source).expect("serialize");
+    assert_eq!(src["layer"], "file_global");
+}
+
+#[test]
+#[serial_test::serial]
+fn check_default_source_is_attributed_when_no_other_layer_fires() {
+    let mut env = EnvGuard::set("VB_CONFIG_DIR", "");
+    env.add("VB_TIMEOUT");
+    env.add("VB_TARGETS_FILE");
+    env.add("VB_TARGET");
+    let (_tmp, prev) = isolate_config_dir();
+    let _restore = ConfigDirRestore(prev);
+    // No env, no file — VB_TIMEOUT must trace back to the constant default.
+    let report = virtuoso_cli::config::Config::build_report(None).expect("build_report");
+    let e = report
+        .entries
+        .iter()
+        .find(|e| e.key == "VB_TIMEOUT")
+        .expect("entry exists");
+    assert_eq!(e.value, "30");
+    let src = serde_json::to_value(&e.source).expect("serialize");
+    assert_eq!(src["layer"], "default");
+    assert_eq!(src["default"], "30");
+    assert!(!report.all_explicit());
+}


### PR DESCRIPTION
## 背景

RFC #83 的完整闭环 = 第 1 步（不再隐式加载 `.env`，#88）+ 第 2 步（结构化 `config.toml`，#88）+ 第 3 步（**能解释每个最终值的来源**）—— 本 PR 实现第 3 步。

`Config::from_env()` 是带优先级的四层查找（`VB_<KEY>_<PROFILE>` env → `VB_<KEY>` env → `config.toml [profile.<PROFILE>]` 段 → `config.toml` 全局段 → 默认值）。在 #88 把配置文件重构之后，用户**仍然没有**问「我的 timeout 怎么变成 120 秒了？」的入口——只能重新读代码。本 PR 给出 `vcli config check`：走相同的优先级，逐字段报告来源。

## 改了什么

### `Config::build_report(profile)`（`src/config.rs`）

复用 `Layers` 的查找逻辑（同一份优先级、同一份 `ConfigFile`），逐字段记录来源。**报告路径与运行时路径共用一份 `raw_with_source`**，因此不可能漂移。

支持的来源类型（serde tag = `layer`）：

| `layer` | 变体字段 | 含义 |
|---|---|---|
| `env_profile` | `var` | `<KEY>_<PROFILE>` 环境变量命中 |
| `env` | `var` | `<KEY>` 环境变量命中 |
| `file_profile` | `file` | `config.toml [profile.<PROFILE>]` 段命中（精确：profile section 自身拥有该键） |
| `file_global` | `file` | `config.toml` 全局段命中 |
| `target` | `target` | `VB_TARGET` 指向的 `targets.yaml` 条目提供的字段 |
| `default` | `default` | 无任何更高优先级层提供，使用内置默认值 |

`target` 模式直接走 `from_target()`，与 `from_env_resolve` 的早返语义一致（target 文件不被 file 层稀释）。

### 新增内部访问器 `ConfigFile::profile_section_has`（`src/config_file.rs`）

`ConfigFile::has(key, Some(profile))` 会先查 profile section、再 fall-through 到 global——而 `build_report` 需要区分「profile section 自身拥有」与「全局段兜底」才能正确归属。否则一个空的 `[profile.prod]` 段会让里面的全局字段被错误地标成 `FileProfile`。该访问器 `pub(crate)`、行为对称（含双拼写友好键 + 大写 env 名）。

### 命令 `vcli config check`（`src/commands/config.rs`、`src/main.rs`）

```
vcli config check [--format json|table] [--require-explicit]
```

- 默认输出：人可读的 key/value ledger（带优先级块、warn 列表）。
- `--format json`：`jq '.entries[] | select(.key == "VB_TIMEOUT")'` 单行可查。
- `--require-explicit`：当任何字段落到默认值时，exit 10（`DRY_RUN_OK`），可用于 CI 守门。

软警告（`warnings[]`，不提升退出码）：
- `~/.vcli/.env` 仍带 `VB_PROFILE=`（已弃用回退）；
- 字段值在运行时解析会失败（如 `VB_TIMEOUT=abc` 仍照实呈现 + 警告）。

### 测试

- `src/config.rs::report_tests`（9 unit，`#[serial]`）：default / env / file global / file profile-section / profile-specific env 优先 / target 模式 / 解析失败警告 / 旧 `.env` 弃用回退警告 / 全字段非默认值。
- `tests/config_check.rs`（6 integration）：JSON 形状契约、env>file、file>default、坏值变 warn、profile 段 fall-through、default 归属。

## 关键 bug：测试隔离重做

第一次跑全量套件时 18 个 `context`/`target::resolve`/`transport::tunnel` 测试红了，全部 panic 在 `Config("VB_SSH_PORT: \"x\" is not valid")`。根因是 `all_explicit_is_true_when_no_default_sources` 直接 `std::env::set_var(k, "x")` 遍历所有 `KEY_SPECS`，但 `EnvGuard::Drop` 只还原它 new() 时传入的 key——`VB_SSH_PORT` 等被设置后没人清掉，污染下一个测试。改成 `EnvGuard::new(&all_keys)`（传入完整键集）后立即复绿。**这是提交前抓到的真实问题**，不是 CI 才发现。

## 门禁

| 项 | 结果 |
|---|---|
| `cargo fmt --check` | ✅ |
| `cargo clippy --all-targets -- -D warnings` | ✅ 0 / 0 |
| `cargo test`（默认特性） | ✅ **971 lib + 1130 windows + 6 config_check + ... 0 failed**（含定向 9 个新 unit + 6 个新 integration） |
| `git diff --check` | ✅ |
| 端到端 smoke | ✅ env 优先 file、file 优先 default；`--require-explicit` 在默认值存在时 exit 10 |
| `--features native-ssh` | 交 Linux CI（本机跳过） |

> 注：全量跑时偶发 2 个 `transport::identity` / `transport::daemon_lifecycle` 测试失败，**与本 PR 无关**——按 PID 读活体进程身份的 macOS 环境问题，isolate 重跑即通过。

## 改动

`src/config.rs`（新增 `ConfigSource`/`ConfigEntry`/`ConfigReport`/`build_report`/`Layers::raw_with_source`/`KEY_SPECS`）/ `src/config_file.rs`（新增 `profile_section_has`）/ `src/commands/config.rs`（新）/ `src/commands/mod.rs`（模块声明）/ `src/main.rs`（`ConfigCmd` enum + dispatch）/ `tests/config_check.rs`（新）

## 后续

- #88 合并后，本 PR 的 base 自然会指向 `main`（rebase 即可，diff 仅含本 PR 的 ~1370 行）。
- 第 3 步完成，RFC #83 的全部三步均已落地。

Refs #73
Refs #83
Refs #88