### PR TITLE
fix(config): session remaining commands + config-check contract gaps

### DIFF
--- a/docs/p0a-config-callchain-inventory.md
+++ b/docs/p0a-config-callchain-inventory.md
@@ -1,6 +1,6 @@
 # P0-A · 配置调用链盘点（Config Call-Chain Inventory）
 
-> 日期：2026-09-05
+> 日期：2026-09-08（更新）
 > 目标：为「命令层显式接收已解析 Config（CommandContext）」的改造提供量化依据。
 > 对应外部审阅项：F06（删除 env 桥接还不够，调用链必须接收同一配置）、F05（配置摘要/身份校验）。
 
@@ -65,13 +65,19 @@
 
 ## 5. CommandContext 迁移进度（P0-A 进行中）
 
-| 命令族 | 状态 |
-|---|---|
-| tunnel（start/stop/restart/status/diagnose/attach/detach） | ✅ 已迁移：接收 `&CommandContext`，经 `ctx.config()` / `SSHClient::from_config` / `VirtuosoClient::from_context` 使用单次解析配置 |
-| `VirtuosoClient` | ✅ `from_context(ctx)` 新入口；`from_config(cfg, target_id)` 拆出；构造时做会话目标归属校验 |
-| session 命令族 | ⏳ 未迁移（仍经 env 重读） |
-| spectre/runner、skill、maestro 等 | ⏳ 未迁移（仍经 env 重读） |
-| env 桥接（`VB_TARGET`） | ⚠️ 保留给未迁移命令族；与 CommandContext 共用同一 `resolve_selection`，保证一致性 |
+> 状态图例：✅ 已合并入 main / 🔄 部分交付（核心已合入，完整语义待补）/ ⏳ 待实现 / ⚠️ 临时桥接保留
+
+| 命令族 / 组件 | 状态 | 说明 |
+|---|---|---|
+| target 选择基础（Resolver + CommandContext） | ✅ 已合并（#75） | `target::resolve` 优先级、冲突检测、失效 active_target 报错；`CommandContext { config, target_id, config_digest }` |
+| tunnel 命令族（start/stop/restart/status/diagnose/attach/detach） | ✅ 已合并（#75） | 接收 `&CommandContext`，经 `ctx.config()` / `SSHClient::from_config` / `VirtuosoClient::from_context` 使用单次解析配置；tunnel state 按 profile 隔离；统一归属校验 |
+| `VirtuosoClient` | ✅ 已合并（#75） | `from_context(ctx)` 新入口；`from_config(cfg, target_id)` 拆出；构造时做会话目标归属校验 |
+| session list/show | ✅ 已合并（#89，2026-09-08） | 接收 `&CommandContext`；共享探测判定函数（`resolve_probe_endpoint`）；远端隧道路径 6 步验证链；本地直连路径；show 两阶段（缓存元数据始终展示 + 在线探测仅在验证通过时）；list 三状态（`endpoint_match`/`tunnel_verified`/`probe_status`）；不再删除 session 文件；`allow_cross_user_daemon` 配置 |
+| session current/cleanup/history/heartbeat | ⏳ 待实现 | 仍为全局缓存语义，尤其 cleanup 需要先明确目标作用域和删除条件 |
+| spectre/runner | ⏳ 待实现 | 仍经 env 重读（`src/spectre/runner.rs:688`） |
+| skill/maestro/window 等命令族 | ⏳ 待实现 | 仍经 `VirtuosoClient::from_env()` 重读 |
+| env 桥接（`VB_TARGET`） | ⚠️ 临时保留 | 保留给未迁移命令族；与 CommandContext 共用同一 `resolve_selection`，保证一致性；全部命令族迁移完成后删除 |
+| daemon 配置身份校验（Hello target_id/config_digest） | ⏳ 待实现 | `Config::digest()` 字段已存在，但主线 IPC 尚未接入 target_id/config_digest 校验 |
 
 - 端到端验证：`tunnel start --dry-run` 对 `--target`/`VB_TARGET`/active_target/
   `--profile` 四种选择均正确解析；目标缺失 exit 3、失效 active_target exit 2；
@@ -125,10 +131,43 @@
 | 绑定标记未按端口匹配：ssh 若在别的端口上完成绑定，也可能被当成目标端口的证明 | 标记串含端口（`…listening on 127.0.0.1 port <n>`），新增单测 `wait_for_forward_ignores_bind_marker_for_another_port` 固定该行为 |
 | `String::from_utf8_lossy(&log.lock().unwrap()[..])` 借用临时 `MutexGuard`（E0716，编译不通过）；且 `wait_for_forward` 头部残留两份重复文档块 | 抽出 `snapshot()` 辅助函数返回自有 `String`（并对 poisoned mutex 降级取值）；合并重复文档块 |
 
-## 6. 待办（下一步）
+## 6. 整体方案状态（2026-09-08 更新）
 
-- 迁移 session 命令族（list/show/current/cleanup/history）到 `&CommandContext`；
-- 迁移 spectre/runner 与其余 `VirtuosoClient::from_env()` 调用点（76 处总量）；
-- 删除 `main()` 的 `VB_TARGET` env 桥接 + `config.rs` 的 `VB_TARGET` 分支
-  （全部命令族迁移完成后）；
-- `config_digest` 接入 daemon Hello 校验（P0-B 前哨，F05）。
+### 已合并入 main
+
+| PR | 内容 | 合并日期 |
+|---|---|---|
+| #75 | target 选择、CommandContext 基础、tunnel 隔离 | 2026-09 上旬 |
+| #78 | endpoint 对象池、调度器接入 | 2026-09 上旬 |
+| #87 | native SSH 跨请求复用、并发 channel、保活 | 2026-09 上旬 |
+| #89 | session list/show 身份验证迁移 | 2026-09-08 |
+
+### 部分交付（核心已合入，完整语义待补）
+
+- **native SSH 长连接（#87）**：跨请求复用、并发 channel、保活已合并；但完整 drain、退出清理、故障恢复尚未完成（见 issue #80）；当前源码仍由每个 NativeTransport 创建自己的 runtime，与原方案"daemon 统一共享、限制线程资源"的目标还有差距。**不应继续笼统写"P0-B 暂缓"。**
+
+### 进行中
+
+- **#88**：dotenv 移除、config.toml 统一配置层（用户单独处理）。四项审查问题尚无新提交修复：统一配置键名、可靠 TOML 序列化、传播 profile 清理错误、隔离配置测试。
+
+### 待实现（按优先级）
+
+1. **收尾 #88**：配置层重构完成后，所有命令族的配置来源需对齐 config.toml 模型。
+2. **重做 config check**：基于 #88 修复后的配置层，解释每个值来自 env / target / config.toml / 默认值；来源记录在解析时同步完成；必须处理解析失败路径；脱敏覆盖错误信息。（旧 PR #73 已关闭）
+3. **完成 P0-A 配置与身份闭环**：
+   - 迁移 session 剩余命令（current/cleanup/history/heartbeat），cleanup 需先明确目标作用域和删除条件
+   - 迁移 spectre/runner
+   - 迁移 skill/maestro/window 等其余命令族
+   - 全部接通后删除 env 桥接（`main()` 的 `VB_TARGET` 同步 + `config.rs` 的 `VB_TARGET` 分支）
+4. **接通 daemon 配置身份校验**：Hello 在执行前验证 target_id、config_digest 和实例身份；配置漂移时拒绝旧实例。
+5. **完成连接生命周期**：按 issue #80 补 drain、退出清理、故障恢复与端到端验收。
+
+### 独立任务（可单独排队）
+
+- issue #84：补 typed RPC 参数写入，避免普通原理图编辑被迫授予 Admin。
+- issue #86：共享 daemon 搜索优先级与目录信任边界；共享部署本身已由 #85 合并，无需重做 #76。
+
+## 7. 本地环境已知问题（不构成合并阻塞）
+
+- `wait_for_forward_*` 系列测试在本地 macOS 偶发失败（`tunnel forward never established in time`）；CI（Ubuntu/macOS/Windows）均未复现；基线对照确认 `rejects_unrelated_listener_when_ssh_fails_late` 在 main 同失败；根因未定。
+- `cargo fmt` 曾段错误，本机使用 `rustfmt --edition 2021 --check $(find src tests -name '*.rs')` 替代；CI 使用标准 `cargo fmt --check`。

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -27,18 +27,22 @@ pub fn check(format: OutputFormat, require_explicit: bool) -> Result<Value> {
     let value = match format {
         OutputFormat::Json => json!({
             "status": status,
+            "valid": report.valid,
             "profile": report.profile,
             "active_target": report.active_target,
             "config_file": report.config_file,
+            "targets_file": report.targets_file,
+            "digest": report.digest,
             "precedence": report.precedence,
             "entries": entries_json(&report),
             "warnings": report.warnings,
+            "diagnostics": report.diagnostics,
             // main() reads "dry_run" to pick DRY_RUN_OK (10) over SUCCESS (0);
-            // we re-use that mechanism so `--require-explicit` propagates a
-            // non-zero exit without dragging a second channel through the
-            // dispatch result. The status string above remains the
+            // we re-use that mechanism so `--require-explicit` or a hard error
+            // propagates a non-zero exit without dragging a second channel
+            // through the dispatch result. The status string above remains the
             // human-readable signal; this is the exit-code driver.
-            "dry_run": status == "fail",
+            "dry_run": status == "fail" || status == "error",
         }),
         OutputFormat::Table => render_table(&report, status),
     };
@@ -82,13 +86,20 @@ fn source_label(src: &ConfigSource) -> String {
             format!("file[profile]={}", file.display())
         }
         ConfigSource::FileGlobal { file } => format!("file[global]={}", file.display()),
-        ConfigSource::Target { target } => format!("target[{target}]"),
-        ConfigSource::Default { default } => format!("default={default}"),
+        ConfigSource::Target { target, file } => {
+            format!("target[{target}]={}", file.display())
+        }
+        ConfigSource::Default { default, kind } => match kind {
+            crate::config::DefaultKind::Hardcoded => format!("default={default}"),
+            crate::config::DefaultKind::Derived => format!("default(derived)={default}"),
+        },
     }
 }
 
 fn status_for(report: &ConfigReport, require_explicit: bool) -> &'static str {
-    if !report.warnings.is_empty() {
+    if !report.valid {
+        "error"
+    } else if !report.warnings.is_empty() {
         "warn"
     } else if require_explicit && !report.all_explicit() {
         "fail"

--- a/src/commands/session.rs
+++ b/src/commands/session.rs
@@ -547,51 +547,215 @@ pub fn list(ctx: &CommandContext, format: OutputFormat) -> Result<Value> {
     }))
 }
 
-pub fn current() -> Result<Value> {
-    let live = SessionInfo::list_alive();
-    match live.len() {
-        0 => Ok(
-            json!({"status": "success", "session": null, "note": "no live sessions; VB_PORT will be used"}),
-        ),
+/// Show the current (active) session for the selected target.
+///
+/// Uses the same shared verification chain as `list` / `show`
+/// (`resolve_probe_endpoint`) rather than the legacy `list_alive()` which
+/// only checks local port reachability and can misclassify remote sessions.
+///
+/// Target mode: only considers sessions whose endpoint matches the current
+/// target. Legacy mode: considers all locally-reachable sessions (preserves
+/// existing behaviour for non-target invocations).
+pub fn current(ctx: &CommandContext) -> Result<Value> {
+    let all = SessionInfo::list().unwrap_or_default();
+    let is_target = ctx.target_id().is_some();
+
+    let mut reachable: Vec<&SessionInfo> = Vec::new();
+    let mut skipped: Vec<(String, String)> = Vec::new(); // (id, reason)
+
+    for s in &all {
+        // Target mode: skip sessions that don't match the target endpoint.
+        if is_target {
+            match compute_endpoint_match(ctx, s) {
+                "match" => {}
+                "mismatch" => {
+                    skipped.push((s.id.clone(), "endpoint_mismatch".into()));
+                    continue;
+                }
+                _ => {
+                    // Legacy/unverifiable — still consider if reachable.
+                }
+            }
+        }
+
+        // Determine liveness.
+        //
+        // Legacy mode (no target): preserve the original `list_alive()` behaviour
+        // — a session whose local port is reachable is alive.
+        //
+        // Target mode: use the shared verification chain. Only sessions whose
+        // probe endpoint resolves successfully are considered reachable.
+        let is_reachable = if is_target {
+            resolve_probe_endpoint(ctx, s).is_ok()
+        } else {
+            s.is_alive()
+        };
+
+        if is_reachable {
+            reachable.push(s);
+        } else if is_target {
+            // In target mode, record why a matching session was not reachable.
+            if let Err(skip) = resolve_probe_endpoint(ctx, s) {
+                skipped.push((s.id.clone(), skip.reason.into()));
+            }
+        }
+    }
+
+    match reachable.len() {
+        0 => Ok(json!({
+            "status": "success",
+            "session": null,
+            "target": ctx.target_id(),
+            "note": if is_target {
+                "no reachable sessions for this target; check tunnel attach"
+            } else {
+                "no live sessions; VB_PORT will be used"
+            },
+            "skipped_count": skipped.len(),
+        })),
         1 => Ok(json!({
             "status": "success",
-            "session": live[0].id,
-            "port": live[0].port,
+            "session": reachable[0].id,
+            "port": reachable[0].port,
+            "host": reachable[0].host,
+            "target": ctx.target_id(),
             "auto_selected": true,
+            "endpoint_match": if is_target { "match" } else { "unchecked" },
         })),
         _ => {
-            let ids: Vec<&str> = live.iter().map(|s| s.id.as_str()).collect();
+            let ids: Vec<&str> = reachable.iter().map(|s| s.id.as_str()).collect();
             Ok(json!({
                 "status": "ambiguous",
                 "sessions": ids,
+                "target": ctx.target_id(),
                 "note": "use --session <id> to select one",
             }))
         }
     }
 }
 
-pub fn cleanup() -> Result<Value> {
+/// Remove dead session records.
+///
+/// Uses the shared verification chain (`resolve_probe_endpoint`) to determine
+/// whether a session is dead, rather than the legacy `is_alive()` which only
+/// checks local port reachability and can misclassify remote sessions that
+/// haven't been attached yet.
+///
+/// Target mode: only removes sessions whose endpoint matches the current target.
+/// Legacy mode: preserves existing global cleanup behaviour.
+///
+/// `dry_run`: when true, reports what would be removed without deleting files.
+pub fn cleanup(ctx: &CommandContext, dry_run: bool) -> Result<Value> {
     let all = SessionInfo::list().unwrap_or_default();
     let dir = SessionInfo::sessions_dir();
-    let mut removed = Vec::new();
+    let is_target = ctx.target_id().is_some();
+
+    let mut removed: Vec<String> = Vec::new();
+    let mut skipped: Vec<(String, String)> = Vec::new(); // (id, reason)
+
     for s in &all {
-        if !s.is_alive() {
-            let path = dir.join(format!("{}.json", s.id));
-            if std::fs::remove_file(&path).is_ok() {
-                removed.push(s.id.clone());
+        // Target mode: skip sessions that don't match the target endpoint.
+        if is_target {
+            match compute_endpoint_match(ctx, s) {
+                "match" => {}
+                "mismatch" => {
+                    skipped.push((s.id.clone(), "endpoint_mismatch".into()));
+                    continue;
+                }
+                _ => {
+                    // Legacy/unverifiable — still evaluate.
+                }
             }
         }
+
+        // Determine liveness.
+        //
+        // Legacy mode (no target): preserve the original `is_alive()` behaviour
+        // — a session whose local port is unreachable is dead. This avoids
+        // breaking existing cleanup semantics for non-target invocations.
+        //
+        // Target mode: use the shared verification chain. A session is "dead"
+        // only if the probe was actually attempted and the port was unreachable.
+        // Identity-skipped sessions are preserved (they may be valid remote
+        // sessions that just can't be verified from this machine).
+        let (is_dead, skip_reason) = if is_target {
+            match resolve_probe_endpoint(ctx, s) {
+                Ok(_) => (false, None),
+                Err(skip) => {
+                    let dead = skip.reason == "forward_port_unreachable"
+                        || skip.reason == "local_port_unreachable";
+                    (dead, Some(skip.reason))
+                }
+            }
+        } else {
+            (!s.is_alive(), None)
+        };
+
+        if is_dead {
+            if dry_run {
+                removed.push(s.id.clone());
+            } else {
+                let path = dir.join(format!("{}.json", s.id));
+                if std::fs::remove_file(&path).is_ok() {
+                    removed.push(s.id.clone());
+                } else {
+                    skipped.push((s.id.clone(), "remove_failed".into()));
+                }
+            }
+        } else {
+            let reason = match skip_reason {
+                Some(r) => format!("skipped:{}", r),
+                None => "reachable".into(),
+            };
+            skipped.push((s.id.clone(), reason));
+        }
     }
+
     Ok(json!({
         "status": "success",
+        "dry_run": dry_run,
+        "target": ctx.target_id(),
         "removed": removed.len(),
         "sessions": removed,
+        "skipped_count": skipped.len(),
+        "skipped": skipped.iter().map(|(id, reason)| json!({"id": id, "reason": reason})).collect::<Vec<_>>(),
     }))
 }
 
-pub fn history(id: &str, only_skill: bool, only_cmd: bool, limit: usize) -> Result<Value> {
+/// Show command/SKILL history for a session.
+///
+/// Read-only: history files are per-session logs and don't require a live
+/// connection. The session's endpoint ownership is verified against the
+/// current target context; a mismatch surfaces as a warning but does not
+/// block reading (history is local cache, not a connection operation).
+pub fn history(
+    ctx: &CommandContext,
+    id: &str,
+    only_skill: bool,
+    only_cmd: bool,
+    limit: usize,
+) -> Result<Value> {
     let show_skill = !only_cmd;
     let show_cmd = !only_skill;
+
+    // Load session metadata for ownership verification (best-effort).
+    let session_meta = SessionInfo::load(id).ok();
+    let (endpoint_match, ownership_warning) = match (&session_meta, ctx.target_id()) {
+        (Some(s), Some(_)) => {
+            let m = compute_endpoint_match(ctx, s);
+            let warning = if m == "mismatch" {
+                Some(format!(
+                    "session {} endpoint does not match target {}; showing history anyway",
+                    id,
+                    ctx.target_id().unwrap_or_default()
+                ))
+            } else {
+                None
+            };
+            (m.to_string(), warning)
+        }
+        _ => ("unchecked".to_string(), None),
+    };
 
     let skill_entries: Vec<Value> = if show_skill {
         crate::history::load_skill(id, limit)
@@ -613,14 +777,22 @@ pub fn history(id: &str, only_skill: bool, only_cmd: bool, limit: usize) -> Resu
         vec![]
     };
 
-    Ok(json!({
+    let mut result = json!({
         "status": "success",
         "session": id,
+        "target": ctx.target_id(),
+        "endpoint_match": endpoint_match,
         "skill_count": skill_entries.len(),
         "cmd_count": cmd_entries.len(),
         "skill": skill_entries,
         "cmd": cmd_entries,
-    }))
+    });
+
+    if let Some(warning) = ownership_warning {
+        result["ownership_warning"] = json!(warning);
+    }
+
+    Ok(result)
 }
 
 /// Show details for a specific session.

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,6 +257,20 @@ struct Layers<'a> {
 /// so a user can ask "why did this 30-second timeout become 120?" and get an
 /// answer that names the actual env var, the exact `[profile.<name>]` section
 /// or the defaulting code path.
+/// How a [`ConfigSource::Default`] value was derived.
+///
+/// `Hardcoded` values are compile-time constants (e.g. `timeout = 30`).
+/// `Derived` values are computed at runtime from the environment (e.g. the
+/// default bridge port is picked by the OS when `port = 0`). Surfacing this
+/// distinction lets a user tell "I didn't set it, and the code picked 30"
+/// apart from "I didn't set it, and the OS picked 40163".
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DefaultKind {
+    Hardcoded,
+    Derived,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(tag = "layer", rename_all = "snake_case")]
 pub enum ConfigSource {
@@ -270,12 +284,13 @@ pub enum ConfigSource {
     /// `config.toml` global section.
     FileGlobal { file: PathBuf },
     /// An active `targets.yaml` entry whose field overrode this setting.
-    /// `target` is the target name as set by `--target` / `VB_TARGET` /
-    /// `active_target` in `targets.yaml`.
-    Target { target: String },
-    /// No higher-precedence layer supplied a value; `default` documents the
-    /// constant the resolver fell through to.
-    Default { default: String },
+    /// `target` is the target name; `file` is the absolute path of the
+    /// `targets.yaml` that owned it (so a user can `vim` it).
+    Target { target: String, file: PathBuf },
+    /// No higher-precedence layer supplied a value. `default` documents the
+    /// constant the resolver fell through to; `kind` distinguishes compile-time
+    /// constants from runtime-derived values (e.g. OS-assigned ports).
+    Default { default: String, kind: DefaultKind },
 }
 
 /// One resolved key, with its value and provenance.
@@ -284,6 +299,21 @@ pub struct ConfigEntry {
     pub key: &'static str,
     pub value: String,
     pub source: ConfigSource,
+}
+
+/// One diagnostic entry in a [`ConfigReport`].
+///
+/// Diagnostics are structured errors/warnings with stable codes so CI and
+/// scripts can match on them without parsing human-readable text. `level`
+/// is `"error"` (blocks usage) or `"warning"` (advisory). `field` names the
+/// config key or subsystem the diagnostic applies to (e.g. `"VB_TIMEOUT"`,
+/// `"targets.yaml"`, `"config.toml"`).
+#[derive(Debug, Clone, Serialize)]
+pub struct ConfigDiagnostic {
+    pub code: &'static str,
+    pub level: &'static str,
+    pub field: String,
+    pub message: String,
 }
 
 /// Aggregated report of the resolved configuration.
@@ -296,7 +326,14 @@ pub struct ConfigEntry {
 pub struct ConfigReport {
     pub profile: Option<String>,
     pub active_target: Option<String>,
+    /// Path of the config.toml that was read, if any. In target mode this is
+    /// `None` because targets.yaml drives resolution and config.toml is not
+    /// consulted — callers should check `active_target.is_some()` to tell
+    /// "not applicable" apart from "file missing".
     pub config_file: Option<PathBuf>,
+    /// Path of the targets.yaml that was read, if a target is active. `None`
+    /// in legacy mode.
+    pub targets_file: Option<PathBuf>,
     /// Resolution precedence, highest first, with the key spelling each layer
     /// expects. Surfaced in `--format json` so a user can verify the order
     /// without reading code.
@@ -306,6 +343,16 @@ pub struct ConfigReport {
     /// fallback being read). Empty when nothing to warn about. Failures
     /// here don't elevate the process exit code — they are advisory.
     pub warnings: Vec<String>,
+    /// Structured diagnostics with stable codes. Includes both parse failures
+    /// (e.g. invalid port, missing target) and advisory warnings.
+    pub diagnostics: Vec<ConfigDiagnostic>,
+    /// `false` when any diagnostic is `level = "error"` — the config cannot
+    /// be used as-is. `true` when only warnings (or nothing) were found.
+    pub valid: bool,
+    /// Config digest (hex-encoded) when resolution succeeded. `None` when a
+    /// hard error prevented a complete config from being built (e.g. targets
+    /// file unreadable, target not found).
+    pub digest: Option<String>,
 }
 
 impl ConfigReport {
@@ -357,7 +404,14 @@ fn report_ssh_port(cfg: &Config) -> String {
         .unwrap_or_else(|| "22".into())
 }
 fn report_ssh_key(cfg: &Config) -> String {
-    cfg.ssh_key.clone().unwrap_or_default()
+    // The key path may contain sensitive info (username, custom paths).
+    // Show only "set" / "unset" to avoid leaking it through a config-check
+    // snapshot or terminal scrollback — same policy as transport_daemon_token.
+    if cfg.ssh_key.is_some() {
+        "***set***".to_string()
+    } else {
+        String::new()
+    }
 }
 fn report_ssh_config(cfg: &Config) -> String {
     cfg.ssh_config.clone().unwrap_or_default()
@@ -566,16 +620,19 @@ fn build_report_from_target(
         let source = if target_provided {
             ConfigSource::Target {
                 target: target_name.to_string(),
-            }
-        } else if value.is_empty() && matches_default(spec.key, &value) {
-            // An empty string when the default *is* empty — the user really
-            // didn't set this anywhere.
-            ConfigSource::Default {
-                default: spec.default.to_string(),
+                file: crate::target::TargetManager::default_config_path(),
             }
         } else {
+            // None from the target means the runtime applied its built-in default.
+            // Port is derived (OS-assigned when 0); everything else is hardcoded.
+            let kind = if spec.key == "VB_PORT" {
+                DefaultKind::Derived
+            } else {
+                DefaultKind::Hardcoded
+            };
             ConfigSource::Default {
                 default: spec.default.to_string(),
+                kind,
             }
         };
         report.entries.push(ConfigEntry {
@@ -634,19 +691,6 @@ fn target_provides(key: &str, t: &crate::target::TargetConfig) -> bool {
         | "VB_REMOTE_SCRATCH_ROOT" => false,
         _ => false,
     }
-}
-
-/// Compare the resolved value to the static default for a key.
-///
-/// Used to detect "the value equals the constant default — that came from
-/// the default, not from anywhere higher up." Empty-string equality is the
-/// common case (e.g. `remote_host` defaults to `""`).
-fn matches_default(key: &str, value: &str) -> bool {
-    KEY_SPECS
-        .iter()
-        .find(|s| s.key == key)
-        .map(|s| s.default == value)
-        .unwrap_or(false)
 }
 
 impl Layers<'_> {
@@ -1125,13 +1169,16 @@ impl Config {
     /// * **legacy mode** (no `VB_TARGET`, or unknown target): the full
     ///   four-layer precedence is consulted.
     ///
-    /// Returns [`VirtuosoError::Config`] when reading or parsing the file
-    /// fails — same hard-error policy as the live path.
+    /// This function never returns `Err` — resolution failures are captured as
+    /// [`ConfigDiagnostic`] entries with `level = "error"` and `valid = false`
+    /// so `vcli config check --format json` always produces a valid document
+    /// (with a non-zero exit code driven by the caller).
     pub fn build_report(profile: Option<&str>) -> Result<ConfigReport> {
         let mut report = ConfigReport {
             profile: profile.map(|s| s.to_string()),
             active_target: None,
             config_file: None,
+            targets_file: None,
             precedence: [
                 "<KEY>_<PROFILE> env",
                 "<KEY> env",
@@ -1140,6 +1187,9 @@ impl Config {
             ],
             entries: Vec::with_capacity(KEY_SPECS.len()),
             warnings: Vec::new(),
+            diagnostics: Vec::new(),
+            valid: true,
+            digest: None,
         };
 
         // Active target detection — mirrors from_env_resolve's honor_vb_target
@@ -1163,12 +1213,19 @@ impl Config {
                         let t = l.trim();
                         t.starts_with("VB_PROFILE=") && !t["VB_PROFILE=".len()..].trim().is_empty()
                     }) {
-                        report.warnings.push(format!(
+                        let msg = format!(
                             "{}: VB_PROFILE= is a deprecated fallback. Run `vcli profile bind \
                              <name> --user` (or export VB_PROFILE in your shell) — this file \
                              will stop being read in a future release.",
                             legacy_env.display()
-                        ));
+                        );
+                        report.warnings.push(msg.clone());
+                        report.diagnostics.push(ConfigDiagnostic {
+                            code: "LEGACY_ENV_PROFILE",
+                            level: "warning",
+                            field: "profile".into(),
+                            message: msg,
+                        });
                     }
                 }
             }
@@ -1176,16 +1233,78 @@ impl Config {
 
         if let Some(ref target_name) = report.active_target.clone() {
             // Target mode: load the target and trace every key to it.
-            let manager = crate::target::TargetManager::load()
-                .map_err(|e| VirtuosoError::Config(format!("failed to load targets: {e}")))?;
-            let target = manager.get(target_name).ok_or_else(|| {
-                VirtuosoError::Config(format!("target '{}' not found", target_name))
-            })?;
-            return Ok(build_report_from_target(target, target_name, report));
+            report.targets_file = Some(crate::target::TargetManager::default_config_path());
+            let manager = match crate::target::TargetManager::load() {
+                Ok(m) => m,
+                Err(e) => {
+                    let msg = format!("failed to load targets: {e}");
+                    report.diagnostics.push(ConfigDiagnostic {
+                        code: "TARGETS_LOAD_FAILED",
+                        level: "error",
+                        field: "targets.yaml".into(),
+                        message: msg.clone(),
+                    });
+                    report.valid = false;
+                    report.warnings.push(msg);
+                    return Ok(report);
+                }
+            };
+            let target = match manager.get(target_name) {
+                Some(t) => t,
+                None => {
+                    let msg = format!("target '{}' not found", target_name);
+                    report.diagnostics.push(ConfigDiagnostic {
+                        code: "TARGET_NOT_FOUND",
+                        level: "error",
+                        field: target_name.clone(),
+                        message: msg.clone(),
+                    });
+                    report.valid = false;
+                    report.warnings.push(msg);
+                    return Ok(report);
+                }
+            };
+            let mut report = build_report_from_target(target, target_name, report);
+            // Compute digest from the synthetic config so the report carries the
+            // same identity the runtime would use.
+            if let Ok(cfg) = Config::from_target(target, target_name) {
+                report.digest = Some(cfg.digest());
+            }
+            return Ok(report);
         }
 
         // Legacy mode: walk the four-layer precedence for every known key.
-        let file = ConfigFile::load()?;
+        let file = match ConfigFile::load() {
+            Ok(f) => f,
+            Err(e) => {
+                let msg = format!("failed to load config.toml: {e}");
+                report.diagnostics.push(ConfigDiagnostic {
+                    code: "CONFIG_LOAD_FAILED",
+                    level: "error",
+                    field: "config.toml".into(),
+                    message: msg.clone(),
+                });
+                report.valid = false;
+                report.warnings.push(msg);
+                // Still report defaults so the user sees what would be used.
+                for spec in KEY_SPECS {
+                    let kind = if spec.key == "VB_PORT" {
+                        DefaultKind::Derived
+                    } else {
+                        DefaultKind::Hardcoded
+                    };
+                    report.entries.push(ConfigEntry {
+                        key: spec.key,
+                        value: spec.default.to_string(),
+                        source: ConfigSource::Default {
+                            default: spec.default.to_string(),
+                            kind,
+                        },
+                    });
+                }
+                return Ok(report);
+            }
+        };
         report.config_file = file.as_ref().map(|_| crate::config_file::path());
         let lz = Layers {
             profile,
@@ -1194,12 +1313,20 @@ impl Config {
         for spec in KEY_SPECS {
             let (raw, source) = match lz.raw_with_source(spec.key) {
                 Some((v, s)) => (v, s),
-                None => (
-                    spec.default.to_string(),
-                    ConfigSource::Default {
-                        default: spec.default.to_string(),
-                    },
-                ),
+                None => {
+                    let kind = if spec.key == "VB_PORT" {
+                        DefaultKind::Derived
+                    } else {
+                        DefaultKind::Hardcoded
+                    };
+                    (
+                        spec.default.to_string(),
+                        ConfigSource::Default {
+                            default: spec.default.to_string(),
+                            kind,
+                        },
+                    )
+                }
             };
             // Apply the same scalar validators as the live path so a value
             // that would fail at runtime shows up here *with the same error
@@ -1218,12 +1345,24 @@ impl Config {
                         value: raw.clone(),
                         source,
                     });
-                    report.warnings.push(format!(
+                    let msg = format!(
                         "{}: {e} — this value would fail to parse at runtime",
                         spec.key
-                    ));
+                    );
+                    report.warnings.push(msg.clone());
+                    report.diagnostics.push(ConfigDiagnostic {
+                        code: "VALUE_PARSE_FAILED",
+                        level: "warning",
+                        field: spec.key.to_string(),
+                        message: msg,
+                    });
                 }
             }
+        }
+        // Compute digest from the resolved config so the report carries the
+        // same identity the runtime would use.
+        if let Ok(cfg) = Config::from_env_with_profile(profile) {
+            report.digest = Some(cfg.digest());
         }
         Ok(report)
     }
@@ -1537,7 +1676,7 @@ targets:
             .find(|e| e.key == "VB_REMOTE_HOST")
             .expect("entry exists");
         assert_eq!(e.value, "target-host");
-        assert!(matches!(&e.source, ConfigSource::Target { target } if target == "prod"));
+        assert!(matches!(&e.source, ConfigSource::Target { target, .. } if target == "prod"));
         // Clean up the VB_TARGETS_FILE we added — Drop on EnvGuard doesn't
         // know about it because it's not in the spec list.
         std::env::remove_var("VB_TARGETS_FILE");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1496,7 +1496,11 @@ enum SessionCmd {
     Current,
 
     /// Remove stale session files for daemons that are no longer running
-    Cleanup,
+    Cleanup {
+        /// Report what would be removed without deleting files
+        #[arg(long)]
+        dry_run: bool,
+    },
 
     /// Show SKILL and command history for a session
     History {
@@ -2773,14 +2777,16 @@ fn main() {
         Commands::Session(cmd) => match cmd {
             SessionCmd::List => commands::session::list(ctx.as_ref().unwrap(), format),
             SessionCmd::Show { id } => commands::session::show(ctx.as_ref().unwrap(), &id, format),
-            SessionCmd::Current => commands::session::current(),
-            SessionCmd::Cleanup => commands::session::cleanup(),
+            SessionCmd::Current => commands::session::current(ctx.as_ref().unwrap()),
+            SessionCmd::Cleanup { dry_run } => {
+                commands::session::cleanup(ctx.as_ref().unwrap(), dry_run)
+            }
             SessionCmd::History {
                 id,
                 skill,
                 cmd,
                 limit,
-            } => commands::session::history(&id, skill, cmd, limit),
+            } => commands::session::history(ctx.as_ref().unwrap(), &id, skill, cmd, limit),
             SessionCmd::Heartbeat { interval } => {
                 let hb = virtuoso_cli::session::SessionHeartbeat::new(interval);
                 hb.start();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -383,6 +383,47 @@ mod session_info_tests {
     use std::fs;
     use tempfile::TempDir;
 
+    fn make_config(
+        remote_host: Option<&str>,
+        remote_user: Option<&str>,
+        jump_host: Option<&str>,
+        jump_user: Option<&str>,
+    ) -> crate::config::Config {
+        crate::config::Config {
+            profile: None,
+            remote_host: remote_host.map(String::from),
+            remote_user: remote_user.map(String::from),
+            port: 65432,
+            port_explicit: true,
+            jump_host: jump_host.map(String::from),
+            jump_user: jump_user.map(String::from),
+            ssh_port: None,
+            ssh_key: None,
+            ssh_config: None,
+            ssh_backend: None,
+            disable_control_master: false,
+            timeout: 30,
+            read_timeout: 120,
+            keep_remote_files: false,
+            spectre_cmd: "spectre".into(),
+            spectre_args: vec![],
+            spectre_max_workers: 8,
+            ssh_max_sessions: 10,
+            ssh_max_bulk_sessions: 2,
+            ssh_reconnect_max_attempts: 8,
+            ssh_reconnect_max_delay: 30,
+            ssh_keepalive_interval: 30,
+            ssh_keepalive_failures: 3,
+            transport_shutdown_grace: 10,
+            cadence_cshrc: None,
+            spectre_bin: None,
+            roles: crate::config::RemoteRoles::default(),
+            transport_daemon_socket: None,
+            transport_daemon_token: None,
+            allow_cross_user_daemon: false,
+        }
+    }
+
     fn make_session(id: &str, port: u16) -> SessionInfo {
         SessionInfo {
             id: id.into(),
@@ -585,7 +626,9 @@ mod session_info_tests {
         fs::remove_file(dir.join(format!("{id}.json"))).ok();
         write_session(&dir, &make_session(&id, port));
 
-        let result = crate::commands::session::cleanup().unwrap();
+        let cfg = make_config(None, None, None, None);
+        let ctx = crate::context::CommandContext::new(cfg, None).unwrap();
+        let result = crate::commands::session::cleanup(&ctx, false).unwrap();
         let removed: Vec<String> = result["sessions"]
             .as_array()
             .unwrap()
@@ -614,7 +657,9 @@ mod session_info_tests {
         fs::remove_file(dir.join(format!("{id}.json"))).ok();
         write_session(&dir, &make_session(&id, port));
 
-        let result = crate::commands::session::cleanup().unwrap();
+        let cfg = make_config(None, None, None, None);
+        let ctx = crate::context::CommandContext::new(cfg, None).unwrap();
+        let result = crate::commands::session::cleanup(&ctx, false).unwrap();
         let removed: Vec<String> = result["sessions"]
             .as_array()
             .unwrap()
@@ -1535,6 +1580,42 @@ mod history_tests {
     use crate::history::{append_cmd, append_skill, history_dir, load_cmd, load_skill};
     use std::fs;
 
+    fn make_config() -> crate::config::Config {
+        crate::config::Config {
+            profile: None,
+            remote_host: None,
+            remote_user: None,
+            port: 65432,
+            port_explicit: true,
+            jump_host: None,
+            jump_user: None,
+            ssh_port: None,
+            ssh_key: None,
+            ssh_config: None,
+            ssh_backend: None,
+            disable_control_master: false,
+            timeout: 30,
+            read_timeout: 120,
+            keep_remote_files: false,
+            spectre_cmd: "spectre".into(),
+            spectre_args: vec![],
+            spectre_max_workers: 8,
+            ssh_max_sessions: 10,
+            ssh_max_bulk_sessions: 2,
+            ssh_reconnect_max_attempts: 8,
+            ssh_reconnect_max_delay: 30,
+            ssh_keepalive_interval: 30,
+            ssh_keepalive_failures: 3,
+            transport_shutdown_grace: 10,
+            cadence_cshrc: None,
+            spectre_bin: None,
+            roles: crate::config::RemoteRoles::default(),
+            transport_daemon_socket: None,
+            transport_daemon_token: None,
+            allow_cross_user_daemon: false,
+        }
+    }
+
     fn rm_skill(session_id: &str) {
         let _ = fs::remove_file(history_dir().join(format!("{session_id}.jsonl")));
     }
@@ -1697,7 +1778,9 @@ mod history_tests {
         append_skill(id, "car(list())", true, "nil");
         append_skill(id, "t", true, "t");
 
-        let result = crate::commands::session::history(id, false, false, 50).unwrap();
+        let cfg = make_config();
+        let ctx = crate::context::CommandContext::new(cfg, None).unwrap();
+        let result = crate::commands::session::history(&ctx, id, false, false, 50).unwrap();
         assert_eq!(result["status"], "success");
         assert_eq!(result["session"], id);
         assert!(result["skill"].is_array());
@@ -1717,7 +1800,9 @@ mod history_tests {
         rm_skill(id);
         append_skill(id, "t", true, "t");
 
-        let result = crate::commands::session::history(id, true, false, 50).unwrap();
+        let cfg = make_config();
+        let ctx = crate::context::CommandContext::new(cfg, None).unwrap();
+        let result = crate::commands::session::history(&ctx, id, true, false, 50).unwrap();
         assert!(!result["skill"].as_array().unwrap().is_empty());
         assert_eq!(
             result["cmd"].as_array().unwrap().len(),
@@ -1733,7 +1818,9 @@ mod history_tests {
         let session_id = "rt-hist-cmd-cmdonly-77777";
         append_cmd(&["vcli".to_string()], Some(session_id), 0);
 
-        let result = crate::commands::session::history(session_id, false, true, 50).unwrap();
+        let cfg = make_config();
+        let ctx = crate::context::CommandContext::new(cfg, None).unwrap();
+        let result = crate::commands::session::history(&ctx, session_id, false, true, 50).unwrap();
         assert_eq!(
             result["skill"].as_array().unwrap().len(),
             0,


### PR DESCRIPTION
## Summary

Two coupled P0-A identity-closure increments:

### 1. Session remaining commands migrate to CommandContext (`eec1106`)

Migrate `current`, `cleanup`, `history` from global-state reads to `&CommandContext`:

- **current()**: target mode only considers sessions matching the target endpoint; legacy preserves `is_alive()` behaviour; output includes `target`/`endpoint_match`
- **cleanup()**: accepts `--dry-run`; target mode only removes matching sessions, uses shared verification chain (`resolve_probe_endpoint`) for liveness, identity-skipped sessions preserved; output includes skipped list with reasons
- **history()**: verifies session endpoint ownership; mismatch surfaces as warning but does not block reading (history is local cache); output includes `target`/`endpoint_match`

### 2. Config-check contract gap closure (`0ea7157`)

Close all 7 gaps identified in review of #92:

**P1:**
1. `ConfigReport.digest: Option<String>` — set via `Config::digest()` when resolution succeeds
2. `build_report` never returns `Err` — failures become `ConfigDiagnostic` entries with `level="error"`, `valid=false`; JSON always valid, non-zero exit driven by `dry_run`
3. `report_ssh_key` desensitized (`***set***`/unset), same policy as `transport_daemon_token`

**P2:**
4. `ConfigSource::Target { target, file }` — carries actual `targets.yaml` path
5. `ConfigReport.targets_file: Option<PathBuf>` — set in target mode; `config_file` doc clarifies None means "not applicable"
6. `ConfigSource::Default { default, kind }` — `DefaultKind::{Hardcoded, Derived}`; port is Derived
7. `ConfigReport.valid: bool` + `diagnostics: Vec<ConfigDiagnostic>` — stable codes: `TARGET_NOT_FOUND`, `TARGETS_LOAD_FAILED`, `CONFIG_LOAD_FAILED`, `VALUE_PARSE_FAILED`, `LEGACY_ENV_PROFILE`

## Verification

- `cargo check --all-targets`: OK
- `cargo clippy --all-targets -- -D warnings`: OK
- `rustfmt --check`: OK
- `config::report_tests`: 9/9 pass
- `tests/config_check`: 6/6 pass
- `session_info_tests`: 10/10 pass
- `history_tests::session_history_*`: 3/3 pass