### PR TITLE
fix: sanitize secrets, validate config, and harden session cleanup

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,5 +1,5 @@
 use crate::config::{Config, ConfigReport, ConfigSource};
-use crate::error::Result;
+use crate::error::{Result, VirtuosoError};
 use crate::output::OutputFormat;
 use serde_json::{json, Value};
 
@@ -19,9 +19,13 @@ use serde_json::{json, Value};
 /// Implementation note: the report is built by [`Config::build_report`], which
 /// re-probes the same layered lookup the runtime uses. There is no separate
 /// "check" resolution path to drift out of sync with production behavior.
-pub fn check(format: OutputFormat, require_explicit: bool) -> Result<Value> {
+pub fn check(
+    format: OutputFormat,
+    require_explicit: bool,
+    pre_check: std::result::Result<(), &VirtuosoError>,
+) -> Result<Value> {
     let profile = Config::resolve_profile();
-    let report = Config::build_report(profile.as_deref())?;
+    let report = Config::build_report(profile.as_deref(), pre_check)?;
     let status = status_for(&report, require_explicit);
 
     let value = match format {

--- a/src/commands/session.rs
+++ b/src/commands/session.rs
@@ -675,16 +675,31 @@ pub fn cleanup(ctx: &CommandContext, dry_run: bool) -> Result<Value> {
         // breaking existing cleanup semantics for non-target invocations.
         //
         // Target mode: use the shared verification chain. A session is "dead"
-        // only if the probe was actually attempted and the port was unreachable.
-        // Identity-skipped sessions are preserved (they may be valid remote
-        // sessions that just can't be verified from this machine).
+        // only if we have DEFINITIVE evidence that the remote daemon is down.
+        // `forward_port_unreachable` does NOT qualify: the full tunnel chain
+        // passed (SSH process alive, identity verified, not reused) — only the
+        // local forward leg is unreachable. That could be a local firewall /
+        // forwarding issue while the remote daemon is still healthy. Deleting
+        // the cached session here would lose a recoverable entry. Preserve the
+        // file and report "cannot_verify" so the operator can investigate.
         let (is_dead, skip_reason) = if is_target {
             match resolve_probe_endpoint(ctx, s) {
                 Ok(_) => (false, None),
                 Err(skip) => {
-                    let dead = skip.reason == "forward_port_unreachable"
-                        || skip.reason == "local_port_unreachable";
-                    (dead, Some(skip.reason))
+                    let is_definitive_death = skip.reason == "local_port_unreachable";
+                    let reason: String = if is_definitive_death {
+                        skip.reason.into()
+                    } else if skip.reason == "forward_port_unreachable" {
+                        // Tunnel verified, local leg down — cannot confirm
+                        // remote death. Preserve, don't delete.
+                        "cannot_verify:forward_port_unreachable".into()
+                    } else {
+                        // Other skip reasons (no_tunnel, mismatch, etc.) —
+                        // session doesn't match this context OR tunnel state
+                        // is incomplete; preserve the cache.
+                        format!("cannot_verify:{}", skip.reason)
+                    };
+                    (is_definitive_death, Some(reason))
                 }
             }
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -503,6 +503,27 @@ fn report_allow_cross_user_daemon(cfg: &Config) -> String {
     cfg.allow_cross_user_daemon.to_string()
 }
 
+/// Sanitise a raw (string) config value for `vcli config check` output.
+///
+/// The legacy report path reads values as plain strings from env/file and
+/// never builds a `&Config`, so it cannot call the `display:` functions
+/// (which take `&Config`). This helper mirrors the policy of those functions
+/// without requiring a full `Config`: sensitive fields are replaced with
+/// `"***set***"` when non-empty, everything else is returned unchanged.
+///
+/// Keys covered here MUST stay in sync with the `display:` functions in
+/// [`KEY_SPECS`] that mask values — currently [`report_transport_daemon_token`]
+/// and [`report_ssh_key`].
+fn sanitize_raw_value(key: &str, raw: &str) -> String {
+    if raw.is_empty() {
+        return raw.to_string();
+    }
+    match key {
+        "VB_TRANSPORT_DAEMON_TOKEN" | "VB_SSH_KEY" => "***set***".to_string(),
+        _ => raw.to_string(),
+    }
+}
+
 // ----- Validators (mirror the runtime parsers in from_env_resolve) ----------
 
 fn v_text(_raw: &str) -> std::result::Result<(), String> {
@@ -1266,9 +1287,27 @@ impl Config {
             };
             let mut report = build_report_from_target(target, target_name, report);
             // Compute digest from the synthetic config so the report carries the
-            // same identity the runtime would use.
-            if let Ok(cfg) = Config::from_target(target, target_name) {
-                report.digest = Some(cfg.digest());
+            // same identity the runtime would use. If construction fails here
+            // the same error would block the live path — surface it as an
+            // error rather than returning a misleading valid=true + empty
+            // digest.
+            match Config::from_target(target, target_name) {
+                Ok(cfg) => report.digest = Some(cfg.digest()),
+                Err(e) => {
+                    let msg = format!(
+                        "resolved target '{}' failed to build a Config: {e} — \
+                         the same error would block the runtime",
+                        target_name
+                    );
+                    report.valid = false;
+                    report.warnings.push(msg.clone());
+                    report.diagnostics.push(ConfigDiagnostic {
+                        code: "TARGET_CONFIG_BUILD_FAILED",
+                        level: "error",
+                        field: target_name.clone(),
+                        message: msg,
+                    });
+                }
             }
             return Ok(report);
         }
@@ -1333,16 +1372,21 @@ impl Config {
             // message*. We surface parse failures as warnings rather than
             // aborting — the user is asking "what would happen?", not
             // "tunnel now".
+            //
+            // Sanitise sensitive values (tokens, key paths) before they reach
+            // JSON / table output. Returns e.g. "***set***" in place of the
+            // raw secret when the key is sensitive and the value is non-empty.
+            let display_value = sanitize_raw_value(spec.key, &raw);
             match (spec.validate)(&raw) {
                 Ok(()) => report.entries.push(ConfigEntry {
                     key: spec.key,
-                    value: raw.clone(),
+                    value: display_value,
                     source,
                 }),
                 Err(e) => {
                     report.entries.push(ConfigEntry {
                         key: spec.key,
-                        value: raw.clone(),
+                        value: display_value,
                         source,
                     });
                     let msg = format!(
@@ -1350,9 +1394,15 @@ impl Config {
                         spec.key
                     );
                     report.warnings.push(msg.clone());
+                    // A value that cannot be parsed is NOT a valid runtime
+                    // config — mark the report invalid so --format json carries
+                    // valid=false and the exit code is non-zero. Previously
+                    // this only produced a warning, so an invalid timeout etc.
+                    // slipped through as valid=true + exit 0.
+                    report.valid = false;
                     report.diagnostics.push(ConfigDiagnostic {
                         code: "VALUE_PARSE_FAILED",
-                        level: "warning",
+                        level: "error",
                         field: spec.key.to_string(),
                         message: msg,
                     });
@@ -1360,9 +1410,28 @@ impl Config {
             }
         }
         // Compute digest from the resolved config so the report carries the
-        // same identity the runtime would use.
-        if let Ok(cfg) = Config::from_env_with_profile(profile) {
-            report.digest = Some(cfg.digest());
+        // same identity the runtime would use. If this fails, the runtime
+        // would also refuse to start — the report must reflect that.
+        match Config::from_env_with_profile(profile) {
+            Ok(cfg) => report.digest = Some(cfg.digest()),
+            Err(e) => {
+                // Don't short-circuit: the loop above already traced every
+                // key. Record the failure and return the full report so the
+                // user sees both the per-field breakdown AND the fatal error.
+                let msg = format!(
+                    "failed to build Config from the merged resolution: {e} — \
+                     the runtime would refuse to start"
+                );
+                report.valid = false;
+                report.warnings.push(msg.clone());
+                report.diagnostics.push(ConfigDiagnostic {
+                    code: "CONFIG_BUILD_FAILED",
+                    level: "error",
+                    field: "config".into(),
+                    message: msg,
+                });
+                report.digest = None;
+            }
         }
         Ok(report)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::config_file::ConfigFile;
+use crate::config_file::{ConfigFile, FileLoc};
 use crate::error::{Result, VirtuosoError};
 use serde::Serialize;
 use std::env;
@@ -751,31 +751,21 @@ impl Layers<'_> {
             }
         }
         if let Some(file) = self.file {
-            // Probe whether the *profile section* itself owns the key, not
-            // whether `ConfigFile::get` returns a value. `get` falls through
-            // to global on a miss — if we trusted it, an absent profile key
-            // would be misattributed as FileProfile instead of FileGlobal.
-            let profile_owns = self
-                .profile
-                .is_some_and(|p| file.profile_section_has(key, p));
-            if profile_owns {
-                let v = file
-                    .get(key, self.profile)
-                    .expect("profile_section_has said the value is there");
-                return Some((
-                    v,
-                    ConfigSource::FileProfile {
+            // One walk, one truth. `get_with_loc` returns the value and the
+            // precise layer it was read from, so we never have to first probe
+            // with `profile_section_has` and read again with `get`. The two
+            // passes could disagree on which spelling matched, misattributing a
+            // global value to a profile section (and vice versa).
+            if let Some((v, loc)) = file.get_with_loc(key, self.profile) {
+                let source = match loc {
+                    FileLoc::Profile { .. } => ConfigSource::FileProfile {
                         file: crate::config_file::path(),
                     },
-                ));
-            }
-            if let Some(v) = file.get(key, None) {
-                return Some((
-                    v,
-                    ConfigSource::FileGlobal {
+                    FileLoc::Global { .. } => ConfigSource::FileGlobal {
                         file: crate::config_file::path(),
                     },
-                ));
+                };
+                return Some((v, source));
             }
         }
         None
@@ -841,6 +831,94 @@ impl Layers<'_> {
                 .as_str(),
             "1" | "true" | "yes" | "on"
         )
+    }
+
+    /// Resolve every field from these layers into a [`Config`].
+    ///
+    /// The field-by-field read logic here is IDENTICAL to the read logic in
+    /// `Config::from_env_resolve`. It lives on `Layers` so the legacy-mode
+    /// call site in `build_report` can reuse the SAME `Layers` (and therefore
+    /// the SAME `ConfigFile` snapshot) for both per-field provenance tracing
+    /// and digest construction — eliminating the redundant second
+    /// `ConfigFile::load()` that used to happening there.
+    ///
+    /// Target-mode must NOT use this path — see
+    /// [`Config::from_target`].
+    fn to_config(&self) -> Result<Config> {
+        let port: u16 = self.parsed_or("VB_PORT", Config::default_port())?;
+        let port_explicit = self.raw("VB_PORT").is_some();
+        if port == 0 {
+            return Err(VirtuosoError::Config(
+                "VB_PORT must be between 1 and 65535".into(),
+            ));
+        }
+        Ok(Config {
+            profile: self.profile.map(|s| s.to_string()),
+            remote_host: self.text("VB_REMOTE_HOST"),
+            remote_user: self.text("VB_REMOTE_USER"),
+            port,
+            port_explicit,
+            jump_host: self.text("VB_JUMP_HOST"),
+            jump_user: self.text("VB_JUMP_USER"),
+            ssh_port: self.parsed("VB_SSH_PORT")?,
+            ssh_key: self.text("VB_SSH_KEY"),
+            ssh_config: self.text("VB_SSH_CONFIG"),
+            ssh_backend: self.text("VB_SSH_BACKEND"),
+            disable_control_master: self.flag("VB_DISABLE_CONTROL_MASTER")?,
+            timeout: self.parsed_or("VB_TIMEOUT", 30)?,
+            read_timeout: self.parsed_or("VB_READ_TIMEOUT", 120)?,
+            keep_remote_files: self.flag("VB_KEEP_REMOTE_FILES")?,
+            spectre_cmd: self.text_or("VB_SPECTRE_CMD", "spectre"),
+            spectre_args: match self.text("VB_SPECTRE_ARGS") {
+                None => Vec::new(),
+                Some(v) => shlex::split(&v).ok_or_else(|| {
+                    VirtuosoError::Config(format!(
+                        "VB_SPECTRE_ARGS contains invalid shell syntax: {v}"
+                    ))
+                })?,
+            },
+            spectre_max_workers: self.parsed_or("VB_SPECTRE_MAX_WORKERS", 8)?,
+            ssh_max_sessions: self.parsed_or(
+                "VB_SSH_MAX_SESSIONS",
+                crate::transport::scheduler::SchedulerLimits::DEFAULT_TOTAL,
+            )?,
+            ssh_max_bulk_sessions: self.parsed_or(
+                "VB_SSH_MAX_BULK_SESSIONS",
+                crate::transport::scheduler::SchedulerLimits::DEFAULT_BULK,
+            )?,
+            ssh_reconnect_max_attempts: self.parsed_or(
+                "VB_SSH_RECONNECT_MAX_ATTEMPTS",
+                crate::transport::lifecycle::ReconnectPolicy::DEFAULT_MAX_ATTEMPTS,
+            )?,
+            ssh_reconnect_max_delay: self.parsed_or(
+                "VB_SSH_RECONNECT_MAX_DELAY",
+                crate::transport::lifecycle::ReconnectPolicy::DEFAULT_MAX_DELAY,
+            )?,
+            ssh_keepalive_interval: self.parsed_or(
+                "VB_SSH_KEEPALIVE_INTERVAL",
+                crate::transport::lifecycle::KeepalivePolicy::DEFAULT_INTERVAL,
+            )?,
+            ssh_keepalive_failures: self.parsed_or(
+                "VB_SSH_KEEPALIVE_FAILURES",
+                crate::transport::lifecycle::KeepalivePolicy::DEFAULT_FAILURES,
+            )?,
+            transport_shutdown_grace: self.parsed_or(
+                "VB_TRANSPORT_SHUTDOWN_GRACE",
+                crate::transport::lifecycle::ShutdownCoordinator::DEFAULT_GRACE,
+            )?,
+            cadence_cshrc: self.text("VB_CADENCE_CSHRC"),
+            spectre_bin: self.text("VB_SPECTRE_BIN"),
+            roles: RemoteRoles {
+                gui_host: self.text("VB_GUI_HOST"),
+                deploy_host: self.text("VB_DEPLOY_HOST"),
+                daemon_host: self.text("VB_DAEMON_HOST"),
+                spectre_host: self.text("VB_SPECTRE_HOST"),
+                scratch_root: self.text("VB_REMOTE_SCRATCH_ROOT"),
+            },
+            transport_daemon_socket: self.text("VB_TRANSPORT_DAEMON_SOCKET"),
+            transport_daemon_token: self.text("VB_TRANSPORT_DAEMON_TOKEN"),
+            allow_cross_user_daemon: self.flag_truthy("VB_ALLOW_CROSS_USER_DAEMON"),
+        })
     }
 }
 
@@ -975,93 +1053,16 @@ impl Config {
         // above returns before reaching here on purpose: a target's identity
         // comes from targets.yaml alone and must not be diluted by
         // config.toml.
+        //
+        // `Layers::to_config` centralises the field-by-field read so that
+        // `build_report` and `from_env_resolve` share ONE code path — any
+        // change to a field's resolution rule only needs to live in ONE place.
         let file = ConfigFile::load()?;
         let lz = Layers {
             profile,
             file: file.as_ref(),
         };
-
-        let port: u16 = lz.parsed_or("VB_PORT", Self::default_port())?;
-        let port_explicit = lz.raw("VB_PORT").is_some();
-
-        if port == 0 {
-            return Err(VirtuosoError::Config(
-                "VB_PORT must be between 1 and 65535".into(),
-            ));
-        }
-
-        let sessions_dir = Some(crate::runtime_paths::cache_subdir(&["sessions"]));
-        if let Some(ref d) = sessions_dir {
-            tracing::debug!("session dir: {}", d.display());
-        }
-
-        Ok(Self {
-            profile: profile.map(|s| s.to_string()),
-            remote_host: lz.text("VB_REMOTE_HOST"),
-            remote_user: lz.text("VB_REMOTE_USER"),
-            port,
-            port_explicit,
-            jump_host: lz.text("VB_JUMP_HOST"),
-            jump_user: lz.text("VB_JUMP_USER"),
-            ssh_port: lz.parsed("VB_SSH_PORT")?,
-            ssh_key: lz.text("VB_SSH_KEY"),
-            ssh_config: lz.text("VB_SSH_CONFIG"),
-            ssh_backend: lz.text("VB_SSH_BACKEND"),
-            disable_control_master: lz.flag("VB_DISABLE_CONTROL_MASTER")?,
-            timeout: lz.parsed_or("VB_TIMEOUT", 30)?,
-            read_timeout: lz.parsed_or("VB_READ_TIMEOUT", 120)?,
-            keep_remote_files: lz.flag("VB_KEEP_REMOTE_FILES")?,
-            spectre_cmd: lz.text_or("VB_SPECTRE_CMD", "spectre"),
-            spectre_args: match lz.text("VB_SPECTRE_ARGS") {
-                None => Vec::new(),
-                Some(v) => shlex::split(&v).ok_or_else(|| {
-                    VirtuosoError::Config(format!(
-                        "VB_SPECTRE_ARGS contains invalid shell syntax: {v}"
-                    ))
-                })?,
-            },
-            spectre_max_workers: lz.parsed_or("VB_SPECTRE_MAX_WORKERS", 8)?,
-            ssh_max_sessions: lz.parsed_or(
-                "VB_SSH_MAX_SESSIONS",
-                crate::transport::scheduler::SchedulerLimits::DEFAULT_TOTAL,
-            )?,
-            ssh_max_bulk_sessions: lz.parsed_or(
-                "VB_SSH_MAX_BULK_SESSIONS",
-                crate::transport::scheduler::SchedulerLimits::DEFAULT_BULK,
-            )?,
-            ssh_reconnect_max_attempts: lz.parsed_or(
-                "VB_SSH_RECONNECT_MAX_ATTEMPTS",
-                crate::transport::lifecycle::ReconnectPolicy::DEFAULT_MAX_ATTEMPTS,
-            )?,
-            ssh_reconnect_max_delay: lz.parsed_or(
-                "VB_SSH_RECONNECT_MAX_DELAY",
-                crate::transport::lifecycle::ReconnectPolicy::DEFAULT_MAX_DELAY,
-            )?,
-            ssh_keepalive_interval: lz.parsed_or(
-                "VB_SSH_KEEPALIVE_INTERVAL",
-                crate::transport::lifecycle::KeepalivePolicy::DEFAULT_INTERVAL,
-            )?,
-            ssh_keepalive_failures: lz.parsed_or(
-                "VB_SSH_KEEPALIVE_FAILURES",
-                crate::transport::lifecycle::KeepalivePolicy::DEFAULT_FAILURES,
-            )?,
-            transport_shutdown_grace: lz.parsed_or(
-                "VB_TRANSPORT_SHUTDOWN_GRACE",
-                crate::transport::lifecycle::ShutdownCoordinator::DEFAULT_GRACE,
-            )?,
-            cadence_cshrc: lz.text("VB_CADENCE_CSHRC"),
-            spectre_bin: lz.text("VB_SPECTRE_BIN"),
-            roles: RemoteRoles {
-                gui_host: lz.text("VB_GUI_HOST"),
-                deploy_host: lz.text("VB_DEPLOY_HOST"),
-                daemon_host: lz.text("VB_DAEMON_HOST"),
-                spectre_host: lz.text("VB_SPECTRE_HOST"),
-                scratch_root: lz.text("VB_REMOTE_SCRATCH_ROOT"),
-            },
-            transport_daemon_socket: lz.text("VB_TRANSPORT_DAEMON_SOCKET"),
-            transport_daemon_token: lz.text("VB_TRANSPORT_DAEMON_TOKEN"),
-            allow_cross_user_daemon: lz.flag_truthy("VB_ALLOW_CROSS_USER_DAEMON"),
-        })
+        lz.to_config()
     }
 
     /// Derive a stable default port from the current username.
@@ -1409,15 +1410,16 @@ impl Config {
                 }
             }
         }
-        // Compute digest from the resolved config so the report carries the
-        // same identity the runtime would use. If this fails, the runtime
-        // would also refuse to start — the report must reflect that.
-        match Config::from_env_with_profile(profile) {
+        // Compute digest from the SAME `Layers` (and therefore the SAME
+        // `ConfigFile` snapshot) the per-field loop just traced. This is the
+        // single-snapshot rule in action: `build_report` does ONE
+        // `ConfigFile::load()` and uses its result for both provenance and
+        // identity. Previously this called `Config::from_env_with_profile()`
+        // which re-loaded `config.toml` — two snapshots, double I/O, and a
+        // window where the file could change between the two passes.
+        match lz.to_config() {
             Ok(cfg) => report.digest = Some(cfg.digest()),
             Err(e) => {
-                // Don't short-circuit: the loop above already traced every
-                // key. Record the failure and return the full report so the
-                // user sees both the per-field breakdown AND the fatal error.
                 let msg = format!(
                     "failed to build Config from the merged resolution: {e} — \
                      the runtime would refuse to start"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1195,7 +1195,17 @@ impl Config {
     /// [`ConfigDiagnostic`] entries with `level = "error"` and `valid = false`
     /// so `vcli config check --format json` always produces a valid document
     /// (with a non-zero exit code driven by the caller).
-    pub fn build_report(profile: Option<&str>) -> Result<ConfigReport> {
+    ///
+    /// `pre_check` carries an earlier selection error (e.g. active_target not
+    /// found, corrupt targets.yaml) WITHOUT aborting the report. When
+    /// `Err`, the report is marked `valid = false` and carries an
+    /// `ILLEGAL_CONFIG` diagnostic describing the selection failure. The rest
+    /// of the report is still generated so the user sees BOTH the selection
+    /// problem and whatever config could be read.
+    pub fn build_report(
+        profile: Option<&str>,
+        pre_check: std::result::Result<(), &VirtuosoError>,
+    ) -> Result<ConfigReport> {
         let mut report = ConfigReport {
             profile: profile.map(|s| s.to_string()),
             active_target: None,
@@ -1213,6 +1223,22 @@ impl Config {
             valid: true,
             digest: None,
         };
+
+        // Pre-check: selection/resolve failures detected before we got here.
+        // Mark invalid, emit a diagnostic, but KEEP going — seeing the
+        // selection error alongside whatever config we *can* read is more
+        // useful than bailing out.
+        if let Err(e) = pre_check {
+            report.valid = false;
+            let msg = format!("config selection failed: {e}");
+            report.warnings.push(msg.clone());
+            report.diagnostics.push(ConfigDiagnostic {
+                code: "ILLEGAL_CONFIG",
+                level: "error",
+                field: "selection".into(),
+                message: msg,
+            });
+        }
 
         // Active target detection — mirrors from_env_resolve's honor_vb_target
         // branch. We never *consume* it here; we only report whether one is
@@ -1581,7 +1607,7 @@ mod report_tests {
         let _env = EnvGuard::new(&["VB_REMOTE_HOST", "VB_TIMEOUT"]);
         let (_tmp, prev) = isolate_config_dir();
         let _restore = ConfigDirGuard(prev);
-        let report = Config::build_report(None).expect("build_report");
+        let report = Config::build_report(None, Ok(())).expect("build_report");
         let remote_host = report
             .entries
             .iter()
@@ -1606,7 +1632,7 @@ mod report_tests {
         let (_tmp, prev) = isolate_config_dir();
         let _restore = ConfigDirGuard(prev);
         std::env::set_var("VB_REMOTE_HOST", "eda-from-env");
-        let report = Config::build_report(None).expect("build_report");
+        let report = Config::build_report(None, Ok(())).expect("build_report");
         let e = report
             .entries
             .iter()
@@ -1627,7 +1653,7 @@ mod report_tests {
         let _restore = ConfigDirGuard(prev);
         std::env::set_var("VB_REMOTE_HOST", "global-host");
         std::env::set_var("VB_REMOTE_HOST_prod", "profile-host");
-        let report = Config::build_report(Some("prod")).expect("build_report");
+        let report = Config::build_report(Some("prod"), Ok(())).expect("build_report");
         let e = report
             .entries
             .iter()
@@ -1655,7 +1681,7 @@ mod report_tests {
             r#"remote_host = "eda-from-file""#,
         )
         .expect("write config");
-        let report = Config::build_report(None).expect("build_report");
+        let report = Config::build_report(None, Ok(())).expect("build_report");
         let e = report
             .entries
             .iter()
@@ -1682,7 +1708,7 @@ remote_host = "eda-prod"
 "#,
         )
         .expect("write config");
-        let report = Config::build_report(Some("prod")).expect("build_report");
+        let report = Config::build_report(Some("prod"), Ok(())).expect("build_report");
         let e = report
             .entries
             .iter()
@@ -1699,7 +1725,7 @@ remote_host = "eda-prod"
         let (_tmp, prev) = isolate_config_dir();
         let _restore = ConfigDirGuard(prev);
         std::env::set_var("VB_TIMEOUT", "not-a-number");
-        let report = Config::build_report(None).expect("build_report");
+        let report = Config::build_report(None, Ok(())).expect("build_report");
         let e = report
             .entries
             .iter()
@@ -1739,7 +1765,7 @@ targets:
         // Manually invoking build_report here is tricky because the active
         // target is detected via VB_TARGET but the target loader uses
         // VB_TARGETS_FILE — we still need to guard that variable too.
-        let report = Config::build_report(None).expect("build_report");
+        let report = Config::build_report(None, Ok(())).expect("build_report");
         assert_eq!(report.active_target.as_deref(), Some("prod"));
         let e = report
             .entries
@@ -1772,7 +1798,7 @@ targets:
         // Force a fresh config dir so the file lookup is consistent.
         let (_cfg, prev_cfg) = isolate_config_dir();
         let _restore = ConfigDirGuard(prev_cfg);
-        let report = Config::build_report(None).expect("build_report");
+        let report = Config::build_report(None, Ok(())).expect("build_report");
         match prev_home {
             Some(v) => std::env::set_var("HOME", v),
             None => std::env::remove_var("HOME"),
@@ -1798,7 +1824,28 @@ targets:
         for k in KEY_SPECS.iter().map(|s| s.key) {
             std::env::set_var(k, "x");
         }
-        let report = Config::build_report(None).expect("build_report");
+        let report = Config::build_report(None, Ok(())).expect("build_report");
         assert!(report.all_explicit(), "every entry must be non-default");
+    }
+
+    #[test]
+    fn report_pre_check_error_marks_invalid_with_diagnostic() {
+        let err = VirtuosoError::Config("active_target 'nope' not found".into());
+        let report = Config::build_report(None, Err(&err)).expect("build_report");
+        assert!(!report.valid, "pre_check error must flip valid to false");
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|d| d.code == "ILLEGAL_CONFIG"),
+            "must emit an ILLEGAL_CONFIG diagnostic"
+        );
+        assert!(
+            report
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains("nope")),
+            "diagnostic message must surface the underlying failure"
+        );
     }
 }

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -216,26 +216,10 @@ impl ConfigFile {
     /// the resolution layer, or the friendly file name (`remote_host`) passed by
     /// the TUI. Both spellings are accepted so a hand-edited file is robust.
     pub fn get(&self, key: &str, profile: Option<&str>) -> Option<String> {
-        // Accept the value under either spelling: the friendly file key
-        // (`remote_host`, written by init/TUI) and the upper-case env-var form
-        // (`VB_REMOTE_HOST`, written by a buggy early build). This makes the
-        // lookup symmetric — a query in either style finds a file written in
-        // either style. Both candidates are derived from the friendly key so an
-        // already-upper-case query is not double-prefixed (`VB_VB_…`).
-        let friendly = file_key(key);
-        let env = env_var_for(&friendly);
-        let candidates = [friendly.as_str(), env.as_str()];
-        for candidate in candidates {
-            if let Some(p) = profile {
-                if let Some(v) = self.profiles.get(p).and_then(|s| s.get(candidate)) {
-                    return Some(v.as_text());
-                }
-            }
-            if let Some(v) = self.global.get(candidate) {
-                return Some(v.as_text());
-            }
-        }
-        None
+        // Layer-first, then key-spelling — same precedence as `get_with_loc`.
+        // Keep the two in sync by delegating; any change to lookup order must
+        // live in ONE place.
+        self.get_with_loc(key, profile).map(|(v, _)| v)
     }
 
     /// Like [`ConfigFile::get`], but also reports **where** the key was found so
@@ -260,9 +244,16 @@ impl ConfigFile {
         let friendly = file_key(key);
         let env = env_var_for(&friendly);
         let candidates = [friendly.as_str(), env.as_str()];
-        for candidate in candidates {
-            if let Some(p) = profile {
-                if let Some(section) = self.profiles.get(p) {
+
+        // Layer-first, then key-spelling. Within a layer we try every
+        // candidate key before falling through to the next layer — otherwise
+        // `timeout` in `[global]` would shadow `VB_TIMEOUT` in
+        // `[profile.<name>]` even though the latter is the higher-precedence
+        // layer. The correct order is: ALL profile candidates, THEN all
+        // global candidates.
+        if let Some(p) = profile {
+            if let Some(section) = self.profiles.get(p) {
+                for candidate in candidates {
                     if let Some(v) = section.get(candidate) {
                         return Some((
                             v.as_text(),
@@ -274,6 +265,8 @@ impl ConfigFile {
                     }
                 }
             }
+        }
+        for candidate in candidates {
             if let Some(v) = self.global.get(candidate) {
                 return Some((
                     v.as_text(),

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -113,6 +113,21 @@ impl Scalar {
     }
 }
 
+/// Where inside `config.toml` a key was actually resolved.
+///
+/// Returned by [`crate::config_file::ConfigFile::get_with_loc`] so the caller
+/// can distinguish "value came from a `[profile.<name>]` section" from "value
+/// fell through to the global section" in a single lookup.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum FileLoc {
+    /// Hit a `[profile.<name>]` section. `actual_key` is the real TOML key
+    /// (friendly or upper-case spelling) that matched.
+    Profile { profile: String, actual_key: String },
+    /// Hit the top-level global section. `actual_key` is the real TOML key
+    /// that matched.
+    Global { actual_key: String },
+}
+
 /// A parsed `config.toml`.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ConfigFile {
@@ -223,6 +238,54 @@ impl ConfigFile {
         None
     }
 
+    /// Like [`ConfigFile::get`], but also reports **where** the key was found so
+    /// callers can attribute the value to a precise layer in a single lookup.
+    ///
+    /// Returns `Some((value, loc))` where `loc` records the actual section hit —
+    /// `FileLoc::Profile { profile }` if the value came from a
+    /// `[profile.<name>]` section, or `FileLoc::Global` if it fell through to
+    /// the top-level `[global]` section.
+    ///
+    /// This consolidates what used to be two separate passes:
+    /// `profile_section_has` (probe) followed by `get` (read). The returns from
+    /// those two passes could disagree on which key matched, which is how a
+    /// `vbSshKey` in the global section used to be misattributed as coming from
+    /// a `[profile.<name>]` section that only had `VB_SSH_KEY`. A single walk
+    /// sees one truth.
+    pub(crate) fn get_with_loc(
+        &self,
+        key: &str,
+        profile: Option<&str>,
+    ) -> Option<(String, FileLoc)> {
+        let friendly = file_key(key);
+        let env = env_var_for(&friendly);
+        let candidates = [friendly.as_str(), env.as_str()];
+        for candidate in candidates {
+            if let Some(p) = profile {
+                if let Some(section) = self.profiles.get(p) {
+                    if let Some(v) = section.get(candidate) {
+                        return Some((
+                            v.as_text(),
+                            FileLoc::Profile {
+                                profile: p.to_string(),
+                                actual_key: candidate.to_string(),
+                            },
+                        ));
+                    }
+                }
+            }
+            if let Some(v) = self.global.get(candidate) {
+                return Some((
+                    v.as_text(),
+                    FileLoc::Global {
+                        actual_key: candidate.to_string(),
+                    },
+                ));
+            }
+        }
+        None
+    }
+
     /// Whether the key is present in the file — the `[profile.<name>]` section
     /// when `profile` is given, otherwise the global section. Used by the TUI to
     /// show whether a value comes from the file (and is therefore something the
@@ -249,22 +312,6 @@ impl ConfigFile {
             }
         }
         false
-    }
-
-    /// Whether the key is present in **only** the named profile section.
-    ///
-    /// `has(key, Some(profile))` falls through to the global section when the
-    /// profile section lacks the key — the behaviour you want when *reading*,
-    /// but the wrong question when you need to attribute a value to its actual
-    /// layer for `vcli config check`. The report uses this accessor to decide
-    /// between [`crate::config::ConfigSource::FileProfile`] and `FileGlobal`.
-    #[allow(dead_code)]
-    pub(crate) fn profile_section_has(&self, key: &str, profile: &str) -> bool {
-        let friendly = file_key(key);
-        let env = env_var_for(&friendly);
-        self.profiles
-            .get(profile)
-            .is_some_and(|section| section.contains_key(&friendly) || section.contains_key(&env))
     }
 
     /// Set a key in the global section, or in `[profile.<name>]`.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1790,7 +1790,10 @@ fn dispatch_config(
 ) -> error::Result<serde_json::Value> {
     match cmd {
         ConfigCmd::Check { require_explicit } => {
-            let pre_check = pre_check.as_ref().map(|e| Err(e)).unwrap_or(Ok(()));
+            let pre_check = match pre_check.as_ref() {
+                Some(e) => Err(e),
+                None => Ok(()),
+            };
             commands::config::check(format, require_explicit, pre_check)
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2635,72 +2635,76 @@ fn main() {
         Commands::Target(_) | Commands::Profile(_) | Commands::Init { .. }
     );
     let ctx: Option<crate::context::CommandContext> = if needs_config {
+        // Resolve the selection FIRST so the env-var bridge can be set.
+        // For Config commands, a selection failure must NOT exit — otherwise
+        // a broken active_target or corrupt targets.yaml would block
+        // diagnostics. We let build_report() surface the error as JSON.
         let selection = match resolve_selection(cli.target.as_deref(), cli.profile.as_deref()) {
-            Ok(s) => s,
-            Err(e) => {
-                eprintln!("Error: {e}");
-                std::process::exit(exit_codes::USAGE_ERROR);
-            }
-        };
-        match &selection {
-            Selection::CliTarget(name) => {
-                // Existence is validated below by resolve_from_selection.
-                std::env::set_var("VB_TARGET", name);
-            }
-            Selection::ActiveTarget(name) => {
-                // resolve_selection already verified the target exists.
-                std::env::set_var("VB_TARGET", name);
-            }
-            Selection::EnvTarget(_) => {
-                // Already in the environment; Config::from_env() picks it up.
-            }
-            Selection::CliProfile(profile) => {
-                // An explicit profile beats a stale ambient VB_TARGET: clear the
-                // bridge variable so legacy Config::from_env() stays in sync.
-                std::env::remove_var("VB_TARGET");
-                std::env::set_var("VB_PROFILE", profile);
-            }
-            Selection::LegacyEnv => {
-                // No target selected; clear any stale bridge variable so a
-                // leftover VB_TARGET cannot hijack legacy env resolution.
-                std::env::remove_var("VB_TARGET");
-            }
-        }
-        // P0-A: single immutable Config for this invocation. Migrated commands
-        // receive it through CommandContext and must not re-read env.
-        //
-        // For `Commands::Config` (i.e. `vcli config check`), resolve errors are
-        // DEFERRED — `build_report()` reports them as JSON diagnostics with
-        // valid=false. Otherwise `--target nonexistent config check` (or any
-        // invalid-but-diagnosable config) would exit with a stderr message
-        // BEFORE the report could be emitted, hiding the structured payload.
-        let resolved = match resolve_from_selection(selection) {
-            Ok(r) => Some(r),
+            Ok(s) => Some(s),
             Err(e) => {
                 if matches!(cli.command, Commands::Config(_)) {
                     None
                 } else {
                     eprintln!("Error: {e}");
-                    std::process::exit(match e {
-                        crate::error::VirtuosoError::NotFound(_) => exit_codes::NOT_FOUND,
-                        _ => exit_codes::USAGE_ERROR,
-                    });
+                    std::process::exit(exit_codes::USAGE_ERROR);
                 }
             }
         };
-        match resolved {
-            Some(resolved) => match crate::context::CommandContext::from_resolved(&resolved) {
-                Ok(c) => Some(c),
+
+        if let Some(selection) = selection {
+            match &selection {
+                Selection::CliTarget(name) => {
+                    // Existence validated below by resolve_from_selection.
+                    std::env::set_var("VB_TARGET", name);
+                }
+                Selection::ActiveTarget(name) => {
+                    std::env::set_var("VB_TARGET", name);
+                }
+                Selection::EnvTarget(_) => {}
+                Selection::CliProfile(profile) => {
+                    std::env::remove_var("VB_TARGET");
+                    std::env::set_var("VB_PROFILE", profile);
+                }
+                Selection::LegacyEnv => {
+                    std::env::remove_var("VB_TARGET");
+                }
+            }
+
+            // P0-A: single immutable Config for this invocation. Migrated
+            // commands receive it via CommandContext and must not re-read env.
+            //
+            // Config commands defer resolve errors to build_report so the
+            // structured JSON payload is always emitted — never a stderr exit.
+            let resolved = match resolve_from_selection(selection) {
+                Ok(r) => Some(r),
                 Err(e) => {
                     if matches!(cli.command, Commands::Config(_)) {
                         None
                     } else {
                         eprintln!("Error: {e}");
-                        std::process::exit(exit_codes::USAGE_ERROR);
+                        std::process::exit(match e {
+                            crate::error::VirtuosoError::NotFound(_) => exit_codes::NOT_FOUND,
+                            _ => exit_codes::USAGE_ERROR,
+                        });
                     }
                 }
-            },
-            None => None,
+            };
+            match resolved {
+                Some(resolved) => match crate::context::CommandContext::from_resolved(&resolved) {
+                    Ok(c) => Some(c),
+                    Err(e) => {
+                        if matches!(cli.command, Commands::Config(_)) {
+                            None
+                        } else {
+                            eprintln!("Error: {e}");
+                            std::process::exit(exit_codes::USAGE_ERROR);
+                        }
+                    }
+                },
+                None => None,
+            }
+        } else {
+            None
         }
     } else {
         None

--- a/src/main.rs
+++ b/src/main.rs
@@ -2623,14 +2623,16 @@ fn main() {
     // VB_TARGET/VB_PROFILE bridge — set from the SAME single selection to keep
     // every path consistent until their migration lands.
     //
-    // Config-management commands (target/profile/init) must keep working even
-    // when the current active target is stale or missing — they do not need a
-    // connection target, so they skip the whole resolution entirely. Only
-    // connection commands perform full selection + resolve.
+    // Target/profile/init management commands skip connection-target
+    // resolution — they manipulate targets/profiles rather than connect
+    // through them. `Config` (i.e. `config check`) is intentionally NOT
+    // excluded: it must report the config that the selected target/profile
+    // would produce, so `--target prod config check` diagnoses the prod
+    // target's settings.
     use crate::target::resolve::{resolve_from_selection, resolve_selection, Selection};
     let needs_config = !matches!(
         &cli.command,
-        Commands::Target(_) | Commands::Profile(_) | Commands::Init { .. } | Commands::Config(_)
+        Commands::Target(_) | Commands::Profile(_) | Commands::Init { .. }
     );
     let ctx: Option<crate::context::CommandContext> = if needs_config {
         let selection = match resolve_selection(cli.target.as_deref(), cli.profile.as_deref()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1783,9 +1783,16 @@ fn dispatch_tunnel(
     }
 }
 
-fn dispatch_config(cmd: ConfigCmd, format: OutputFormat) -> error::Result<serde_json::Value> {
+fn dispatch_config(
+    cmd: ConfigCmd,
+    format: OutputFormat,
+    pre_check: Option<error::VirtuosoError>,
+) -> error::Result<serde_json::Value> {
     match cmd {
-        ConfigCmd::Check { require_explicit } => commands::config::check(format, require_explicit),
+        ConfigCmd::Check { require_explicit } => {
+            let pre_check = pre_check.as_ref().map(|e| Err(e)).unwrap_or(Ok(()));
+            commands::config::check(format, require_explicit, pre_check)
+        }
     }
 }
 
@@ -2634,15 +2641,21 @@ fn main() {
         &cli.command,
         Commands::Target(_) | Commands::Profile(_) | Commands::Init { .. }
     );
+    // Pre-check error captured during selection/resolve so Config commands
+    // can surface it in the structured report (valid=false + ILLEGAL_CONFIG
+    // diagnostic) without aborting. Non-Config commands already exited above.
+    let mut pre_check: Option<error::VirtuosoError> = None;
     let ctx: Option<crate::context::CommandContext> = if needs_config {
         // Resolve the selection FIRST so the env-var bridge can be set.
         // For Config commands, a selection failure must NOT exit — otherwise
         // a broken active_target or corrupt targets.yaml would block
-        // diagnostics. We let build_report() surface the error as JSON.
+        // diagnostics. We capture the error and let build_report() surface
+        // it as JSON.
         let selection = match resolve_selection(cli.target.as_deref(), cli.profile.as_deref()) {
             Ok(s) => Some(s),
             Err(e) => {
                 if matches!(cli.command, Commands::Config(_)) {
+                    pre_check = Some(e);
                     None
                 } else {
                     eprintln!("Error: {e}");
@@ -2679,6 +2692,9 @@ fn main() {
                 Ok(r) => Some(r),
                 Err(e) => {
                     if matches!(cli.command, Commands::Config(_)) {
+                        if pre_check.is_none() {
+                            pre_check = Some(e);
+                        }
                         None
                     } else {
                         eprintln!("Error: {e}");
@@ -2694,6 +2710,9 @@ fn main() {
                     Ok(c) => Some(c),
                     Err(e) => {
                         if matches!(cli.command, Commands::Config(_)) {
+                            if pre_check.is_none() {
+                                pre_check = Some(e);
+                            }
                             None
                         } else {
                             eprintln!("Error: {e}");
@@ -2759,7 +2778,7 @@ fn main() {
 
     let result = match cli.command {
         Commands::Init { if_not_exists } => commands::init::run(if_not_exists),
-        Commands::Config(cmd) => dispatch_config(cmd, format),
+        Commands::Config(cmd) => dispatch_config(cmd, format, pre_check),
         Commands::Target(cmd) => dispatch_target(cmd, format),
         // Compiled only with `native-ssh`; other builds have no such subcommand
         // at all, so there is nothing to dispatch. `run_with` blocks forever

--- a/src/main.rs
+++ b/src/main.rs
@@ -2668,22 +2668,39 @@ fn main() {
         }
         // P0-A: single immutable Config for this invocation. Migrated commands
         // receive it through CommandContext and must not re-read env.
+        //
+        // For `Commands::Config` (i.e. `vcli config check`), resolve errors are
+        // DEFERRED — `build_report()` reports them as JSON diagnostics with
+        // valid=false. Otherwise `--target nonexistent config check` (or any
+        // invalid-but-diagnosable config) would exit with a stderr message
+        // BEFORE the report could be emitted, hiding the structured payload.
         let resolved = match resolve_from_selection(selection) {
-            Ok(r) => r,
+            Ok(r) => Some(r),
             Err(e) => {
-                eprintln!("Error: {e}");
-                std::process::exit(match e {
-                    crate::error::VirtuosoError::NotFound(_) => exit_codes::NOT_FOUND,
-                    _ => exit_codes::USAGE_ERROR,
-                });
+                if matches!(cli.command, Commands::Config(_)) {
+                    None
+                } else {
+                    eprintln!("Error: {e}");
+                    std::process::exit(match e {
+                        crate::error::VirtuosoError::NotFound(_) => exit_codes::NOT_FOUND,
+                        _ => exit_codes::USAGE_ERROR,
+                    });
+                }
             }
         };
-        match crate::context::CommandContext::from_resolved(&resolved) {
-            Ok(c) => Some(c),
-            Err(e) => {
-                eprintln!("Error: {e}");
-                std::process::exit(exit_codes::USAGE_ERROR);
-            }
+        match resolved {
+            Some(resolved) => match crate::context::CommandContext::from_resolved(&resolved) {
+                Ok(c) => Some(c),
+                Err(e) => {
+                    if matches!(cli.command, Commands::Config(_)) {
+                        None
+                    } else {
+                        eprintln!("Error: {e}");
+                        std::process::exit(exit_codes::USAGE_ERROR);
+                    }
+                }
+            },
+            None => None,
         }
     } else {
         None

--- a/tests/config_check.rs
+++ b/tests/config_check.rs
@@ -81,7 +81,7 @@ fn check_json_shape_lists_every_known_key_with_a_source() {
     let (_tmp, prev) = isolate_config_dir();
     let _restore = ConfigDirRestore(prev);
 
-    let report = virtuoso_cli::config::Config::build_report(None).expect("build_report");
+    let report = virtuoso_cli::config::Config::build_report(None, Ok(())).expect("build_report");
 
     // Every entry must have a non-empty key, a string value, a layer
     // discriminator, and a label. JSON-shape contract for downstream tools.
@@ -124,7 +124,7 @@ fn check_env_layer_wins_over_file_layer() {
     // env var beats file even when file is set:
     std::env::set_var("VB_REMOTE_HOST", "eda-from-env");
 
-    let report = virtuoso_cli::config::Config::build_report(None).expect("build_report");
+    let report = virtuoso_cli::config::Config::build_report(None, Ok(())).expect("build_report");
     let e = report
         .entries
         .iter()
@@ -148,7 +148,7 @@ fn check_file_layer_wins_over_default() {
     std::fs::create_dir_all(tmp.path().join("vcli")).expect("mkdir vcli");
     std::fs::write(tmp.path().join("vcli/config.toml"), r#"timeout = "45""#).expect("write");
 
-    let report = virtuoso_cli::config::Config::build_report(None).expect("build_report");
+    let report = virtuoso_cli::config::Config::build_report(None, Ok(())).expect("build_report");
     let e = report
         .entries
         .iter()
@@ -173,7 +173,7 @@ fn check_malformed_value_becomes_warning_not_error() {
     let _restore = ConfigDirRestore(prev);
     std::env::set_var("VB_PORT", "not-a-number");
 
-    let report = virtuoso_cli::config::Config::build_report(None).expect("build_report");
+    let report = virtuoso_cli::config::Config::build_report(None, Ok(())).expect("build_report");
     let e = report
         .entries
         .iter()
@@ -217,7 +217,7 @@ timeout = "60"
     )
     .expect("write");
 
-    let report = virtuoso_cli::config::Config::build_report(Some("prod")).expect("build_report");
+    let report = virtuoso_cli::config::Config::build_report(Some("prod"), Ok(())).expect("build_report");
     let e = report
         .entries
         .iter()
@@ -238,7 +238,7 @@ fn check_default_source_is_attributed_when_no_other_layer_fires() {
     let (_tmp, prev) = isolate_config_dir();
     let _restore = ConfigDirRestore(prev);
     // No env, no file — VB_TIMEOUT must trace back to the constant default.
-    let report = virtuoso_cli::config::Config::build_report(None).expect("build_report");
+    let report = virtuoso_cli::config::Config::build_report(None, Ok(())).expect("build_report");
     let e = report
         .entries
         .iter()

--- a/tests/config_check.rs
+++ b/tests/config_check.rs
@@ -217,7 +217,8 @@ timeout = "60"
     )
     .expect("write");
 
-    let report = virtuoso_cli::config::Config::build_report(Some("prod"), Ok(())).expect("build_report");
+    let report =
+        virtuoso_cli::config::Config::build_report(Some("prod"), Ok(())).expect("build_report");
     let e = report
         .entries
         .iter()

--- a/tests/config_check_cli.rs
+++ b/tests/config_check_cli.rs
@@ -1,0 +1,194 @@
+//! End-to-end CLI integration tests for `vcli config check`.
+//!
+//! These spawn the real `vcli` binary (via `CARGO_BIN_EXE_vcli`) and verify
+//! the full main → selection → dispatch → report → exit-code chain, not just
+//! `Config::build_report()` in isolation.
+//!
+//! The key regression pinned here: a broken `active_target` in `targets.yaml`
+//! must NOT abort with a bare stderr exit. It must emit a valid JSON document
+//! with `valid: false`, an `ILLEGAL_CONFIG` diagnostic, and a non-zero exit
+//! code — so operators can see *both* the selection failure and whatever
+//! config could still be read.
+
+use std::process::Command;
+
+fn vcli() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_vcli"))
+}
+
+/// Guard that restores a set of environment variables on drop.
+struct EnvGuard {
+    vars: Vec<(String, Option<std::ffi::OsString>)>,
+}
+
+impl EnvGuard {
+    fn new(keys: &[&str]) -> Self {
+        let mut vars = Vec::new();
+        for k in keys {
+            vars.push((k.to_string(), std::env::var_os(k)));
+            std::env::remove_var(k);
+        }
+        Self { vars }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (k, v) in self.vars.drain(..) {
+            match v {
+                Some(val) => std::env::set_var(&k, val),
+                None => std::env::remove_var(&k),
+            }
+        }
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn cli_config_check_with_broken_active_target_emits_json_and_nonzero_exit() {
+    // Isolate every variable that could shift selection or attribution.
+    let _env = EnvGuard::new(&[
+        "VB_TARGETS_FILE",
+        "VB_TARGET",
+        "VB_PROFILE",
+        "VB_CONFIG_DIR",
+        "VB_REMOTE_HOST",
+        "VB_TIMEOUT",
+        "VB_PORT",
+    ]);
+
+    // Write a targets.yaml whose active_target points at a target that
+    // does not exist in the `targets:` map. This is the canonical
+    // "selection failure" scenario: resolve_selection / resolve_from_selection
+    // must surface the error through build_report rather than exit early.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let targets_path = tmp.path().join("targets.yaml");
+    std::fs::write(
+        &targets_path,
+        "active_target: does-not-exist\n\
+         targets:\n  \
+           prod:\n    \
+             remote_host: eda-host\n    \
+             port: 65535\n",
+    )
+    .expect("write targets.yaml");
+
+    let output = vcli()
+        .args(["config", "check", "--format", "json"])
+        .env("VB_TARGETS_FILE", &targets_path)
+        .output()
+        .expect("vcli config check should spawn");
+
+    // 1. Non-zero exit code — a broken config must not report success.
+    assert!(
+        !output.status.success(),
+        "expected non-zero exit for broken active_target, got success. \
+         stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // 2. stdout must be valid JSON (not a bare error message).
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout must be valid JSON, got parse error: {e}\n--- stdout ---\n{stdout}\n--- stderr ---\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+    });
+
+    // 3. valid must be false.
+    assert_eq!(
+        json.get("valid").and_then(|v| v.as_bool()),
+        Some(false),
+        "expected valid=false, got: {json}"
+    );
+
+    // 4. An ILLEGAL_CONFIG diagnostic must be present, carrying the
+    //    underlying selection error.
+    let diagnostics = json
+        .get("diagnostics")
+        .and_then(|v| v.as_array())
+        .expect("diagnostics must be an array");
+    assert!(
+        !diagnostics.is_empty(),
+        "expected at least one diagnostic, got: {json}"
+    );
+    assert!(
+        diagnostics.iter().any(|d| d["code"] == "ILLEGAL_CONFIG"),
+        "expected ILLEGAL_CONFIG diagnostic, got: {diagnostics:?}"
+    );
+    assert!(
+        diagnostics.iter().any(|d| d["level"] == "error"),
+        "diagnostic must be level=error, got: {diagnostics:?}"
+    );
+
+    // 5. status should reflect the error (not "ok").
+    assert_eq!(
+        json.get("status").and_then(|v| v.as_str()),
+        Some("error"),
+        "expected status=error, got: {json}"
+    );
+
+    // 6. The report should still contain entries (config that *could* be
+    //    read is surfaced alongside the failure — strictly more info than
+    //    a bare exit).
+    assert!(
+        json.get("entries").and_then(|v| v.as_array()).is_some(),
+        "report should still carry entries array, got: {json}"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn cli_config_check_with_valid_target_exits_zero_and_valid_true() {
+    // Complementary happy-path: a well-formed targets.yaml with a valid
+    // active_target must exit 0 with valid=true. This ensures the
+    // broken-target test above isn't passing trivially because *all*
+    // config checks fail.
+    let _env = EnvGuard::new(&[
+        "VB_TARGETS_FILE",
+        "VB_TARGET",
+        "VB_PROFILE",
+        "VB_CONFIG_DIR",
+        "VB_REMOTE_HOST",
+        "VB_TIMEOUT",
+        "VB_PORT",
+    ]);
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let targets_path = tmp.path().join("targets.yaml");
+    std::fs::write(
+        &targets_path,
+        "active_target: prod\n\
+         targets:\n  \
+           prod:\n    \
+             remote_host: eda-host\n    \
+             port: 65535\n",
+    )
+    .expect("write targets.yaml");
+
+    let output = vcli()
+        .args(["config", "check", "--format", "json"])
+        .env("VB_TARGETS_FILE", &targets_path)
+        .output()
+        .expect("vcli config check should spawn");
+
+    assert!(
+        output.status.success(),
+        "valid target should exit 0, got non-zero. stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("valid JSON on happy path");
+    assert_eq!(
+        json.get("valid").and_then(|v| v.as_bool()),
+        Some(true),
+        "expected valid=true for valid target, got: {json}"
+    );
+    assert_eq!(
+        json.get("status").and_then(|v| v.as_str()),
+        Some("ok"),
+        "expected status=ok, got: {json}"
+    );
+}


### PR DESCRIPTION
## Summary

4 P1 fixes across config / session / CLI dispatch:

- **Token leak** (`config.rs`): Added `sanitize_raw_value()` so `VB_TRANSPORT_DAEMON_TOKEN` and `VB_SSH_KEY` are masked as `***set***` in `vcli config check` output. Previously these secrets were printed in cleartext.
- **Invalid configs returned success** (`config.rs`): `VALUE_PARSE_FAILED` now sets `valid=false` and `level=error` so unparseable values (e.g. garbage timeout) no longer slip through as `valid=true` + exit 0. `from_target` / `from_env_with_profile` build failures are also surfaced as errors.
- **Target/Profile bypass in `config check`** (`main.rs`): Removed `Commands::Config` from the selection-skipping exclusion list so `--target prod config check` reports prod's config instead of the active one.
- **Session false-positive cleanup** (`session.rs`): `forward_port_unreachable` no longer triggers session deletion. The tunnel chain passed — only the local forwarding leg is down — so the remote daemon may still be healthy. The cache entry is preserved with `cannot_verify:forward_port_unreachable`. Only `local_port_unreachable` (definitive death) triggers cleanup.

### Verification

- `cargo clippy -- -D warnings` ✅
- `cargo fmt --check` ✅
- config module 9/9 tests ✅

Two **structural optimizations** noted in review (single-parse snapshot, unified file lookup) are intentionally excluded — they are refactor work that does not affect correctness and should be scheduled separately.