### PR TITLE
feat: migrate CommandContext to spectre/process + 6 command families

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh run:*)"
+    ]
+  }
+}

--- a/.workbuddy/memory/2026-09-05.md
+++ b/.workbuddy/memory/2026-09-05.md
@@ -1,0 +1,132 @@
+# 2026-09-05
+
+## tunnel 命令族：第 3~4 轮审阅修复 + 第 5 轮复检加固（commit f694659，未推送）
+
+分支 `fix/gui-debug-env-session-improvements`，基线 `8cbf83a`（round 2 已提交）。
+
+### 落地内容
+1. **转发成功判定**（P1-①）：`try_ssh_tunnel` 加 `-v` + `-o LogLevel=DEBUG1`；
+   `wait_for_forward` 三条件判定（ssh stderr 绑定标记 + 端口可达 + 子进程存活），
+   后台线程排空 stderr，失败 kill+reap。
+2. **PID 必须是转发持有者**（P1-②）：去掉 `-f`，显式 `-o ControlMaster=no`。
+3. **restart 语义**（P1-③）：抽 `discover_live_session()`（无副作用）供
+   attach/restart 共用；restart 先预检，无存活 daemon 在断开前拒绝，通过后 stop→attach。
+4. **digest 补约束**（P2-④）：`Config::digest()` 哈希输入补 `port_explicit`。
+5. **默认端口非约束**（第 3 轮）：`Config.port_explicit`（from_env 按 `VB_PORT`
+   是否存在，from_target 按 `target.port.is_some()`）；attach 端口过滤与
+   `validate_endpoint_ownership` 端口臂仅在显式约束时生效，host 恒校验。
+   `SSHClient::warm()` 收敛为纯部署（返回 IL 路径，不建隧道不写状态）；
+   删 `ensure_tunnel`/`save_state`/`cleanup_remote`；`open_tunnel(local, remote)` 双端口。
+
+### 第 5 轮复检加固（我本轮追加）
+- `-v` **并非无条件生效**：OpenSSH 只在用户配置未设 `LogLevel` 时才被 `-v` 抬高，
+  `~/.ssh/config` 的 `LogLevel QUIET` 会静默掉绑定标记 → 每个 attach 必超时。
+  必须显式 `-o LogLevel=DEBUG1`（命令行 `-o` 优先级高于配置文件）。
+- 轮询预算参数化 `wait_for_forward(child, port, budget)`；生产
+  `TUNNEL_FORWARD_BUDGET = 20s`（失败由子进程退出立即返回，不靠预算耗尽），
+  单测传短预算（5s / 500ms），整组约 3s。原固定 50×100ms=5s 对慢跳板机太紧。
+- 绑定标记需**数字边界**：`port 30001` 会满足 `port 3000` 的子串匹配。
+- 修 E0716（`String::from_utf8_lossy(&log.lock().unwrap()[..])` 借用临时 Guard）
+  → 抽 `snapshot()` 返回自有 String；合并重复文档块。
+
+### 门禁结果（全绿）
+`cargo fmt --check` ✅ / `clippy --all-targets -D warnings` ✅ /
+`cargo test` TEST_EXIT=0（新增 13 例全过：wait_for_forward 6、attach_candidates 3、
+context 默认端口 3、config digest 1）/ `cargo build --features daemon` ✅。
+
+## 环境事实（本轮新踩）
+- **Bash 是 zsh，不是 fish**（系统提示写 fish，实测 `ulimit -n` 报
+  `failed to load module 'zsh/rlimits'`；`(eval):1: no matches found: --include=*.rs`
+  是 zsh 的 glob 展开）。→ **glob 参数必须加引号，否则 zsh 直接报错退出**。
+  搜索一律用 Grep 工具，不要 shell grep。
+- 编译极慢：`cargo check --all-targets` 4m12s、`clippy` 8~10m、`cargo test` 完整
+  30m（含编译）。**门禁一律 `run_in_background`，别前台等**。
+- `cmd1 && cmd2 | tail -N` 的退出码是 `tail` 的，**不能用 `&&` 链判定测试成败**。
+  正确做法：`cmd > /tmp/x.log 2>&1; echo "EXIT=$?" >> /tmp/x.log`，再用 Grep 读日志。
+- Swift/Objective-C 无关：核实 OpenSSH 日志文案用 `strings /usr/bin/ssh | grep -i
+  "forwarding listening"` → 本机 OpenSSH_9.0p1 确认为
+  `Local forwarding listening on %s port %s.`（另有 path 变体）。
+
+## 提交纪律口径
+- 提交文件清单显式 `git add <files>`，**不 `git add -A`**：3 个未跟踪文件
+  （`.claude/settings.local.json`、`docs/debug-log-2026-08-31.md`、
+  `tests/docs/2026-08-31-transport-p1-progress.md`）按要求保持未跟踪。
+- 长 commit message 用 `git commit -F /tmp/xxx.txt`（heredoc 在 zsh 不可靠）。
+- 本次因 `port_explicit` 跨接缝、与其余修复共享文件、无法拆出可独立编译的中间
+  提交，破例合为一次提交（已在 message 里注明偏离"一次提交一个接缝"的理由）。
+- ~~只提交未推送~~ → 后经拆分已推送并开出 **PR #75**（见下节）。
+
+## 🔴 分支污染事故：两个工作流被误堆在同一分支（已修复）
+
+`fix/gui-debug-env-session-improvements` 本地分支上堆了**两个完全不相关的工作流**：
+- gui-debug 组 `68dcdf8..dcdf436`（origin 头 `dcdf436`，对应 PR #74）：仅
+  `.claude/skills/virtuoso-gui-debug/**` 5 个 Python/SKILL.md 文件；
+- target/context/tunnel 组 `a7df5d2..f694659`（**从未推送**）：24 个 Rust 源码 + docs。
+
+`gh pr view 74` 显示只有 5 文件/+133，而本地 `git diff origin/main` 有 13 文件/+684，
+**两边数字对不上 → 是发现该问题的信号**。直接 push 会把 tunnel 工作塞进
+gui-debug 的 PR #74。
+
+修复：从 `origin/main` 新建 `fix/target-context-tunnel`，cherry-pick `a7df5d2^..f694659`（干净通过，
+5 commits），用 `git diff dcdf436 f694659 | shasum` vs `git diff origin/main HEAD | shasum`
+校验两份 diff 指纹一致（`c2f3bc8f…`）→ 内容与原子集逐字节相同。推送后开出 **PR #75**（24 文件/+2861/-196，MERGEABLE）。
+
+**教训（写进流程）**：
+1. push 前必查 `gh pr view <n> --json changedFiles,additions` 与本地 `git diff --stat` 是否对得上；
+2. 分支名与提交内容不符（分支叫 gui-debug，提交却是 target/tunnel）时立刻警觉；
+3. 拆分时用 diff 指纹比对而非目测，能证明无损；
+4. 拆前确认 Rust 侧不依赖被剥离的资源（全仓仅 `src/commands/schematic.rs:376`
+   有 `include_str!("../../resources/rb_connect_terminal.il")`，与 `.claude/**` 无关）。
+
+**遗留（未做，等用户决定）**：本地 `fix/gui-debug-env-session-improvements` 仍领先
+origin 5 个 tunnel 提交。需 `git reset --hard origin/fix/gui-debug-env-session-improvements`
+才能与 PR #74 对齐（提交已在新分支上，无损；但因属破坏性操作未擅自执行）。
+
+## PR #75 CI 红灯修复：Windows 上 `dirs::home_dir()` 忽略 `HOME`（commit eeb3a7f）
+
+CI run 33975399570：6 job 中 4 绿 2 红，**两个红的都是 `windows-latest`**
+（default + native-ssh），失败 `target::resolve::tests` 8 例，全部
+`left: LegacyEnv / right: ActiveTarget("prod")` 或 `unwrap_err() on Ok(LegacyEnv)`。
+（我新增的 `wait_for_forward` 6 例在 Windows **全部通过** —— runner 的 PATH 有
+Git Bash 的 `sh`。）
+
+**根因（已实证到 crate 源码）**：
+- `dirs` 6.0.0 在 Windows 走 `src/win.rs`：`home_dir() = dirs_sys::known_folder_profile()`
+  = `SHGetKnownFolderPath(FOLDERID_Profile)` → **`C:\Users\runneradmin`，完全忽略 `HOME`**。
+- 只有 unix 分支（`dirs-sys-0.5.0/src/lib.rs:33`）才读 `HOME`。
+- 测试 helper `with_home()` 只 `set_var("HOME", tmp)` → 在 Windows 上是空操作，
+  于是 `TargetManager::load()` 去读真实 profile 目录 → 文件不存在 → 空配置 → `LegacyEnv`。
+
+**修复**：`TargetManager::default_config_path()` 支持 `VB_TARGETS_FILE`（非空时直接返回），
+回退逻辑不变（`dirs::home_dir()/.vcli/targets.yaml`）；测试 helper 改名
+`with_targets_dir()`（改设 `VB_TARGETS_FILE`，`write_targets` 直接写该目录，
+不再建 `.vcli` 子目录）；新增 2 例钉住覆盖本身（生效 / 空值视为未设）。
+README 双语 env 表 + AGENTS.md 同步。
+
+**为何不用已有的 `VB_CONFIG_DIR`**：它是 `runtime_paths::config_root()` 的覆盖，
+`src/runtime_paths.rs` 里已有多条 `#[serial]` 测试在改它，复用会串扰。
+`VB_TARGETS_FILE` 零耦合。
+
+### 🔴 新踩坑：`perl -pi -e` 批量替换误伤函数定义
+`s/(?<![:\w])default_config_path\(\)/TargetManager::default_config_path()/g` 把
+`pub fn default_config_path()` 的定义也改成了 `pub fn TargetManager::default_config_path()`。
+**改调用点前先确认模式不会命中定义/文档**；更稳的是逐处 Edit，或先
+`grep -n` 看命中清单。教训：批量正则省下的时间远小于编译报错后的修复成本。
+
+### 本地门禁环境抖动（非回归）
+`transport::daemon_lifecycle::tests::live_matching_process_is_unresponsive_but_identified`
+本地偶发 `sysctl KERN_PROCARGS2: errno 5`（EPERM，Seatbelt 拦截）。
+该文件**与 main 完全相同**（不在分支 diff 里），单独复跑 `cargo test --lib daemon_lifecycle`
+10/10 通过；CI 的 macOS runner 不受本地沙箱影响。→ 属本地环境抖动，不是回归。
+
+## ✅ PR #75 已合并（2026-09-05T22:35:42Z）
+
+- 合并方式：**`gh pr merge 75 --rebase`** → main 上得到 6 个线性、单亲提交
+  （`db703a5 → 57814f6 → d6b89ae → 1350857 → 9e5d131 → 609e060`），
+  **保留了每个接缝的独立提交**，同时 main 历史仍是线性的。
+- 选 rebase 而非 squash 的理由：本分支 6 个提交各自是独立接缝且语义完整，
+  squash 会把 2928 行压成一个提交，违背"一次提交一个接缝"。
+  （历史观察：PR #72 落为单提交 `67ca635`，但那类分支本身提交就少。）
+- 合并前后都确认了 `origin/main` 的 CI 本身是绿的（最近 4 次 success）—
+  这是项目约定：**开 PR / 合并前先看 main 是否自绿**。
+- 合并后 main 无未关闭 issue（`gh issue list --state open` 为空）。

--- a/.workbuddy/memory/2026-09-07.md
+++ b/.workbuddy/memory/2026-09-07.md
@@ -1,0 +1,260 @@
+# 2026-09-07
+
+## PR #74 已 rebase 合并入 main（01:52:23Z）
+
+- 分支 `fix/gui-debug-env-session-improvements`（gui-debug：env allowlist、session-aware vcli、
+  动态 CIW 坐标 + P1/P2 审阅修正），5 文件 +133/-16，纯 Python/SKILL.md。
+- 合并前做了 rebase 到最新 main（`609e060`），4 个提交变为 `5efa915..a641306`，
+  `.claude` 内容与旧头逐字节一致（仅换父提交，用 `git diff dcdf436 HEAD -- .claude` 验证为空）。
+- 合并后 main CI **10/10 绿**（Check&Lint 4 + Integration Matrix 6，run 34074401746 / 34074401756）。
+
+## 🔴 长期事实：CI 完全不覆盖 `.claude/skills` 的 Python 测试
+
+`.github/workflows/` 下 4 个 workflow（ci / integration / release / security-audit）
+**没有任何一处出现 python**。→ 涉及 skill 脚本改动的 PR，CI 绿灯**只代表 Rust 没被改坏**，
+Python 改动本身零验证。必须本地补跑：
+
+```bash
+cd .claude/skills/virtuoso-gui-debug && python3 -m unittest discover tests
+```
+
+本次在 PR #74 内容上实测：Python 3.13.12 与系统 3.9.6 **均 242/242 通过**。
+
+## 手法：用临时 worktree 做 rebase，避免污染主工作区
+
+主工作区长期有未提交的 `.workbuddy/memory/*.md` 改动，`git rebase` 会直接拒绝
+（`error: cannot rebase: You have unstaged changes`）。解决：
+
+```bash
+git worktree add --detach /tmp/wt74 origin/<pr-branch>
+cd /tmp/wt74 && git rebase origin/main
+git push --force-with-lease origin HEAD:<pr-branch>
+git worktree remove /tmp/wt74 --force && git worktree prune
+```
+
+好处：不动主工作区、不动本地已污染的旧分支；rebase 后仍可用
+`git diff <旧头> HEAD -- <改动目录>` 证明内容无损。
+
+## PR #78 暂缓（用户决策，本轮未动源码）
+
+三个 P1 阻塞，收敛为「daemon 接入对象池与调度器」后再合，且不作为「真实连接池完成」验收：
+1. **Unix 构建失败**：默认测试缺 feature 门控；native-ssh 里 `Result` 别名误用、
+   线程创建返回 `JoinHandle` 与预期 `()` 不符；需查 `config` 移入闭包后的借用、
+   `factory` 跨工作线程捕获。Windows 绿灯覆盖不到这些 Unix 分支
+   （证据 run 34073632031，4 绿 6 红）。
+2. **并未复用真实 SSH 连接**：池里复用的是 `NativeTransport` 对象，执行仍每次
+   建 runtime → 建 SSH → 断。既有「factory 只调用一次」测试只能证明对象复用，
+   不能证明认证/连接复用。
+3. **旧请求可驱逐新连接 + 重置调度额度**：错误处理直接 `pool.remove(key)`，A/B 共用
+   旧实例时 A 失败后 C 建新实例，B 的迟到失败会删掉 C；删整个 endpoint 还会重建
+   scheduler，使新旧请求用两套额度。→ 应按实例身份/generation 条件失效，保持 endpoint
+   调度器稳定。另：重构删掉了退出时删除 IPC socket 的逻辑，需恢复清理并补 shutdown 回归。
+
+**真实长连接另作后续交付**：共享 runtime、持久 SSH handle、按代重连与 drain；
+验收看**实际握手次数**而非 factory 次数。
+
+## 建 issue #79 / #80（用户要求只拆 2 个，不拆 4 个）
+
+- **#79 「PR #78 合并前修复与范围澄清（对象池与调度接入）」**：用检查清单收纳
+  Unix 编译 / 按实例或 generation 条件失效 / 保持 scheduler 稳定 / 恢复 socket 清理
+  与回归 / 补并发回归。并明确要求**改 PR 标题描述、删除「SSH 连接只建一次」的承诺**。
+- **#80 「后续：真实 SSH 长连接复用」**：共享 runtime、持久连接、按代重连、drain；
+  验收口径明确为**统计实际 SSH 建连与认证次数**（不是 factory 调用次数），
+  外加并发、断连恢复、退出清理。
+
+## PR #81：把 skill Python 测试接入 CI
+
+用户建议「至少覆盖 `.claude/skills/virtuoso-gui-debug/**`，长期依赖本地补跑容易漏验」→ 已实现。
+
+- 新增 `.github/workflows/skill-tests.yml`：`paths` 过滤到 `.claude/skills/**`
+  （+ workflow/脚本自身），纯 Rust PR 不触发；matrix Python **3.9 × 3.13**，`fail-fast: false`。
+- 新增 `.github/scripts/run-skill-tests.sh`：AST 解析所有 skill 脚本 → 遍历
+  `.claude/skills/*/tests` 逐个 `unittest discover`；**无 tests 目录则失败**（防静默转绿）；
+  通用发现，不硬编码 virtuoso-gui-debug。
+- 踩坑：仓库在 `.claude` 下**跟踪了一个 `.pyc`**。第一版用 `compileall` + 本地
+  `find -name __pycache__ -delete` 清理，把该被跟踪文件删了
+  （已 `git checkout -- <path>` 恢复）。→ 改用 `ast.parse` 做语法检查
+  + `PYTHONDONTWRITEBYTECODE=1`，零文件写入。
+- 验证：在 `origin/main` 的 `.claude` 上 242/242 通过（3.13.12 与系统 3.9.6 均过），
+  `EXIT=0`，`__pycache__` 增量为 0；空目录守卫按预期非 0 退出。
+
+## PR #82：0 测试守卫（#81 的补强）
+
+用户指出「发现 tests 目录但实际运行 0 个测试也应失败」—— 属实，已修：
+- `python3 -m unittest discover` 在空/无 test 文件时输出 `Ran 0 tests` 且 **exit 0**；
+  **Python 3.9 还会打印 `OK`** → job 会绿着通过但零验证（3.13 则输出 `NO TESTS RAN` 且非零退出）。
+- 守卫：捕获输出，要求匹配 `^Ran [1-9][0-9]* tests?`。
+- 🔴 **正则必须接受单数**：unittest 对 1 个测试打印 `Ran 1 test`（无 s）。
+  第一版写 `tests`，用 1 测试的最小 fixture 跑出来直接误判为 0 → 已改 `tests?` 并注释说明。
+  → 教训：这类输出解析守卫**必须拿「最小通过用例」反测**，只测「失败用例」会漏掉误杀。
+
+## PR #78 已留合并门槛评论
+
+按用户给定文案在 #78 上评论，把 **#79 明确为合并前检查清单**、#80 为后续真实长连接，
+并写明「CI 全绿、factory 仅调用一次均不能证明真实 SSH 连接复用」。
+
+## 🔴 沙箱会 kill 长跑测试进程（本地命令，非 CI）
+
+skill 测试里有用例读 `~/.ssh/*`，本地 Bash 工具跑全量 242 例会触发 Seatbelt 拦截
+（`/Users/dean/.ssh/config`、`id_ed25519` file-read-data 被拒）并 **SIGTERM（exit 137）**。
+走 `run_in_background` 可跑完（242 pass，exit 0）。CI runner 无此限制。
+
+## PR #82 已 rebase 合并入 main（约 05:10Z）
+
+- 用户「继续」驱动：PR #82 融合前 CI 已全绿（Check&Lint / Integration Matrix 6/6 / Skill tests py3.9+py3.13 / Build / Test / Security Audit 全 SUCCESS）。
+- `gh pr merge 82 --rebase --delete-branch` 成功（远程合并）；本地分支删除因被 `/private/tmp/wt82` worktree 占用失败 → 先 `git worktree remove /private/tmp/wt82 --force` 再 `git branch -d ci/skill-tests-zero-guard`。
+- main 推送（fabf56c，05:06:32Z）触发**三个 workflow，共 12 项全绿**（均为 main 合并后验证，非 PR 阶段）：
+  - `CI` (34085532876)：Test / Security Audit / Build / Check&Lint 4 项 success。
+  - `Integration Matrix` (34085532916)：macos/ubuntu/windows × default/native-ssh **6/6 success**。
+  - `Skill Tests` (34085532872)：py3.9 + py3.13 2 项 success。
+- 合并后 main 端 **12 项全绿**闭环（注：PR 阶段的 Skill Tests 是 34080360625，属 #81；此处 34085532872 才是 #82 合并后主线验证）。零测试守卫正式进入 CI 门禁。
+
+## PR #78 三提交推进（对象池接线）：编译修复 → 条件失效 → socket 清理
+
+worktree `/tmp/wt78`，分支 `feat/endpoint-pool-daemon-wiring`（基线 8b86358）。
+
+### 提交1 `6751893` 修复 default/native-ssh 双构建（零行为变更）
+根因逐条（均已验证 EXIT=0）：
+- `transport_daemon.rs`：`factory` 闭包 `move` 走 `config` 后，后面又 `&config` 算 `shutdown` → E0382。
+  修法：**把 `shutdown` 计算前移到 factory 之前**（值不变，纯重排）。
+- 🔴 **`crate::error::Result` 是单参别名**（=`Result<T, VirtuosoError>`），写
+  `Result<Arc<dyn RemoteTransport>, TransportError>` 会 E0107。必须显式
+  `std::result::Result<..., TransportError>`。这条连锁消去 6 处 E0308 级联。
+- `server.rs`：`bind_listener`/`accept_loop` 用了 native-ssh 专属类型却无门控 →
+  default 构建 8 处 E0425/E0433/E0599/E0609。修法：两函数加 `#[cfg(feature="native-ssh")]`。
+- `run`/`run_with_pool` 的 spawn 闭包返回 `JoinHandle`，函数要 `Result<(),String>` → E0308。
+  修法：`.map_err(...)?; Ok(())`（与 origin/main `run` 的 `?` 风格一致）。
+- 🔴 `Fn` 闭包捕获的 `Arc` 不能按值 move 进内部 `move` 闭包 → 外层先 `Arc::clone(&factory)` 再传 inner。
+- 测试断言：`client` 返回 `TransportError` 不是 `IpcError`；`TransportError` 导入要
+  `#[cfg(feature="native-ssh")]`（否则 default 构建 unused-import 警告 → `-D warnings` 挂）。
+
+### 提交2 `636ceee` 条件失效（generation）
+- `Endpoint` 加 `generation: Arc<AtomicU64>`，进程级 `NEXT_ENDPOINT_GENERATION` 自增；
+  新增 `EndpointPool::remove_if_matches(key, gen)`：只有槽位当前 endpoint 的 generation
+  匹配才删，否则 no-op（**旧请求迟到失败不会误删并发重建的新实例**）。
+- `remove` 保留给 `tunnel stop`/`clear`（无条件）。
+- `serve_one_pooled` 派发前 capture generation，`TransportAccess.captured_generation` 传下去；
+  `on_connection_error` 签名 `FnMut(&ResponseResult)` → `FnMut(u64)`。
+- 4 个新回归：generation 自增 / 迟到驱逐不删替换 / 空槽 no-op / 删 endpoint 不重建 scheduler。
+
+### 提交3 `c6570bd` 恢复 socket 退出清理
+- `accept_loop` 不 unlink，`run`/`run_with_pool` 重构后丢了 origin/main `run` 末尾的
+  `remove_file(socket_path)` → 干净重启会撞上残留 socket。修法：两入口
+  `accept_loop` 返回后 `let _ = std::fs::remove_file(socket_path);`（best-effort，覆盖全部退出路径）。
+- 新测试 `run_with_pool_unlinks_its_socket_on_clean_shutdown`（并断言 factory 只调一次）。
+
+### 提交4 `216cc0d` clippy 1.98 差异（Linux CI 才暴露）
+- 🔴 **本机 cargo 1.96、Linux CI clippy 1.98**：1.98 默认开 `too_many_arguments`(7)，
+  `serve_one_pooled`/`run_with_pool` 各 8 参 → CI 红而本机绿。
+  → **本机 clippy 通过不等于 CI 通过**；native-ssh 相关 lint 只能靠 Linux runner 兜。
+- `run`/`serve_one_with_shutdown` 在 daemon 改走 `run_with_pool` 后无 in-tree caller，
+  `-D warnings` 下 dead_code 变 error → 加 `#[allow(dead_code)]` 并注明「移除另开 PR」。
+
+## 🔴 本机别跑 native-ssh 测试（会卡 1h+）
+`cargo test --features native-ssh` 在本机链 aws-lc-sys/russh 极慢，跑了 1h07m 无输出，
+只能 kill。**native-ssh 的编译/测试一律推分支让 Linux runner 跑**（用户确认：「编译可以在远程linux主机」）。
+本机只跑 default 档 + fmt + clippy 即可。
+
+## 复审 #78 抓出两个 🔴：remove_if_matches 死锁 + scheduler 归属错误
+
+### A. 🔴 `let` shadowing 不 drop 旧 guard → 同 Mutex 二次 lock **死锁**（通用 Rust 陷阱）
+`EndpointPool::remove_if_matches` 先 `let slots = self.slots.lock()`，后又
+`let mut slots = self.slots.lock()`。**shadowing 不会提前 drop 旧值**，旧 guard
+活到作用域结束 → 第一个锁未释放就再次 lock 同一个非重入 Mutex → 永久阻塞。
+
+只在「generation 匹配 ⇒ 真的驱逐」这条路径触发，即**真实连接级失败走的正是这条路**，
+也是 `a_late_eviction_does_not_drop_a_concurrent_replacement` 最后一行断言的路径。
+
+**这就是 CI 挂死的真因**（不是排队、不是慢）：pool 测试永不返回 → `Test` 与
+Integration Matrix 6 项 `in_progress` 卡 1h；而更早的 run 因代码编译不过，
+7 分钟内快速失败，两者对比才暴露出来。
+
+修法：check 与 clear 合并进**单个临界区**（`matches` 先算成 bool 释放借用，再 clear）。
+修后本机 20/20 pool 测试 0.02s 跑完。
+
+### B. 🔴 #79 ③ 原先没真正满足：scheduler 挂错了对象
+原实现 scheduler 在 `Endpoint` 上，且 evict 直接 `slots.remove(key)` 删整个 slot
+→ 重建必得新 `SessionScheduler` → 旧请求与新请求**两套调度额度**（正是 #79 ③ 要禁的）。
+
+修法：scheduler 提升到 **`EndpointSlot`（per-key）**，`Endpoint` 只 `Arc::clone` 引用；
+`remove_if_matches` 改为 `slot.clear()`（清 endpoint、留 slot+scheduler）；
+`len()`/`keys()` 改按「有 endpoint 的 slot」计数，evict 后 `is_empty()` 语义不变。
+
+配套：删除测试 `removing_one_endpoint_does_not_reset_its_scheduler`——**名字承诺稳定、
+断言却是 `!Arc::ptr_eq`（相反）**。换成 `evicting_an_endpoint_keeps_its_scheduler_and_budget`：
+持 permit 跨 eviction，断言 `Arc::ptr_eq` 同一实例 + 重建后 `stats().active` 仍为 1（额度未重置）。
+
+### 口径修正（用户指出）
+- 「本机必须卡 1h、测试只能交给 Linux」是**执行环境观察，不是代码事实**，不能据此跳过测试。
+  实测：default 档本机可跑 —— pool 20 测试 0.02s，全量 `cargo test` EXIT=0（3m58s）。
+  只有 `--features native-ssh` 慢（链 aws-lc-sys）。→ 定向模块测试本机先跑，native-ssh 交给 Linux。
+- #78 没改 Python，**242 项 skill 测试未跑不算合并阻塞**（按变更范围 + workflow paths 触发规则验收）。
+- 状态口径：修复提交后应标「**修复已提交，执行验证与复审未完成**」，不得写「三项已完成」。
+
+### 流程事实
+- rebase 后 push 被非快进拒绝 → `git push --force-with-lease`（PR 分支标准操作，比 --force 安全）。
+- rebase 前先 `git branch -f backup-<name> HEAD` 留回退点。
+- #78 已 rebase 到 `origin/main`(fabf56c)：behind 0 / ahead 8（`0785d6f` 为最新修复）。
+
+## #78 已合并（main `0b07869`，12:57Z）
+
+门禁全绿：
+- 本机：fmt / clippy(default + native-ssh) / `cargo test` 全量 EXIT=0 / `cargo check --features daemon`
+- PR CI：**10/10**（CI 4 + Integration Matrix **6/6**）
+- 新增 5 个回归在 macOS native-ssh runner **实跑 ok**（三 suite：970 / 1122 / 963 passed，0 failed），
+  不是"只编译过"
+- #79 六项清单全满足；标题改为 "wire the endpoint object pool and scheduler into the daemon"
+
+## 🔴 macOS Unix socket `sun_path` ≤104 字节（只在 macOS 失败，极易误判）
+新测试 socket 名 `vcli-shut-pool-{uuid}.sock` 在 macOS runner 上总长 ~105 > 上限
+→ `bind` 失败 → 报错是 "**daemon did not come up**"（完全看不出是路径太长）。
+ubuntu 的 `temp_dir()` 是 `/tmp`（短）、windows 不走 Unix socket → **只有 macOS 红**。
+
+既有测试前缀 `vcli-shut-`（总长~100）恰好卡在线内才一直没暴露。
+修法：改短为 `vcli-shp-`，并加 `assert!(path.len() <= 100)` 让下次立刻暴露真因。
+→ 以后写 Unix socket 测试：**名字要短 + 加长度断言**。
+
+## 🔴 CI 僵尸 run 会占满并发
+被新提交 supersede 的旧 run **不会自动取消**，一直占并发 → 新 run 排队数小时（曾误判为"卡住"）。
+推送后应主动 `gh run cancel <旧 run id>`。本次两个 09:20 的 run 卡了 3h41m 才被清掉。
+
+## 口径：main 验收的项目数不是固定 12
+Skill Tests workflow 按 `paths` 过滤 `.claude/skills/**` → **只在改了 skill Python 时才触发**。
+#78 没改 Python，故 main 合并只触发 2 个 workflow = 10 项（CI 4 + Matrix 6），
+不是 12。**按变更范围与 workflow 触发规则验收，不把未触发的 suite 算阻塞。**
+
+## 工作区清理（用户指示「清掉后继续」）
+删 4 个未跟踪文件：`.github/workflows/skill-tests.yml`、`.github/scripts/run-skill-tests.sh`
+（**与 origin/main 逐字节相同**的重复副本，rebase 后本会被跟踪）、
+`docs/debug-log-2026-08-31.md`、`tests/docs/2026-08-31-transport-p1-progress.md`（8-31 过期调试记录）。
+`.workbuddy/memory/*` 变更保留（rebase 前 `git stash push -u -- .workbuddy`，事后 pop 恢复）。
+
+## 🔴 `fix/target-context-tunnel` 是 PR #75 的陈旧副本，别再为它开 PR
+用户原以为该分支有未合入的工作。三条决定性证据（分支 tip `eeb3a7f`）：
+1. `git cherry -v origin/main HEAD` → 6 个提交**全部标记 `-`**（main 已有等价补丁）。
+2. `git diff --stat 609e060 eeb3a7f` → **空**：分支树与 main 上同批工作落点 `609e060` 完全一致。
+3. 两提交时间戳完全相同（`2026-09-06 06:21:15 +0800`）→ 同一内容重建的副本。
+→ 该工作已由 **PR #75**（2026-09-05T22:35:42Z 合并）落地。分支 **behind 21 / ahead 6**，
+   rebase 会得到空分支。保留分支未删，备份 `backup-tct-pre-rebase`。
+
+🔴 **读 `git rev-list --left-right --count A...B` 的顺序**：输出是「**A 独有数 B 独有数**」
+（左=第一个参数）。曾把 `21 6` 读成「领先 21 落后 6」，实际是**落后 21、领先 6**，方向完全反了。
+
+## PR #76 复审（外部贡献 LXY-freshman，shared daemon 安装）
+4 文件 +289/-24：`install.sh`(新 123) / `resources/ramic_bridge.il`(+44/-20) / README / CHANGELOG。
+状态 MERGEABLE 但 `mergeStateStatus=UNSTABLE`、**`gh pr checks` 零检查**（无任何 CI 证据），
+head ref `feat/multi-user-daemon-deploy`，**headRepository=null（来源仓库已不可访问）**。
+复核：`; RB_VERSION: 1.3.4` == Cargo.toml 1.3.4 ✓。
+
+### 发现（详见本轮对话报告）
+- 🟠 `install.sh:104` `sed "s|__DAEMON_PATH__|$DAEMON_BIN|g"`：前缀含 `&` 时被 sed 当作「整个匹配」，
+  实测 `/opt/a&b` → 烤进 `/opt/a__DAEMON_PATH__b`（**静默损坏**，`set -e` 下 sed 仍 exit 0）；
+  含 `|` 则 sed 报错中止。注释「路径不含 `|`」不成立。
+- 🟠 `install.sh:91` 占位符守卫 grep 的是 `$IL_SRC` 不是 `$IL_DEST` → 上面那种静默损坏兜不住。
+- 🟡 `install.sh:40` `usage()` 用 `sed -n '3,28p'`，头注释 23 行就结束 → `--help` 实测漏出
+  `set -euo pipefail`、`SCRIPT_DIR=` 等裸 shell 代码。应为 `3,23p`。
+- 🟠 搜索链把 `/opt/virtuoso-cli/bin`、`/usr/local/bin` 排在 `~/.local/bin`、`~/.cargo/bin` **之前**
+  → 共享机上用户自己的新 daemon 会被旧共享 daemon 顶掉，触发 `session.rs:257` 警告的版本偏差；
+  且共享目录若可写则是跨用户执行边界（`RB_DAEMON_PATH` 优先级 2 可作逃生口）。
+- 🟠 PR 自带 `3909e13 chore(release): 1.3.4`，与上游 `3461706 release: v1.3.4` 重复。
+- 🔴 基线 `609e060` **落后 main 15 个提交**，从未与 #78 对象池改动一起编译/测试过。

--- a/.workbuddy/memory/2026-09-08.md
+++ b/.workbuddy/memory/2026-09-08.md
@@ -1,0 +1,105 @@
+# 2026-09-08
+
+## RFC #83 第 2 步落地（接 PR #88）
+
+- PR #88（`feat/drop-dotenv-read`）**仍开、未合并**。早前"#88 已合"记录有误。
+- 第 2 步代码：`src/config_file.rs`（单一 `config.toml`，读盘一次、profile 段、坏文件=硬错误、路径经 `VB_CONFIG_DIR`/`VB_HOME` 可覆盖）+ 接入 `config.rs` 的 `Layers` 解析（优先级 `<KEY>_<PROFILE>` env → `<KEY>` env → 文件 profile 段 → 文件全局段 → 默认；set 但无效=报错）。`env_with_profile()` 不动——文件只在 `from_env_resolve` 入口读一次。TUI 与 `vcli init` 改写目标为 `config.toml`。
+- 提交历史：`git fetch` 后确认 origin/main 在分支之上已前进 4 个提交（含 #80 `4286652` SSH 长连接复用 + transport 硬化）。rebase 干净、无冲突。step② 提交后 amend 合并了 fmt 与 bin 模块修复。
+- **双 crate 编译坑**：`vtui` bin 缺 `mod config_file`/`mod profile`（main.rs 有 config_file 但无 profile）→ 报 `cannot find in crate`。修法：三处 entry 都 `mod config_file`；`profile` 走 `virtuoso_cli::profile` 的 pub API（参考 `dispatch_profile`），bin 内不重复 `mod profile`（会导致 duplicate dead_code）；必要处 `#![allow(dead_code)]`。`config_file::has` 仅单测用到，`#[allow(dead_code)]`。
+- **门禁全绿**：`cargo fmt --check` ✅、`cargo clippy --all-targets -- -D warnings` ✅ 0/0、`cargo test`（默认特性）✅ **3161 passed / 0 failed**（含 `vcli_profile_user_scope_does_not_touch_the_real_home`）、`git diff --check` ✅。`--features native-ssh` 交 Linux CI。
+- 已 force-push（`d7eab91...bd690cd`），PR #88 描述更新为"第 1+2 步"，保留用户要求的纠正（Refs #83、事故如实记录）。CI 已触发（CI / Integration Matrix / Security audit 跑中）。
+- 沙箱拦截了某测试对 `~/.ssh/config` 的读——非致命，测试仍全绿（TEST_EXIT=0）。
+
+## 后续
+
+- 第 3 步：在 1+2 之上重做 #73 config check，须解释每个最终值来自 env/target/文件/默认。
+- 仍是开放项：#73 config-check（CONFLICTING）、#80 已合 main、#86 设计取舍待定。
+
+## PR #88 review 4 项修复（并入 `4afd51d`）
+
+基于 review「暂不建议合并」，4 项全部按源码核对后修复，已 force-push（`bd690cd...4afd51d`，PR #88 仍 OPEN），PR body 补「复核修复」段：
+- **P1 键名不一致**：`config_file.rs` 加对称映射 `file_key(env_key)`/`env_var_for(file_key)`，`get`/`has` 用友好键派生候选集 `[友好键, VB_<大写键>]`（修两处自伤：① 候选集 `[mapped,key]` 导致 `remote_host` 永不试 `VB_REMOTE_HOST`；② `env_var_for("VB_REMOTE_HOST")` 产出 `VB_VB_REMOTE_HOST` 双前缀）。TUI `data.rs` 改友好键经 `env_var_for` 映射回 env 名。
+- **P2 保存写坏**：`to_toml_string` 改用 `toml::to_string_pretty` 构建 `toml::Table`（点号键自动引号、`\n` 转义），`save()` 序列化失败返回错误。回归：`dotted_profile_name_is_quoted_on_save`、`newline_in_value_is_escaped_on_save`（用 round-trip 等价断言，弃用 `!contains("line1\nline2")`，因序列化器本就出合法多行串）。
+- **P3 `clear --user` 吞错**：`clear_legacy_user_env_profile_in` 改 `io::Result`，仅内容变化才写，无 `VB_PROFILE=` 的只读旧文件不动不报错。回归：`test_clear_user_profile_propagates_legacy_write_error`（macOS 设 `0o444`）。
+- **P4 测试隔离**：`tests/config.rs` 加 `isolate_config_dir()` 指向空临时目录，套到默认/超时/worker 默认值与 env 覆盖测试。
+- **门禁复绿**：fmt/clippy(-D warnings 0/0)/定向(test config_file 962、tests::config 7、profile 9 全绿)+全量 0 failed/diff-check ✅。CI（force-push 后）：Build/Check&Lint/Test 已绿，Integration Matrix 跑中。
+- **环境坑（复用）**：① Bash 工具实际是 fish，不支持 `$?`/`if [...]`/`for`，背景命令的 `echo "EXIT=$?"` 拖尾会让整条命令失败 → 单命令直跑、直接看日志。② `cargo clippy` 报 "Finished in 0.7s" 无重编 ≠ 没改到：看 `target/debug/deps/libvirtuoso_cli-*.rlib` 时间戳，必要时 `cargo test` 强制重编。③ 全量偶发卡 `identity` 测试（按 PID 读活体进程身份，macOS），与本次改动无关，isolate 重跑即通过。
+
+## PR #92 config-check（RFC #83 第 3 步，#73）
+
+**状态**：OPEN，base `feat/drop-dotenv-read`，head `feat/config-check-redo`，HEAD `ef1d4ae`，6 files / +1370 / −5。`backup/old-config-check` 保留旧 `.env` 时代 5 提交（`490f06f`）。
+
+**新增**：
+- `ConfigSource`/`ConfigEntry`/`ConfigReport`（`src/config.rs`）—— 6 个变体（env_profile/env/file_profile/file_global/target/default），serde tag = `layer`，JSON 形如 `{"layer":"env","var":"VB_TIMEOUT"}`。
+- `Config::build_report(profile)` —— 复用 `Layers::raw_with_source` 走与运行时**同一份**优先级，杜绝报告漂移。
+- `ConfigFile::profile_section_has`（`src/config_file.rs`，`pub(crate)`）—— 区分「profile section 自身拥有」与「全局段兜底」。**没有它**，空 `[profile.prod]` 段里的全局字段会被错标 `FileProfile`（用 `file.has` 会 fall-through 到 global）。
+- `vcli config check [--format json|table] [--require-explicit]` —— `--require-explicit` 字段落到默认值时 exit 10（`DRY_RUN_OK`，借 main 的 `dry_run` 退出码机制）。
+- 9 unit (`config::report_tests`) + 6 integration (`tests/config_check.rs`) 全部 `#[serial]`。
+
+**关键 bug（提交前抓到）**：
+- `all_explicit_is_true_when_no_default_sources` 直接 `std::env::set_var(k, "x")` 遍历所有 `KEY_SPECS`，但 `EnvGuard::Drop` 只还原它 new() 时传入的 key——`VB_SSH_PORT` 等被设置后没人清掉，污染下个测试（18 个 context/target::resolve/transport::tunnel 测试全红，panic 在 `VB_SSH_PORT: "x" is not valid`）。改成 `EnvGuard::new(&all_keys)` 即修。**结论：任何会 `set_var` 到全局 env 的测试，必须把对应 key 列入 EnvGuard 的 new() 列表**。
+- 测试模块必须在文件**末尾**（`items_after_test_module` clippy lint）。
+
+**坑（复用）**：
+- 沙箱禁止 `git checkout` 覆盖已 tracked 的源文件（"Operation not permitted"），但允许 `git stash`、`git commit`、`git branch -f` 等。需要切回 base 测 baseline 时，用 `git worktree add /tmp/wt-basetest <branch>`。
+- 另一个 worktree (`virtuoso-cli-config-check`) 持有 `feat/config-check` checked out — 改名 / 删除均被拒。用 `-redo` 后缀避免冲突。
+
+## 合并顺序：#88（drop-dotenv-read）→ #92（config-check）
+
+### SHA snapshot（2026-09-08 21:06 +0800）
+- **#88** head `4afd51d2f44ce78afe4e96641ba43e21a40e0f65`，base `main`=`c88b80a`，mergeable=`CONFLICTING`，CI 10/10 ✅。
+- **#92** head `ef1d4aed46ef9551e7e4fcee4702222db0e5132c`，base `feat/drop-dotenv-read`，mergeable=`MERGEABLE`，CI 未触发。
+- **`4afd51d` 是 #92 rebase 时的下界分界 commit**——必须严格保留（任何"#88 改完 → #92 在新 main 上重放" 的方案都依赖这个 SHA 固定不变）。
+
+### CI 触发规则（事实订正）
+- `.github/workflows/` 仅对 **base=`main`** 的 PR 触发完整 CI；其他 base（feature 分支互））跳过。
+- 上一轮我误判 "#92 没有 CI 是因为 #88 CONFLICTING"——**错**。base=`feat/drop-dotenv-read` 是 #92 不触发 CI 的唯一原因，与 #88 mergeable 状态无关。
+
+### 工作流拓扑
+- `feat/drop-dotenv-read` (#88) 与 `fix/session-command-context` (#89, 已合 main) 从同一 merge-base `7804baa` 分叉。
+- main 上的 #89 引入了 `allow_cross_user_daemon` 字段、`vb_*` 字段保留在 `from_env_resolve`（无 `Layers`、无 `config.toml`）。
+- #88 引入 `Layers` + `config.toml` + 移除 `dotenvy`。两者在 `src/config.rs::from_env_resolve` 的设计**不互斥**——`#89` 在 main 上是基于「无 `Layers`」的旧架构，`#88` 是新架构；rebase 时是把 #89 的字段接入 #88 的 `Layers`，**不是两种架构二选一**。
+
+### 合并步骤（用户给定的 5 步）
+1. **归档当前 SHA**：本节已写入；并在隔离 worktree 操作。
+2. **rebase #88 到 origin/main（`c88b80a`）**：
+   - 隔离 worktree：`~/Documents/git/wt-rebase88`（避开 `/tmp` 清理坑、避开已存在的 wt-noenv/wt-config-check）。
+   - `git checkout feat/drop-dotenv-read` → `git rebase origin/main`。
+   - 冲突点已知：`src/config.rs` 3 处（HEAD 用 `Self::env_with_profile(...)`，#88 用 `lz.text/lz.parsed_or`）。
+   - 合并方向：**保留 #88 的 `Layers` + `config.toml`**；把 #89 新增的 `allow_cross_user_daemon` 接入：
+     - `Config` 字段（`pub allow_cross_user_daemon: bool`）
+     - `from_env_resolve`：`lz.flag("VB_ALLOW_CROSS_USER_DAEMON")?` 或 `lz.parsed_or(...)`，遵循 #88 的 `parsed_or`/`flag` 模式（保持「set 但无效=报错」契约）。
+     - `from_target`：`target.allow_cross_user_daemon.unwrap_or(false)`。
+     - `KEY_SPECS` 新增：`VB_ALLOW_CROSS_USER_DAEMON`，默认 `"false"`，validator `v_bool`，display 复用 `report_disable_control_master` 同模式。
+     - `digest()` **排除**（用户明确要求；与原 PR 同样的语义："不参与身份哈希"）。
+   - 跑本地门禁：fmt / clippy `-D warnings` / 全量 test。
+   - **不 push**——把改动汇总后给用户拍板再 push。
+3. **push + 合并 #88**：等 CI 全绿后用 `gh pr merge --merge`（保留 merge commit，下一步 #92 剥离依赖 `#88` 的旧 SHA）。
+4. **剥离 #92 → 合并后的 main**：用 `git rebase --onto <新 main SHA> 4afd51d <#92 head>`。`4afd51d` 是排除点，rebase 后 #92 的唯一 commit 内容应仍是「6 files / +1370 / −5」，但 base 是新 main。
+5. **验收 #92**：调整 PR base 为 `main`，本地门禁全绿后 push，等 CI 全绿。
+
+### 自我修正（事实订正）
+- 上一轮诊断"#89 没动 config.rs/tests/config.rs" **是错的**——`#89` 在 main 上加了 `allow_cross_user_daemon` 字段（src/config.rs +15 行、tests/config.rs +1 行），但**没删除 `Layers`**（因为 main 上本来就没有 `Layers`）。
+- "GitHub 不会自动 rebase #92"：**对**——自动调整 PR target 是仓库设置层面行为，不会改写 commit 历史；#88 rebase 后 SHA 全变，#92 必须显式剥离。
+- "上次 dry-run rebase + abort 是只读"：**错**——rebase 中途会改 working tree 和 index，abort 后已恢复但措辞不准；后续 rebase 必须在隔离 worktree 操作。
+- **不要再裸 rebase 当前 wt-noenv**——它 checked-out `feat/config-check-redo`=`ef1d4ae`，动了会污染 #92 工作状态。
+- 复用规则：所有会改 HEAD/index/working-tree 的 git 操作必须在隔离 worktree 完成；只在 wt-noenv 做 #92 的 final 修。
+
+## RFC #83 收尾：#88 → #92 按序落地（全部完成）
+
+### #88（drop-dotenv-read / config.toml）
+- 在 `~/Documents/git/wt-rebase88` rebase 到 `origin/main`(`c88b80a`)。冲突**只有 `src/config.rs` 的 `from_env_resolve` 一处**（`main.rs`、`tests/config.rs` 自动合并；结构体字段、`from_target`、`target/mod.rs` 随 base 带入）。
+- 解法：保留 `Layers`，新增 `Layers::flag_truthy`（1/true/yes/on，忽略大小写与空白）——**刻意不复用严格的 `flag()`**，因为该字段在 main 上就以 yes/on 语义发布，收窄即回归；未识别值回落 false 而非报错（它只压制提示性告警，保守方向是保持告警开启）。`digest()` 保持排除。
+- 单独提交 `a5a3c29` 补 4 项回归（默认 false / 拼写集 / from_target / digest 忽略）。CI 11/11 绿 → merge commit `8957256`。
+
+### #92（config check）
+- `git rebase --onto 8957256 4afd51d feat/config-check-redo` —— 无冲突，diff 恒为 6 files/+1370/−5，**未夹带 #88**。
+- 补 `KEY_SPECS` 缺口（#89 的字段在 config check 写完后才合进 main，导致该字段根本不出现在"解释每个字段"的命令里）：`report_allow_cross_user_daemon` + `v_truthy` + `target_has` 映射。**教训：合并 main 上新字段时，KEY_SPECS / validators / target_has 三处漏一处就静默漏报。**
+
+### 两个新踩的坑
+1. **改 PR base 不触发 CI。** `CI` / `Integration Matrix` 是 `pull_request: branches:[main]`，默认事件只有 opened/synchronize/reopened；`gh pr edit --base` 是 **edited** 事件，不触发。改完 base 必须再 `git commit --amend --no-edit` + force-push 制造 synchronize。（`Security audit` 是 `push` 事件无分支过滤，所以只有它跑了 —— 曾误以为"CI 只有 1 项"。）
+2. **注释声称的 cfg 门根本不存在。** `report_legacy_env_dotenv_fallback_emits_warning` 注释写"the cfg gate below skips Windows"，但没写 `#[cfg(unix)]` → 两个 Windows 作业红。Windows 上 `dirs::home_dir()` 读 Win32 profile API，不认 `$HOME`（也不认 `USERPROFILE`），**无 env 级重定向办法**，只能 cfg 跳过。修：加 `#[cfg(unix)]` 并把理由写进属性自己的注释，避免注释与代码再次漂移。
+
+### 结果
+- #88 merge `8957256`（11/11 绿）、#92 merge `189a5b7`（11/11 绿，含双 Windows）。RFC #83 三步全部落地。
+- 遗留：PR #73（旧 `.env` 时代 config-check）仍开且 CONFLICTING，应由 #92 取代后关闭。

--- a/src/commands/cell.rs
+++ b/src/commands/cell.rs
@@ -2,7 +2,14 @@ use crate::client::bridge::VirtuosoClient;
 use crate::error::Result;
 use serde_json::{json, Value};
 
-pub fn open(lib: &str, cell: &str, view: &str, mode: &str, dry_run: bool) -> Result<Value> {
+pub fn open(
+    ctx: &crate::context::CommandContext,
+    lib: &str,
+    cell: &str,
+    view: &str,
+    mode: &str,
+    dry_run: bool,
+) -> Result<Value> {
     if dry_run {
         return Ok(json!({
             "action": "open",
@@ -17,7 +24,7 @@ pub fn open(lib: &str, cell: &str, view: &str, mode: &str, dry_run: bool) -> Res
         }));
     }
 
-    let client = VirtuosoClient::from_env()?;
+    let client = VirtuosoClient::from_context(ctx)?;
     let result = client.open_cell_view(lib, cell, view, mode)?;
 
     Ok(json!({
@@ -30,8 +37,8 @@ pub fn open(lib: &str, cell: &str, view: &str, mode: &str, dry_run: bool) -> Res
     }))
 }
 
-pub fn save() -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn save(ctx: &crate::context::CommandContext) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     let result = client.save_current_cellview()?;
 
     Ok(json!({
@@ -40,8 +47,8 @@ pub fn save() -> Result<Value> {
     }))
 }
 
-pub fn close() -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn close(ctx: &crate::context::CommandContext) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     let result = client.close_current_cellview()?;
 
     Ok(json!({
@@ -50,8 +57,8 @@ pub fn close() -> Result<Value> {
     }))
 }
 
-pub fn info() -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn info(ctx: &crate::context::CommandContext) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     let (lib, cell, view) = client.get_current_design()?;
 
     Ok(json!({

--- a/src/commands/diag.rs
+++ b/src/commands/diag.rs
@@ -52,7 +52,11 @@ pub struct CdsLockInfo {
 ///   the SKILL channel is what we may be trying to debug.
 /// - We never delete locks; if a lock needs breaking, the user should
 ///   `ps -p <pid> @ <host>` first and then `rm` manually.
-pub fn cdslck(ctx: &crate::context::CommandContext, lib: &str, view_filter: Option<&str>) -> Result<Value> {
+pub fn cdslck(
+    ctx: &crate::context::CommandContext,
+    lib: &str,
+    view_filter: Option<&str>,
+) -> Result<Value> {
     let client = VirtuosoClient::from_context(ctx)?;
     // Step 1: resolve library readPath via the cell.read_path RPC.
     let req = crate::rpc::dispatcher::RpcRequest {

--- a/src/commands/diag.rs
+++ b/src/commands/diag.rs
@@ -60,7 +60,8 @@ pub fn cdslck(lib: &str, view_filter: Option<&str>) -> Result<Value> {
         params: json!({ "lib": lib }),
         api_key: std::env::var("VCLI_API_KEY").ok().filter(|k| !k.is_empty()),
     };
-    let resp = crate::rpc::dispatcher::RpcDispatcher::dispatch(&client, req)?;
+    let ctx = crate::context::CommandContext::new(crate::config::Config::from_env()?, None)?;
+    let resp = crate::rpc::dispatcher::RpcDispatcher::new(ctx).dispatch(&client, req)?;
     let lib_path = resp
         .get("read_path")
         .and_then(|v| v.as_str())

--- a/src/commands/diag.rs
+++ b/src/commands/diag.rs
@@ -52,16 +52,15 @@ pub struct CdsLockInfo {
 ///   the SKILL channel is what we may be trying to debug.
 /// - We never delete locks; if a lock needs breaking, the user should
 ///   `ps -p <pid> @ <host>` first and then `rm` manually.
-pub fn cdslck(lib: &str, view_filter: Option<&str>) -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn cdslck(ctx: &crate::context::CommandContext, lib: &str, view_filter: Option<&str>) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     // Step 1: resolve library readPath via the cell.read_path RPC.
     let req = crate::rpc::dispatcher::RpcRequest {
         method: "cell.read_path".into(),
         params: json!({ "lib": lib }),
         api_key: std::env::var("VCLI_API_KEY").ok().filter(|k| !k.is_empty()),
     };
-    let ctx = crate::context::CommandContext::new(crate::config::Config::from_env()?, None)?;
-    let resp = crate::rpc::dispatcher::RpcDispatcher::new(ctx).dispatch(&client, req)?;
+    let resp = crate::rpc::dispatcher::RpcDispatcher::new(ctx.clone()).dispatch(&client, req)?;
     let lib_path = resp
         .get("read_path")
         .and_then(|v| v.as_str())

--- a/src/commands/library.rs
+++ b/src/commands/library.rs
@@ -4,8 +4,8 @@ use crate::client::skill_sexp::{parse_sexp, sexp_to_str_list};
 use crate::error::{Result, VirtuosoError};
 use serde_json::{json, Value};
 
-pub fn list() -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn list(ctx: &crate::context::CommandContext) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     // Use unchecked — capability check already passed at RPC dispatch level
     let r = client.execute_skill_unchecked(&LibraryOps.list(), Some(client.read_timeout()))?;
     if !r.skill_ok() {

--- a/src/commands/process.rs
+++ b/src/commands/process.rs
@@ -5,6 +5,7 @@ use serde_json::{json, Value};
 
 #[allow(clippy::too_many_arguments)]
 pub fn char(
+    ctx: &crate::context::CommandContext,
     lib: &str,
     cell: &str,
     view: &str,
@@ -17,7 +18,7 @@ pub fn char(
     output: &str,
     timeout: u64,
 ) -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+    let client = VirtuosoClient::from_context(ctx)?;
 
     client.execute_skill("simulator('spectre)", None)?;
     let design_result = client.execute_skill(
@@ -121,6 +122,7 @@ pub fn char(
 /// Generates a netlist for each L, runs spectre, parses PSF ASCII oppoint results.
 #[allow(clippy::too_many_arguments)]
 pub fn char_netlist(
+    ctx: &crate::context::CommandContext,
     device_type: &str,
     l_values: &[f64],
     vgs_start: f64,
@@ -135,9 +137,7 @@ pub fn char_netlist(
     vds: f64,
 ) -> Result<Value> {
     let is_pmos = device_type == "pmos";
-    let spectre_cmd = crate::config::Config::from_env()
-        .map(|c| c.spectre_cmd)
-        .unwrap_or_else(|_| "spectre".into());
+    let spectre_cmd = ctx.config().spectre_cmd.clone();
 
     let mut all_data: Vec<Value> = Vec::new();
     let mut total_points = 0;

--- a/src/commands/sim.rs
+++ b/src/commands/sim.rs
@@ -580,10 +580,10 @@ pub fn netlist(
 
 // ── Async job commands ──────────────────────────────────────────────
 
-pub fn run_async(netlist_path: &str) -> Result<Value> {
+pub fn run_async(ctx: &crate::context::CommandContext, netlist_path: &str) -> Result<Value> {
     let content = std::fs::read_to_string(netlist_path)
         .map_err(|e| VirtuosoError::Config(format!("Cannot read netlist '{netlist_path}': {e}")))?;
-    let sim = SpectreSimulator::from_env()?;
+    let sim = SpectreSimulator::from_config(ctx.config())?;
     let job = sim.run_async(&content)?;
     Ok(json!({
         "status": "launched",
@@ -603,7 +603,10 @@ pub fn run_async(netlist_path: &str) -> Result<Value> {
 ///
 /// For each entry, the path is read as netlist content and passed to
 /// SpectreSimulator::run_parallel().
-pub fn run_parallel(inputs: &[(String, String)]) -> Result<Value> {
+pub fn run_parallel(
+    ctx: &crate::context::CommandContext,
+    inputs: &[(String, String)],
+) -> Result<Value> {
     if inputs.is_empty() {
         return Err(VirtuosoError::Config(
             "run-parallel requires at least one input (label:path pair)".into(),
@@ -623,7 +626,7 @@ pub fn run_parallel(inputs: &[(String, String)]) -> Result<Value> {
         netlists.push((label.clone(), content));
     }
 
-    let sim = SpectreSimulator::from_env()?;
+    let sim = SpectreSimulator::from_config(ctx.config())?;
     let results = sim.run_parallel(&netlists);
 
     Ok(parallel_report(results, inputs.len()))

--- a/src/commands/skill.rs
+++ b/src/commands/skill.rs
@@ -5,8 +5,13 @@ use crate::models::SessionInfo;
 use crate::skill_finder::{SKILLFinder, SearchMode};
 use serde_json::{json, Value};
 
-pub fn exec(code: &str, timeout: u64, readonly: bool) -> Result<Value> {
-    let mut client = VirtuosoClient::from_env()?;
+pub fn exec(
+    ctx: &crate::context::CommandContext,
+    code: &str,
+    timeout: u64,
+    readonly: bool,
+) -> Result<Value> {
+    let mut client = VirtuosoClient::from_context(ctx)?;
     if readonly {
         client = client.with_sandbox_mode();
     }
@@ -111,8 +116,8 @@ pub fn broadcast(code: &str, timeout: u64) -> Result<Value> {
     }))
 }
 
-pub fn load(file: &str, skillpp: bool) -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn load(ctx: &crate::context::CommandContext, file: &str, skillpp: bool) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
 
     let result = client.load_il(file, skillpp)?;
     let skillpp_mode = result.metadata.contains_key("skillpp_mode");
@@ -136,7 +141,11 @@ pub fn load(file: &str, skillpp: bool) -> Result<Value> {
 /// Supports two input modes:
 /// - `code` provided directly: single expression or multi-line block
 /// - `stdin == true`: read from stdin (avoids shell quoting pain)
-pub fn eval(code: Option<String>, stdin: bool) -> Result<Value> {
+pub fn eval(
+    ctx: &crate::context::CommandContext,
+    code: Option<String>,
+    stdin: bool,
+) -> Result<Value> {
     use std::io::Read;
 
     // Input validation: mutually exclusive modes
@@ -171,7 +180,7 @@ pub fn eval(code: Option<String>, stdin: bool) -> Result<Value> {
     // - Embedded newlines flow through unchanged
     let wrapped = format!("progn(\n{}\n)", skill);
 
-    let client = VirtuosoClient::from_env()?;
+    let client = VirtuosoClient::from_context(ctx)?;
     let result = client.execute_skill(&wrapped, None)?;
 
     Ok(json!({
@@ -197,6 +206,7 @@ pub fn eval(code: Option<String>, stdin: bool) -> Result<Value> {
 /// * `include_desc` - When `true`, also match against the description field,
 ///   not just the function name. Useful for "what function does X" queries.
 pub fn find(
+    ctx: &crate::context::CommandContext,
     query: &str,
     mode: &str,
     limit: usize,
@@ -204,14 +214,14 @@ pub fn find(
     include_desc: bool,
 ) -> Result<Value> {
     let search_mode: SearchMode = mode.parse().unwrap_or(SearchMode::Fuzzy);
-    let cfg = Config::from_env()?;
+    let cfg = ctx.config();
 
     let mut finder = SKILLFinder::new();
 
     if cfg.is_remote() {
         // Remote mode: use cache or sync. Reject an explicit `native` backend
         // before any ssh/scp sync runs, so the mismatch is never swallowed.
-        crate::transport::backend::require_openssh(&cfg)?;
+        crate::transport::backend::require_openssh(cfg)?;
         let host = cfg.remote_host.clone().unwrap_or_default();
         let target = cfg.ssh_target();
         let cshrc = cfg.cadence_cshrc.as_deref();
@@ -224,7 +234,7 @@ pub fn find(
         let _ = crate::skill_finder::load_or_sync(&mut finder, &host, &target, cshrc)?;
     } else {
         // Local mode: find from local Cadence installation
-        let finder_dir = find_skill_finder_dir(&cfg)?;
+        let finder_dir = find_skill_finder_dir(cfg)?;
         if let Some(dir) = finder_dir {
             finder.load(&dir).map_err(|e| {
                 VirtuosoError::Config(format!("failed to load SKILL Finder: {}", e))
@@ -257,12 +267,12 @@ pub fn find(
 /// Get detailed More Info documentation for a specific SKILL function.
 ///
 /// This queries the Cadence More Info system via the Virtuoso bridge.
-pub fn info(func_name: &str) -> Result<Value> {
+pub fn info(ctx: &crate::context::CommandContext, func_name: &str) -> Result<Value> {
     if func_name.is_empty() {
         return Err(VirtuosoError::Config("function name is required".into()));
     }
 
-    let client = VirtuosoClient::from_env()?;
+    let client = VirtuosoClient::from_context(ctx)?;
 
     // Use Virtuoso's More Info system via SKILL
     let skill_code = format!(
@@ -411,16 +421,21 @@ exit 1"#,
 }
 
 /// Sync SKILL Finder cache from remote server.
-pub fn sync_cache(host: Option<&str>, cshrc: Option<&str>, verbose: bool) -> Result<Value> {
-    let cfg = Config::from_env()?;
-    crate::transport::backend::require_openssh(&cfg)?;
+pub fn sync_cache(
+    ctx: &crate::context::CommandContext,
+    host: Option<&str>,
+    cshrc: Option<&str>,
+    verbose: bool,
+) -> Result<Value> {
+    let cfg = ctx.config();
+    crate::transport::backend::require_openssh(cfg)?;
     let target_host = host
         .map(String::from)
         .or(cfg.remote_host.clone())
         .ok_or_else(|| VirtuosoError::Config("Remote host required for sync".into()))?;
 
     let target = cfg.ssh_target();
-    let target_cshrc = cshrc.map(String::from).or(cfg.cadence_cshrc);
+    let target_cshrc = cshrc.map(String::from).or(cfg.cadence_cshrc.clone());
     let target_cshrc_ref = target_cshrc.as_deref();
 
     let old_count = crate::skill_finder::cache_file_count(&target_host);
@@ -457,8 +472,12 @@ pub fn sync_cache(host: Option<&str>, cshrc: Option<&str>, verbose: bool) -> Res
 }
 
 /// Show or clear SKILL Finder cache.
-pub fn show_cache(host: Option<&str>, clear: bool) -> Result<Value> {
-    let cfg = Config::from_env()?;
+pub fn show_cache(
+    ctx: &crate::context::CommandContext,
+    host: Option<&str>,
+    clear: bool,
+) -> Result<Value> {
+    let cfg = ctx.config();
     let target_host = host
         .map(String::from)
         .or(cfg.remote_host.clone())

--- a/src/commands/symbol.rs
+++ b/src/commands/symbol.rs
@@ -4,8 +4,14 @@ use crate::client::symbol_ops::SymbolOps;
 use crate::error::{Result, VirtuosoError};
 use serde_json::{json, Value};
 
-pub fn inspect(lib: &str, cell: &str, view: &str, view_type: &str) -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn inspect(
+    ctx: &crate::context::CommandContext,
+    lib: &str,
+    cell: &str,
+    view: &str,
+    view_type: &str,
+) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     let r = client.execute_skill(
         &SymbolOps::new().inspect(lib, cell, view, view_type),
         Some(client.read_timeout()),
@@ -37,6 +43,7 @@ pub fn inspect(lib: &str, cell: &str, view: &str, view_type: &str) -> Result<Val
 }
 
 pub fn generate(
+    ctx: &crate::context::CommandContext,
     lib: &str,
     cell: &str,
     schematic_view: &str,
@@ -55,7 +62,7 @@ pub fn generate(
             ));
         }
     }
-    let client = VirtuosoClient::from_env()?;
+    let client = VirtuosoClient::from_context(ctx)?;
     let r = client.execute_skill(
         &SymbolOps::new().generate(lib, cell, schematic_view, symbol_view, sort_pins),
         Some(client.read_timeout()),

--- a/src/commands/transaction.rs
+++ b/src/commands/transaction.rs
@@ -4,26 +4,32 @@ use crate::client::bridge::VirtuosoClient;
 use crate::error::Result;
 use serde_json::{json, Value};
 
-pub fn begin(id: &str, lib: &str, cell: &str, view: &str) -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn begin(
+    ctx: &crate::context::CommandContext,
+    id: &str,
+    lib: &str,
+    cell: &str,
+    view: &str,
+) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     client.tx_begin(id, lib, cell, view)?;
     Ok(json!({ "status": "transaction_began", "id": id }))
 }
 
-pub fn commit() -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn commit(ctx: &crate::context::CommandContext) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     client.tx_commit()?;
     Ok(json!({ "status": "transaction_committed" }))
 }
 
-pub fn rollback() -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn rollback(ctx: &crate::context::CommandContext) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     client.tx_rollback()?;
     Ok(json!({ "status": "transaction_rolled_back" }))
 }
 
-pub fn diff() -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn diff(ctx: &crate::context::CommandContext) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     let diff = client.tx_diff()?;
     let (id, _snap) = client
         .tx_status()
@@ -31,8 +37,8 @@ pub fn diff() -> Result<Value> {
     Ok(json!({ "status": "ok", "transaction": id, "diff": diff }))
 }
 
-pub fn status() -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn status(ctx: &crate::context::CommandContext) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     if let Some((id, snap)) = client.tx_snapshot() {
         Ok(json!({
             "status": "active",

--- a/src/commands/window.rs
+++ b/src/commands/window.rs
@@ -118,8 +118,8 @@ lazy_static::lazy_static! {
 ///   "ADE Explorer Editing: LIB/CELL/maestro"
 ///   "ADE Explorer Reading: ..."
 ///   "Virtuoso Schematic Editor"
-pub fn list() -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn list(ctx: &crate::context::CommandContext) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     let r = client.execute_skill(&client.window.list_windows(), None)?;
     if !r.skill_ok() {
         return Err(VirtuosoError::Execution(format!(
@@ -142,8 +142,12 @@ pub fn list() -> Result<Value> {
 /// When `use_x11` is true, the call goes through the X11 SSH bypass
 /// (`transport::x11::dismiss`) instead of SKILL. This is the only path
 /// that works when a modal has deadlocked the SKILL channel itself.
-pub fn dismiss_dialog(action: &str, dry_run: bool) -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn dismiss_dialog(
+    ctx: &crate::context::CommandContext,
+    action: &str,
+    dry_run: bool,
+) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     if dry_run {
         let r = client.execute_skill(&client.window.get_dialog_info(), None)?;
         let raw = r.output.trim_matches('"');
@@ -167,16 +171,18 @@ pub fn dismiss_dialog(action: &str, dry_run: bool) -> Result<Value> {
 /// Useful as a "dry-run" alternative when SKILL is deadlocked and you want
 /// to see what dialogs are present before deciding which action to send.
 /// Works locally when VB_REMOTE_HOST is absent, otherwise via SSH.
-pub fn list_dialogs_x11(explicit_display: Option<&str>) -> Result<Value> {
-    use crate::config::Config;
+pub fn list_dialogs_x11(
+    ctx: &crate::context::CommandContext,
+    explicit_display: Option<&str>,
+) -> Result<Value> {
     use crate::transport::x11;
 
-    let config = Config::from_env()?;
-    let runner = x11::transport_for_config(&config)?;
+    let config = ctx.config();
+    let runner = x11::transport_for_config(config)?;
     let user = config.remote_user.as_deref();
     let (env, dialogs) = x11::list_dialogs(
         runner.as_ref(),
-        &x11::client_id_for(&config),
+        &x11::client_id_for(config),
         user,
         explicit_display,
     )?;
@@ -199,12 +205,12 @@ pub fn list_dialogs_x11(explicit_display: Option<&str>) -> Result<Value> {
 /// Adopted from <https://github.com/Arcadia-1/virtuoso-bridge-lite>
 /// (MIT, 2026-05; helper vendored in resources/x11_dismiss_dialog.py).
 pub fn dismiss_dialog_x11(
+    ctx: &crate::context::CommandContext,
     action: &str,
     dry_run: bool,
     explicit_display: Option<&str>,
     window_id: Option<&str>,
 ) -> Result<Value> {
-    use crate::config::Config;
     use crate::transport::x11;
 
     if !["enter", "escape", "alt-y", "alt-n", "alt-o"].contains(&action) {
@@ -213,12 +219,12 @@ pub fn dismiss_dialog_x11(
             action
         )));
     }
-    let config = Config::from_env()?;
-    let runner = x11::transport_for_config(&config)?;
+    let config = ctx.config();
+    let runner = x11::transport_for_config(config)?;
     let user = config.remote_user.as_deref();
     let result = x11::dismiss(
         runner.as_ref(),
-        &x11::client_id_for(&config),
+        &x11::client_id_for(config),
         user,
         explicit_display,
         action,
@@ -255,16 +261,18 @@ pub fn dismiss_dialog_x11(
 /// along with its WM frame and dismiss id. Use this when you want to see
 /// what's on screen before picking a target. Works locally when VB_REMOTE_HOST
 /// is absent.
-pub fn list_windows_x11(explicit_display: Option<&str>) -> Result<Value> {
-    use crate::config::Config;
+pub fn list_windows_x11(
+    ctx: &crate::context::CommandContext,
+    explicit_display: Option<&str>,
+) -> Result<Value> {
     use crate::transport::x11;
 
-    let config = Config::from_env()?;
-    let runner = x11::transport_for_config(&config)?;
+    let config = ctx.config();
+    let runner = x11::transport_for_config(config)?;
     let user = config.remote_user.as_deref();
     let (env, windows) = x11::list_windows(
         runner.as_ref(),
-        &x11::client_id_for(&config),
+        &x11::client_id_for(config),
         user,
         explicit_display,
     )?;
@@ -282,16 +290,16 @@ pub fn list_windows_x11(explicit_display: Option<&str>) -> Result<Value> {
 /// (typically an X resource id like `0x2e01f16`). Works locally when VB_REMOTE_HOST
 /// is absent.
 pub fn dismiss_window_x11(
+    ctx: &crate::context::CommandContext,
     window_id: Option<&str>,
     pid: Option<u32>,
     action: &str,
     explicit_display: Option<&str>,
 ) -> Result<Value> {
-    use crate::config::Config;
     use crate::transport::x11;
 
-    let config = Config::from_env()?;
-    let runner = x11::transport_for_config(&config)?;
+    let config = ctx.config();
+    let runner = x11::transport_for_config(config)?;
     let user = config.remote_user.as_deref();
 
     // Resolve the target window id. Precedence: explicit --window-id (or the
@@ -305,7 +313,7 @@ pub fn dismiss_window_x11(
             // to discover dismiss_ids.
             let (_env, windows) = x11::list_windows(
                 runner.as_ref(),
-                &x11::client_id_for(&config),
+                &x11::client_id_for(config),
                 user,
                 explicit_display,
             )?;
@@ -334,7 +342,7 @@ pub fn dismiss_window_x11(
 
     let result = x11::dismiss_window(
         runner.as_ref(),
-        &x11::client_id_for(&config),
+        &x11::client_id_for(config),
         user,
         explicit_display,
         &id,
@@ -366,8 +374,12 @@ pub fn dismiss_window_x11(
 /// Capture a screenshot of the current (or pattern-matched) Virtuoso window.
 ///
 /// Saves to --path as PNG. Requires IC23.1+ (hiGetWindowScreenDump).
-pub fn screenshot(path: &str, window_pattern: Option<&str>) -> Result<Value> {
-    let client = VirtuosoClient::from_env()?;
+pub fn screenshot(
+    ctx: &crate::context::CommandContext,
+    path: &str,
+    window_pattern: Option<&str>,
+) -> Result<Value> {
+    let client = VirtuosoClient::from_context(ctx)?;
     let skill = match window_pattern {
         Some(pat) => client.window.screenshot_by_pattern(path, pat),
         None => client.window.screenshot(path),
@@ -402,6 +414,7 @@ pub fn screenshot(path: &str, window_pattern: Option<&str>) -> Result<Value> {
 /// It validates parameters, calls the transport layer, and returns structured JSON.
 #[allow(clippy::too_many_arguments)]
 pub fn action_x11(
+    ctx: &crate::context::CommandContext,
     window_id: &str,
     pid: Option<u32>,
     display: &str,
@@ -415,7 +428,6 @@ pub fn action_x11(
     explicit_display: Option<&str>,
     direct: bool,
 ) -> Result<Value> {
-    use crate::config::Config;
     use crate::transport::x11;
 
     let op = x11::X11Operation::from_str(operation)?;
@@ -423,12 +435,12 @@ pub fn action_x11(
         window_id, pid, display, operation, x, y, text, button, output_dir,
     )?;
 
-    let config = Config::from_env()?;
-    let runner: Arc<dyn RemoteTransport> = x11::transport_for_config(&config)?;
+    let config = ctx.config();
+    let runner: Arc<dyn RemoteTransport> = x11::transport_for_config(config)?;
     let user = config.remote_user.as_deref();
     let actual_display = explicit_display.unwrap_or(display);
 
-    let client_id = x11::client_id_for(&config);
+    let client_id = x11::client_id_for(config);
     let inputs = x11::ActionX11Inputs {
         window_id,
         pid,
@@ -458,6 +470,7 @@ pub fn action_x11(
 /// scan for maximum throughput.
 #[allow(clippy::too_many_arguments)]
 pub fn action_x11_batch(
+    ctx: &crate::context::CommandContext,
     file_path: &str,
     direct: bool,
     default_pid: Option<u32>,
@@ -465,7 +478,6 @@ pub fn action_x11_batch(
     explicit_display: Option<&str>,
     timeout_secs: u64,
 ) -> Result<Value> {
-    use crate::config::Config;
     use crate::transport::x11;
     use std::io::{BufRead, BufReader};
 
@@ -492,10 +504,10 @@ pub fn action_x11_batch(
         ));
     }
 
-    let config = Config::from_env()?;
-    let runner: Arc<dyn RemoteTransport> = x11::transport_for_config(&config)?;
+    let config = ctx.config();
+    let runner: Arc<dyn RemoteTransport> = x11::transport_for_config(config)?;
     let user = config.remote_user.as_deref();
-    let client_id = x11::client_id_for(&config);
+    let client_id = x11::client_id_for(config);
     let effective_default_display = explicit_display.or(default_display);
 
     let batch_inputs = x11::BatchX11Inputs {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2120,33 +2120,39 @@ fn parse_bind_scope(
     }
 }
 
-fn dispatch_skill(cmd: SkillCmd) -> error::Result<serde_json::Value> {
+fn dispatch_skill(
+    cmd: SkillCmd,
+    ctx: &crate::context::CommandContext,
+) -> error::Result<serde_json::Value> {
     match cmd {
         SkillCmd::Exec {
             code,
             timeout,
             readonly,
-        } => commands::skill::exec(&code, timeout, readonly),
-        SkillCmd::Load { file, skillpp } => commands::skill::load(&file, skillpp),
+        } => commands::skill::exec(ctx, &code, timeout, readonly),
+        SkillCmd::Load { file, skillpp } => commands::skill::load(ctx, &file, skillpp),
         SkillCmd::Broadcast { code, timeout } => commands::skill::broadcast(&code, timeout),
-        SkillCmd::Eval { code, stdin } => commands::skill::eval(code, stdin),
+        SkillCmd::Eval { code, stdin } => commands::skill::eval(ctx, code, stdin),
         SkillCmd::Find {
             query,
             mode,
             limit,
             include_desc,
-        } => commands::skill::find(&query, &mode, limit, false, include_desc),
-        SkillCmd::Info { func } => commands::skill::info(&func),
+        } => commands::skill::find(ctx, &query, &mode, limit, false, include_desc),
+        SkillCmd::Info { func } => commands::skill::info(ctx, &func),
         SkillCmd::Sync {
             host,
             cshrc,
             verbose,
-        } => commands::skill::sync_cache(host.as_deref(), cshrc.as_deref(), verbose),
-        SkillCmd::Cache { host, clear } => commands::skill::show_cache(host.as_deref(), clear),
+        } => commands::skill::sync_cache(ctx, host.as_deref(), cshrc.as_deref(), verbose),
+        SkillCmd::Cache { host, clear } => commands::skill::show_cache(ctx, host.as_deref(), clear),
     }
 }
 
-fn dispatch_cell(cmd: CellCmd) -> error::Result<serde_json::Value> {
+fn dispatch_cell(
+    cmd: CellCmd,
+    ctx: &crate::context::CommandContext,
+) -> error::Result<serde_json::Value> {
     match cmd {
         CellCmd::Open {
             lib,
@@ -2154,10 +2160,10 @@ fn dispatch_cell(cmd: CellCmd) -> error::Result<serde_json::Value> {
             view,
             mode,
             dry_run,
-        } => commands::cell::open(&lib, &cell, &view, &mode, dry_run),
-        CellCmd::Save => commands::cell::save(),
-        CellCmd::Close => commands::cell::close(),
-        CellCmd::Info => commands::cell::info(),
+        } => commands::cell::open(ctx, &lib, &cell, &view, &mode, dry_run),
+        CellCmd::Save => commands::cell::save(ctx),
+        CellCmd::Close => commands::cell::close(ctx),
+        CellCmd::Info => commands::cell::info(ctx),
     }
 }
 
@@ -2473,14 +2479,17 @@ fn dispatch_schematic(cmd: SchematicCmd) -> error::Result<serde_json::Value> {
     }
 }
 
-fn dispatch_symbol(cmd: SymbolCmd) -> error::Result<serde_json::Value> {
+fn dispatch_symbol(
+    cmd: SymbolCmd,
+    ctx: &crate::context::CommandContext,
+) -> error::Result<serde_json::Value> {
     match cmd {
         SymbolCmd::Inspect {
             lib,
             cell,
             view,
             view_type,
-        } => commands::symbol::inspect(&lib, &cell, &view, &view_type),
+        } => commands::symbol::inspect(ctx, &lib, &cell, &view, &view_type),
         SymbolCmd::Generate {
             lib,
             cell,
@@ -2488,6 +2497,7 @@ fn dispatch_symbol(cmd: SymbolCmd) -> error::Result<serde_json::Value> {
             symbol_view,
             sort_pins,
         } => commands::symbol::generate(
+            ctx,
             &lib,
             &cell,
             &schematic_view,
@@ -2497,9 +2507,12 @@ fn dispatch_symbol(cmd: SymbolCmd) -> error::Result<serde_json::Value> {
     }
 }
 
-fn dispatch_window(cmd: WindowCmd) -> error::Result<serde_json::Value> {
+fn dispatch_window(
+    cmd: WindowCmd,
+    ctx: &crate::context::CommandContext,
+) -> error::Result<serde_json::Value> {
     match cmd {
-        WindowCmd::List => commands::window::list(),
+        WindowCmd::List => commands::window::list(ctx),
         WindowCmd::DismissDialog {
             action,
             dry_run,
@@ -2509,20 +2522,21 @@ fn dispatch_window(cmd: WindowCmd) -> error::Result<serde_json::Value> {
         } => {
             if x11 {
                 commands::window::dismiss_dialog_x11(
+                    ctx,
                     &action,
                     dry_run,
                     display.as_deref(),
                     window_id.as_deref(),
                 )
             } else {
-                commands::window::dismiss_dialog(&action, dry_run)
+                commands::window::dismiss_dialog(ctx, &action, dry_run)
             }
         }
         WindowCmd::ListDialogsX11 { display } => {
-            commands::window::list_dialogs_x11(display.as_deref())
+            commands::window::list_dialogs_x11(ctx, display.as_deref())
         }
         WindowCmd::ListWindowsX11 { display } => {
-            commands::window::list_windows_x11(display.as_deref())
+            commands::window::list_windows_x11(ctx, display.as_deref())
         }
         WindowCmd::DismissWindowX11 {
             window_id,
@@ -2531,13 +2545,14 @@ fn dispatch_window(cmd: WindowCmd) -> error::Result<serde_json::Value> {
             action,
             display,
         } => commands::window::dismiss_window_x11(
+            ctx,
             window_id.as_deref().or(window_id_pos.as_deref()),
             pid,
             &action,
             display.as_deref(),
         ),
         WindowCmd::Screenshot { path, window } => {
-            commands::window::screenshot(&path, window.as_deref())
+            commands::window::screenshot(ctx, &path, window.as_deref())
         }
         WindowCmd::ActionX11 {
             window_id,
@@ -2553,6 +2568,7 @@ fn dispatch_window(cmd: WindowCmd) -> error::Result<serde_json::Value> {
             display_override,
             direct,
         } => commands::window::action_x11(
+            ctx,
             &window_id,
             pid,
             &display,
@@ -2574,6 +2590,7 @@ fn dispatch_window(cmd: WindowCmd) -> error::Result<serde_json::Value> {
             display_override,
             timeout,
         } => commands::window::action_x11_batch(
+            ctx,
             &file,
             direct,
             pid,
@@ -2590,18 +2607,21 @@ fn dispatch_diag(cmd: DiagCmd) -> error::Result<serde_json::Value> {
     }
 }
 
-fn dispatch_tx(cmd: TxCmd) -> error::Result<serde_json::Value> {
+fn dispatch_tx(
+    cmd: TxCmd,
+    ctx: &crate::context::CommandContext,
+) -> error::Result<serde_json::Value> {
     match cmd {
         TxCmd::Begin {
             id,
             lib,
             cell,
             view,
-        } => commands::transaction::begin(&id, &lib, &cell, &view),
-        TxCmd::Commit => commands::transaction::commit(),
-        TxCmd::Rollback => commands::transaction::rollback(),
-        TxCmd::Diff => commands::transaction::diff(),
-        TxCmd::Status => commands::transaction::status(),
+        } => commands::transaction::begin(ctx, &id, &lib, &cell, &view),
+        TxCmd::Commit => commands::transaction::commit(ctx),
+        TxCmd::Rollback => commands::transaction::rollback(ctx),
+        TxCmd::Diff => commands::transaction::diff(ctx),
+        TxCmd::Status => commands::transaction::status(ctx),
     }
 }
 
@@ -2817,15 +2837,15 @@ fn main() {
                 dispatch_profile(cmd, cli.profile.clone())
             }
         }
-        Commands::Skill(cmd) => dispatch_skill(cmd),
-        Commands::Cell(cmd) => dispatch_cell(cmd),
+        Commands::Skill(cmd) => dispatch_skill(cmd, ctx.as_ref().unwrap()),
+        Commands::Cell(cmd) => dispatch_cell(cmd, ctx.as_ref().unwrap()),
         Commands::Sim(cmd) => dispatch_sim(cmd, ctx.as_ref().unwrap()),
         Commands::Process(cmd) => dispatch_process(cmd, ctx.as_ref().unwrap()),
         Commands::Design(cmd) => dispatch_design(cmd, format),
         Commands::Maestro(cmd) => dispatch_maestro(cmd),
         Commands::Schematic(cmd) => dispatch_schematic(cmd),
-        Commands::Symbol(cmd) => dispatch_symbol(cmd),
-        Commands::Library(LibraryCmd::List) => commands::library::list(),
+        Commands::Symbol(cmd) => dispatch_symbol(cmd, ctx.as_ref().unwrap()),
+        Commands::Library(LibraryCmd::List) => commands::library::list(ctx.as_ref().unwrap()),
         Commands::Session(cmd) => match cmd {
             SessionCmd::List => commands::session::list(ctx.as_ref().unwrap(), format),
             SessionCmd::Show { id } => commands::session::show(ctx.as_ref().unwrap(), &id, format),
@@ -2849,9 +2869,9 @@ fn main() {
                 }
             }
         },
-        Commands::Tx(cmd) => dispatch_tx(cmd),
+        Commands::Tx(cmd) => dispatch_tx(cmd, ctx.as_ref().unwrap()),
         Commands::Rpc(cmd) => dispatch_rpc(cmd),
-        Commands::Window(cmd) => dispatch_window(cmd),
+        Commands::Window(cmd) => dispatch_window(cmd, ctx.as_ref().unwrap()),
         Commands::Diag(cmd) => dispatch_diag(cmd),
         Commands::Schema { all, noun, verb } => {
             let schema = if all || noun.is_none() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2633,7 +2633,10 @@ fn dispatch_tx(
 /// `ctx` carries the already-resolved config (and target_id if any) from the
 /// selection layer — the dispatcher and client reuse it instead of re‑reading
 /// env, so `--target prod rpc call …` exercises the prod target.
-fn dispatch_rpc(cmd: RpcCmd, ctx: &crate::context::CommandContext) -> error::Result<serde_json::Value> {
+fn dispatch_rpc(
+    cmd: RpcCmd,
+    ctx: &crate::context::CommandContext,
+) -> error::Result<serde_json::Value> {
     match cmd {
         RpcCmd::Call { method, params } => {
             let params: serde_json::Value =

--- a/src/main.rs
+++ b/src/main.rs
@@ -2638,7 +2638,8 @@ fn dispatch_rpc(cmd: RpcCmd) -> error::Result<serde_json::Value> {
                 params,
                 api_key,
             };
-            crate::rpc::dispatcher::RpcDispatcher::dispatch(&client, request)
+            let ctx = crate::context::CommandContext::new(crate::config::Config::from_env()?, None)?;
+            crate::rpc::dispatcher::RpcDispatcher::new(ctx).dispatch(&client, request)
         }
         RpcCmd::Schema => {
             let schema = standard_schema();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2161,7 +2161,10 @@ fn dispatch_cell(cmd: CellCmd) -> error::Result<serde_json::Value> {
     }
 }
 
-fn dispatch_sim(cmd: SimCmd) -> error::Result<serde_json::Value> {
+fn dispatch_sim(
+    cmd: SimCmd,
+    ctx: &crate::context::CommandContext,
+) -> error::Result<serde_json::Value> {
     match cmd {
         SimCmd::Setup {
             lib,
@@ -2216,7 +2219,7 @@ fn dispatch_sim(cmd: SimCmd) -> error::Result<serde_json::Value> {
             recreate,
             with_analysis,
         } => commands::sim::netlist(&lib, &cell, &view, recreate, &with_analysis),
-        SimCmd::RunAsync { netlist } => commands::sim::run_async(&netlist),
+        SimCmd::RunAsync { netlist } => commands::sim::run_async(ctx, &netlist),
         SimCmd::JobStatus { id } => commands::sim::job_status(&id),
         SimCmd::JobList => commands::sim::job_list(),
         SimCmd::JobCancel { id } => commands::sim::job_cancel(&id),
@@ -2251,13 +2254,16 @@ fn dispatch_sim(cmd: SimCmd) -> error::Result<serde_json::Value> {
                     }
                 })
                 .collect();
-            commands::sim::run_parallel(&parsed)
+            commands::sim::run_parallel(ctx, &parsed)
         }
         SimCmd::CheckLicense => commands::sim::check_license(),
     }
 }
 
-fn dispatch_process(cmd: ProcessCmd) -> error::Result<serde_json::Value> {
+fn dispatch_process(
+    cmd: ProcessCmd,
+    ctx: &crate::context::CommandContext,
+) -> error::Result<serde_json::Value> {
     match cmd {
         ProcessCmd::Char {
             lib,
@@ -2298,6 +2304,7 @@ fn dispatch_process(cmd: ProcessCmd) -> error::Result<serde_json::Value> {
                     }
                 });
                 commands::process::char_netlist(
+                    ctx,
                     &r#type,
                     &l_vals,
                     vgs_start,
@@ -2313,8 +2320,8 @@ fn dispatch_process(cmd: ProcessCmd) -> error::Result<serde_json::Value> {
                 )
             } else {
                 commands::process::char(
-                    &lib, &cell, &view, &inst, &r#type, &l_vals, vgs_start, vgs_stop, vgs_step,
-                    &output, timeout,
+                    ctx, &lib, &cell, &view, &inst, &r#type, &l_vals, vgs_start, vgs_stop,
+                    vgs_step, &output, timeout,
                 )
             }
         }
@@ -2812,8 +2819,8 @@ fn main() {
         }
         Commands::Skill(cmd) => dispatch_skill(cmd),
         Commands::Cell(cmd) => dispatch_cell(cmd),
-        Commands::Sim(cmd) => dispatch_sim(cmd),
-        Commands::Process(cmd) => dispatch_process(cmd),
+        Commands::Sim(cmd) => dispatch_sim(cmd, ctx.as_ref().unwrap()),
+        Commands::Process(cmd) => dispatch_process(cmd, ctx.as_ref().unwrap()),
         Commands::Design(cmd) => dispatch_design(cmd, format),
         Commands::Maestro(cmd) => dispatch_maestro(cmd),
         Commands::Schematic(cmd) => dispatch_schematic(cmd),

--- a/src/main.rs
+++ b/src/main.rs
@@ -2601,9 +2601,12 @@ fn dispatch_window(
     }
 }
 
-fn dispatch_diag(cmd: DiagCmd) -> error::Result<serde_json::Value> {
+fn dispatch_diag(
+    cmd: DiagCmd,
+    ctx: &crate::context::CommandContext,
+) -> error::Result<serde_json::Value> {
     match cmd {
-        DiagCmd::Cdslck { lib, view } => commands::diag::cdslck(&lib, view.as_deref()),
+        DiagCmd::Cdslck { lib, view } => commands::diag::cdslck(ctx, &lib, view.as_deref()),
     }
 }
 
@@ -2625,12 +2628,19 @@ fn dispatch_tx(
     }
 }
 
-fn dispatch_rpc(cmd: RpcCmd) -> error::Result<serde_json::Value> {
+/// Execute an RPC call.
+///
+/// `ctx` carries the already-resolved config (and target_id if any) from the
+/// selection layer — the dispatcher and client reuse it instead of re‑reading
+/// env, so `--target prod rpc call …` exercises the prod target.
+fn dispatch_rpc(cmd: RpcCmd, ctx: &crate::context::CommandContext) -> error::Result<serde_json::Value> {
     match cmd {
         RpcCmd::Call { method, params } => {
             let params: serde_json::Value =
                 serde_json::from_str(&params).map_err(crate::error::VirtuosoError::Json)?;
-            let client = crate::client::bridge::VirtuosoClient::from_env()?;
+            // Build the session‑bound client from the SAME resolved context so
+            // target identity (client_id, session‑binding) is preserved.
+            let client = crate::client::bridge::VirtuosoClient::from_context(ctx)?;
             // Read API key from environment if set (VCLI_API_KEY)
             let api_key = std::env::var("VCLI_API_KEY").ok().filter(|k| !k.is_empty());
             let request = crate::rpc::dispatcher::RpcRequest {
@@ -2638,8 +2648,7 @@ fn dispatch_rpc(cmd: RpcCmd) -> error::Result<serde_json::Value> {
                 params,
                 api_key,
             };
-            let ctx = crate::context::CommandContext::new(crate::config::Config::from_env()?, None)?;
-            crate::rpc::dispatcher::RpcDispatcher::new(ctx).dispatch(&client, request)
+            crate::rpc::dispatcher::RpcDispatcher::new(ctx.clone()).dispatch(&client, request)
         }
         RpcCmd::Schema => {
             let schema = standard_schema();
@@ -2871,9 +2880,9 @@ fn main() {
             }
         },
         Commands::Tx(cmd) => dispatch_tx(cmd, ctx.as_ref().unwrap()),
-        Commands::Rpc(cmd) => dispatch_rpc(cmd),
+        Commands::Rpc(cmd) => dispatch_rpc(cmd, ctx.as_ref().unwrap()),
         Commands::Window(cmd) => dispatch_window(cmd, ctx.as_ref().unwrap()),
-        Commands::Diag(cmd) => dispatch_diag(cmd),
+        Commands::Diag(cmd) => dispatch_diag(cmd, ctx.as_ref().unwrap()),
         Commands::Schema { all, noun, verb } => {
             let schema = if all || noun.is_none() {
                 commands::schema::show(None, None)

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -195,6 +195,8 @@ impl McpServer {
             params: arguments,
             api_key,
         };
-        crate::rpc::dispatcher::RpcDispatcher::dispatch(&client, request)
+        let ctx =
+            crate::context::CommandContext::new(crate::config::Config::from_env()?, None)?;
+        crate::rpc::dispatcher::RpcDispatcher::new(ctx).dispatch(&client, request)
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -82,16 +82,19 @@ pub struct McpServer {
     #[allow(dead_code)]
     config: McpConfig,
     tools: Vec<tools::McpTool>,
+    /// Config + target identity. Held here so call_tool can pass it through to
+    /// the RPC dispatcher instead of re-reading env with no target context.
+    ctx: crate::context::CommandContext,
 }
 
 impl McpServer {
-    pub fn new(config: McpConfig) -> Self {
+    pub fn new(config: McpConfig, ctx: crate::context::CommandContext) -> Self {
         let mut tools = tools::all_tools(&config.capabilities);
         // Merge in plugin tools if any
         if let Ok(registry) = super::plugins::PluginRegistry::get_global() {
             tools.extend(registry.mcp_tools());
         }
-        Self { config, tools }
+        Self { config, tools, ctx }
     }
 
     /// Run the MCP stdio loop.
@@ -188,15 +191,13 @@ impl McpServer {
         tool: &tools::McpTool,
         arguments: serde_json::Value,
     ) -> Result<serde_json::Value> {
-        let client = VirtuosoClient::from_env()?;
+        let client = VirtuosoClient::from_context(&self.ctx)?;
         let api_key = std::env::var("VCLI_API_KEY").ok().filter(|k| !k.is_empty());
         let request = crate::rpc::dispatcher::RpcRequest {
             method: tool.rpc_method.to_string(),
             params: arguments,
             api_key,
         };
-        let ctx =
-            crate::context::CommandContext::new(crate::config::Config::from_env()?, None)?;
-        crate::rpc::dispatcher::RpcDispatcher::new(ctx).dispatch(&client, request)
+        crate::rpc::dispatcher::RpcDispatcher::new(self.ctx.clone()).dispatch(&client, request)
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -9,6 +9,7 @@ use crate::error::Result;
 pub fn run() -> Result<()> {
     crate::auth::Auth::init();
     let config = crate::mcp::McpConfig::from_env();
-    let server = crate::mcp::McpServer::new(config);
+    let ctx = crate::context::CommandContext::new(crate::config::Config::from_env()?, None)?;
+    let server = crate::mcp::McpServer::new(config, ctx);
     server.run()
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -9,7 +9,20 @@ use crate::error::Result;
 pub fn run() -> Result<()> {
     crate::auth::Auth::init();
     let config = crate::mcp::McpConfig::from_env();
-    let ctx = crate::context::CommandContext::new(crate::config::Config::from_env()?, None)?;
+    // Resolve the active target via the canonical selection path so the MCP
+    // server inherits the same target identity as any other CLI invocation —
+    // NOT a bare env-only Config that ignores targets.yaml.
+    let selection = crate::target::resolve::resolve_selection(None, None).map_err(|e| {
+        crate::error::VirtuosoError::Config(format!(
+            "MCP server failed to resolve target selection: {e}"
+        ))
+    })?;
+    let resolved = crate::target::resolve::resolve_from_selection(selection).map_err(|e| {
+        crate::error::VirtuosoError::Config(format!(
+            "MCP server failed to resolve target: {e}"
+        ))
+    })?;
+    let ctx = crate::context::CommandContext::from_resolved(&resolved)?;
     let server = crate::mcp::McpServer::new(config, ctx);
     server.run()
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -18,11 +18,121 @@ pub fn run() -> Result<()> {
         ))
     })?;
     let resolved = crate::target::resolve::resolve_from_selection(selection).map_err(|e| {
-        crate::error::VirtuosoError::Config(format!(
-            "MCP server failed to resolve target: {e}"
-        ))
+        crate::error::VirtuosoError::Config(format!("MCP server failed to resolve target: {e}"))
     })?;
     let ctx = crate::context::CommandContext::from_resolved(&resolved)?;
     let server = crate::mcp::McpServer::new(config, ctx);
     server.run()
+}
+
+#[cfg(test)]
+mod tests {
+    struct EnvGuard {
+        vars: Vec<(String, Option<std::ffi::OsString>)>,
+    }
+
+    impl EnvGuard {
+        fn new(keys: &[&str]) -> Self {
+            let mut vars = Vec::new();
+            for k in keys {
+                vars.push((k.to_string(), std::env::var_os(k)));
+                std::env::remove_var(k);
+            }
+            Self { vars }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (k, v) in self.vars.drain(..) {
+                match v {
+                    Some(val) => std::env::set_var(&k, val),
+                    None => std::env::remove_var(&k),
+                }
+            }
+        }
+    }
+
+    /// Regression: MCP entry must inherit the active target from targets.yaml
+    /// via the canonical selection chain — NOT fall back to a bare env-only
+    /// Config that silently drops target identity.
+    #[test]
+    #[serial_test::serial]
+    fn mcp_selection_chain_inherits_active_target_from_targets_yaml() {
+        let _env = EnvGuard::new(&[
+            "VB_TARGETS_FILE",
+            "VB_TARGET",
+            "VB_PROFILE",
+            "VB_CONFIG_DIR",
+            "VB_REMOTE_HOST",
+        ]);
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let targets_path = tmp.path().join("targets.yaml");
+        std::fs::write(
+            &targets_path,
+            "active_target: prod\n\
+             targets:\n  \
+               prod:\n    \
+                 remote_host: eda-prod\n    \
+                 port: 65535\n",
+        )
+        .expect("write targets.yaml");
+        std::env::set_var("VB_TARGETS_FILE", &targets_path);
+
+        // Replicate the exact selection chain mcp::server::run() uses.
+        let selection = crate::target::resolve::resolve_selection(None, None)
+            .expect("resolve_selection should succeed with valid active_target");
+        let resolved = crate::target::resolve::resolve_from_selection(selection)
+            .expect("resolve_from_selection should succeed");
+        let ctx = crate::context::CommandContext::from_resolved(&resolved)
+            .expect("from_resolved should succeed");
+
+        assert_eq!(
+            ctx.target_id(),
+            Some("prod"),
+            "MCP context must carry the active_target identity from targets.yaml"
+        );
+        assert_eq!(
+            ctx.config().remote_host.as_deref(),
+            Some("eda-prod"),
+            "MCP config must reflect the active target's remote_host"
+        );
+    }
+
+    /// Regression: a broken active_target must make the MCP selection chain
+    /// fail — not silently degrade to an env-only Config with no target.
+    #[test]
+    #[serial_test::serial]
+    fn mcp_selection_chain_fails_on_broken_active_target() {
+        let _env = EnvGuard::new(&[
+            "VB_TARGETS_FILE",
+            "VB_TARGET",
+            "VB_PROFILE",
+            "VB_CONFIG_DIR",
+            "VB_REMOTE_HOST",
+        ]);
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let targets_path = tmp.path().join("targets.yaml");
+        std::fs::write(
+            &targets_path,
+            "active_target: does-not-exist\n\
+             targets:\n  \
+               prod:\n    \
+                 remote_host: eda-prod\n",
+        )
+        .expect("write targets.yaml");
+        std::env::set_var("VB_TARGETS_FILE", &targets_path);
+
+        // resolve_selection itself validates that active_target exists in
+        // the targets map — it fails early rather than returning a
+        // Selection that resolve_from_selection would later reject.
+        let result = crate::target::resolve::resolve_selection(None, None);
+        assert!(
+            result.is_err(),
+            "resolve_selection must fail when active_target is missing, \
+             so MCP cannot silently run with no target identity"
+        );
+    }
 }

--- a/src/rpc/dispatcher.rs
+++ b/src/rpc/dispatcher.rs
@@ -6,6 +6,7 @@
 use crate::auth::{check_auth, log_rpc};
 use crate::client::bridge::{escape_skill_string, VirtuosoClient};
 use crate::commands;
+use crate::context::CommandContext;
 use crate::error::{Result, VirtuosoError};
 use crate::models::VirtuosoResult;
 use once_cell::sync::Lazy;
@@ -139,32 +140,36 @@ impl RpcDispatcher {
 
         match domain {
             "schematic" => Self::dispatch_schematic(client, op, params),
-            "symbol" => match op {
-                "inspect" => {
-                    let lib = json_str(params.get("lib"), "lib")?;
-                    let cell = json_str(params.get("cell"), "cell")?;
-                    let view = json_str_or(params.get("view"), "symbol")?;
-                    let view_type = json_str_or(params.get("view_type"), "schematicSymbol")?;
-                    crate::commands::symbol::inspect(&lib, &cell, &view, &view_type)
+            "symbol" => {
+                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                match op {
+                    "inspect" => {
+                        let lib = json_str(params.get("lib"), "lib")?;
+                        let cell = json_str(params.get("cell"), "cell")?;
+                        let view = json_str_or(params.get("view"), "symbol")?;
+                        let view_type = json_str_or(params.get("view_type"), "schematicSymbol")?;
+                        crate::commands::symbol::inspect(&ctx, &lib, &cell, &view, &view_type)
+                    }
+                    "generate" => {
+                        let lib = json_str(params.get("lib"), "lib")?;
+                        let cell = json_str(params.get("cell"), "cell")?;
+                        let src = json_str_or(params.get("schematic_view"), "schematic")?;
+                        let dst = json_str_or(params.get("symbol_view"), "symbol")?;
+                        let sort = params.get("sort_pins").and_then(Value::as_str);
+                        crate::commands::symbol::generate(&ctx, &lib, &cell, &src, &dst, sort)
+                    }
+                    _ => Err(VirtuosoError::NotFound(format!(
+                        "unknown symbol method '{op}'"
+                    ))),
                 }
-                "generate" => {
-                    let lib = json_str(params.get("lib"), "lib")?;
-                    let cell = json_str(params.get("cell"), "cell")?;
-                    let src = json_str_or(params.get("schematic_view"), "schematic")?;
-                    let dst = json_str_or(params.get("symbol_view"), "symbol")?;
-                    let sort = params.get("sort_pins").and_then(Value::as_str);
-                    crate::commands::symbol::generate(&lib, &cell, &src, &dst, sort)
-                }
-                _ => Err(VirtuosoError::NotFound(format!(
-                    "unknown symbol method '{op}'"
-                ))),
-            },
+            }
             "library" => match op {
                 "list"
                     if params.is_null()
                         || params.as_object().map(|m| m.is_empty()).unwrap_or(false) =>
                 {
-                    crate::commands::library::list()
+                    let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                    crate::commands::library::list(&ctx)
                 }
                 _ => Err(VirtuosoError::NotFound(format!(
                     "unknown library method '{op}'"
@@ -589,14 +594,18 @@ impl RpcDispatcher {
                     .unwrap_or(false);
                 let display = params.get("display").and_then(|v| v.as_str());
                 let window_id = params.get("window_id").and_then(|v| v.as_str());
-                crate::commands::window::dismiss_dialog_x11(&action, dry_run, display, window_id)
+                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                crate::commands::window::dismiss_dialog_x11(
+                    &ctx, &action, dry_run, window_id, display,
+                )
             }
             "list_windows_x11" => {
                 // Enumerate every Virtuoso-related X11 window (no keypress).
                 // Returns { display, windows, count }. Use the `dismiss_id`
                 // from each entry to feed `dismiss_window_x11` next.
                 let display = params.get("display").and_then(|v| v.as_str());
-                crate::commands::window::list_windows_x11(display)
+                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                crate::commands::window::list_windows_x11(&ctx, display)
             }
             "dismiss_window_x11" => {
                 // Dismiss a SPECIFIC window by id (typically the dismiss_id
@@ -608,7 +617,8 @@ impl RpcDispatcher {
                 let pid = params.get("pid").and_then(|v| v.as_u64()).map(|n| n as u32);
                 let action = json_str_or(params.get("action"), "enter")?;
                 let display = params.get("display").and_then(|v| v.as_str());
-                crate::commands::window::dismiss_window_x11(window_id, pid, &action, display)
+                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                crate::commands::window::dismiss_window_x11(&ctx, window_id, pid, &action, display)
             }
             _ => Err(VirtuosoError::Execution(format!(
                 "unknown window method '{}'",
@@ -819,6 +829,7 @@ impl RpcDispatcher {
                 }))
             }
             "eval" => {
+                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
                 let code = params
                     .get("code")
                     .and_then(|v| v.as_str().map(String::from));
@@ -826,10 +837,11 @@ impl RpcDispatcher {
                     .get("stdin")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                let r = commands::skill::eval(code, stdin)?;
+                let r = commands::skill::eval(&ctx, code, stdin)?;
                 Ok(r)
             }
             "find" => {
+                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
                 let query = json_str(params.get("query"), "query")?;
                 let mode = params
                     .get("mode")
@@ -844,23 +856,26 @@ impl RpcDispatcher {
                     .get("refresh")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                commands::skill::find(&query, mode, limit, refresh, include_desc)
+                commands::skill::find(&ctx, mode, &query, limit, include_desc, refresh)
             }
             "info" => {
+                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
                 let func = json_str(params.get("func"), "func")?;
-                commands::skill::info(&func)
+                commands::skill::info(&ctx, &func)
             }
             "sync" => {
+                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
                 let host = params.get("host").and_then(|v| v.as_str());
-                commands::skill::sync_cache(host, None, false)
+                commands::skill::sync_cache(&ctx, None, host, false)
             }
             "cache" => {
+                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
                 let host = params.get("host").and_then(|v| v.as_str());
                 let clear = params
                     .get("clear")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                commands::skill::show_cache(host, clear)
+                commands::skill::show_cache(&ctx, host, clear)
             }
             _ => Err(VirtuosoError::Execution(format!(
                 "unknown skill method '{}'",

--- a/src/rpc/dispatcher.rs
+++ b/src/rpc/dispatcher.rs
@@ -94,11 +94,17 @@ pub struct RpcRequest {
     pub api_key: Option<String>,
 }
 
-pub struct RpcDispatcher;
+pub struct RpcDispatcher {
+    ctx: CommandContext,
+}
 
 impl RpcDispatcher {
+    pub fn new(ctx: CommandContext) -> Self {
+        Self { ctx }
+    }
+
     /// Dispatch a JSON-RPC request to the appropriate handler.
-    pub fn dispatch(client: &VirtuosoClient, request: RpcRequest) -> Result<Value> {
+    pub fn dispatch(&self, client: &VirtuosoClient, request: RpcRequest) -> Result<Value> {
         let RpcRequest {
             method,
             params,
@@ -116,7 +122,7 @@ impl RpcDispatcher {
             )));
         }
 
-        let result = Self::dispatch_inner(client, &method, params.clone());
+        let result = Self::dispatch_inner(self, client, &method, params.clone());
 
         // Audit log — always log, regardless of success/failure
         let result_str = match &result {
@@ -128,7 +134,7 @@ impl RpcDispatcher {
         result
     }
 
-    fn dispatch_inner(client: &VirtuosoClient, method: &str, params: Value) -> Result<Value> {
+    fn dispatch_inner(&self, client: &VirtuosoClient, method: &str, params: Value) -> Result<Value> {
         let parts: Vec<&str> = method.splitn(2, '.').collect();
         if parts.len() != 2 {
             return Err(VirtuosoError::Execution(format!(
@@ -139,9 +145,9 @@ impl RpcDispatcher {
         let (domain, op) = (parts[0], parts[1]);
 
         match domain {
-            "schematic" => Self::dispatch_schematic(client, op, params),
+            "schematic" => self.dispatch_schematic(client, op, params),
             "symbol" => {
-                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                let ctx = &self.ctx;
                 match op {
                     "inspect" => {
                         let lib = json_str(params.get("lib"), "lib")?;
@@ -168,21 +174,21 @@ impl RpcDispatcher {
                     if params.is_null()
                         || params.as_object().map(|m| m.is_empty()).unwrap_or(false) =>
                 {
-                    let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                    let ctx = &self.ctx;
                     crate::commands::library::list(&ctx)
                 }
                 _ => Err(VirtuosoError::NotFound(format!(
                     "unknown library method '{op}'"
                 ))),
             },
-            "maestro" => Self::dispatch_maestro(client, op, params),
-            "window" => Self::dispatch_window(client, op, params),
-            "cell" => Self::dispatch_cell(client, op, params),
-            "tx" => Self::dispatch_tx(client, op, params),
-            "file" => Self::dispatch_file(client, op, params),
-            "util" => Self::dispatch_util(client, op, params),
-            "skill" => Self::dispatch_skill(client, op, params),
-            "sim" => Self::dispatch_sim(client, op, params),
+            "maestro" => self.dispatch_maestro(client, op, params),
+            "window" => self.dispatch_window(client, op, params),
+            "cell" => self.dispatch_cell(client, op, params),
+            "tx" => self.dispatch_tx(client, op, params),
+            "file" => self.dispatch_file(client, op, params),
+            "util" => self.dispatch_util(client, op, params),
+            "skill" => self.dispatch_skill(client, op, params),
+            "sim" => self.dispatch_sim(client, op, params),
             _ => {
                 // Try plugin registry for unknown domains
                 match crate::plugins::PluginRegistry::get_global() {
@@ -196,7 +202,7 @@ impl RpcDispatcher {
         }
     }
 
-    fn dispatch_schematic(client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
+    fn dispatch_schematic(&self, client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
         let ops = crate::client::schematic_ops::SchematicOps::new();
         match op {
             "open_cell_view" => {
@@ -332,7 +338,7 @@ impl RpcDispatcher {
         }
     }
 
-    fn dispatch_maestro(client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
+    fn dispatch_maestro(&self, client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
         let ops = crate::client::maestro_ops::MaestroOps;
         match op {
             "open_session" => {
@@ -531,7 +537,7 @@ impl RpcDispatcher {
         }
     }
 
-    fn dispatch_window(client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
+    fn dispatch_window(&self, client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
         let ops = crate::client::window_ops::WindowOps;
         match op {
             "list" => {
@@ -594,9 +600,9 @@ impl RpcDispatcher {
                     .unwrap_or(false);
                 let display = params.get("display").and_then(|v| v.as_str());
                 let window_id = params.get("window_id").and_then(|v| v.as_str());
-                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                let ctx = &self.ctx;
                 crate::commands::window::dismiss_dialog_x11(
-                    &ctx, &action, dry_run, window_id, display,
+                    ctx, &action, dry_run, window_id, display,
                 )
             }
             "list_windows_x11" => {
@@ -604,8 +610,8 @@ impl RpcDispatcher {
                 // Returns { display, windows, count }. Use the `dismiss_id`
                 // from each entry to feed `dismiss_window_x11` next.
                 let display = params.get("display").and_then(|v| v.as_str());
-                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
-                crate::commands::window::list_windows_x11(&ctx, display)
+                let ctx = &self.ctx;
+                crate::commands::window::list_windows_x11(ctx, display)
             }
             "dismiss_window_x11" => {
                 // Dismiss a SPECIFIC window by id (typically the dismiss_id
@@ -617,8 +623,8 @@ impl RpcDispatcher {
                 let pid = params.get("pid").and_then(|v| v.as_u64()).map(|n| n as u32);
                 let action = json_str_or(params.get("action"), "enter")?;
                 let display = params.get("display").and_then(|v| v.as_str());
-                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
-                crate::commands::window::dismiss_window_x11(&ctx, window_id, pid, &action, display)
+                let ctx = &self.ctx;
+                crate::commands::window::dismiss_window_x11(ctx, window_id, pid, &action, display)
             }
             _ => Err(VirtuosoError::Execution(format!(
                 "unknown window method '{}'",
@@ -627,7 +633,7 @@ impl RpcDispatcher {
         }
     }
 
-    fn dispatch_cell(client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
+    fn dispatch_cell(&self, client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
         match op {
             "open" => {
                 let lib = json_str(params.get("lib"), "lib")?;
@@ -691,7 +697,7 @@ impl RpcDispatcher {
         }
     }
 
-    fn dispatch_tx(client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
+    fn dispatch_tx(&self, client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
         match op {
             "begin" => {
                 let id = json_str(params.get("id"), "id")?;
@@ -742,7 +748,7 @@ impl RpcDispatcher {
         }
     }
 
-    fn dispatch_file(client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
+    fn dispatch_file(&self, client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
         match op {
             "upload" => {
                 let local = json_str(params.get("local"), "local")?;
@@ -763,7 +769,7 @@ impl RpcDispatcher {
         }
     }
 
-    fn dispatch_util(client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
+    fn dispatch_util(&self, client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
         match op {
             "version" => {
                 let version = client.version()?;
@@ -811,7 +817,7 @@ impl RpcDispatcher {
         }
     }
 
-    fn dispatch_skill(client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
+    fn dispatch_skill(&self, client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
         match op {
             "exec" => {
                 // Admin capability is checked by execute_skill (not execute_skill_unchecked)
@@ -829,7 +835,7 @@ impl RpcDispatcher {
                 }))
             }
             "eval" => {
-                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                let ctx = &self.ctx;
                 let code = params
                     .get("code")
                     .and_then(|v| v.as_str().map(String::from));
@@ -837,11 +843,11 @@ impl RpcDispatcher {
                     .get("stdin")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                let r = commands::skill::eval(&ctx, code, stdin)?;
+                let r = commands::skill::eval(ctx, code, stdin)?;
                 Ok(r)
             }
             "find" => {
-                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                let ctx = &self.ctx;
                 let query = json_str(params.get("query"), "query")?;
                 let mode = params
                     .get("mode")
@@ -856,26 +862,26 @@ impl RpcDispatcher {
                     .get("refresh")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                commands::skill::find(&ctx, mode, &query, limit, include_desc, refresh)
+                commands::skill::find(ctx, mode, &query, limit, include_desc, refresh)
             }
             "info" => {
-                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                let ctx = &self.ctx;
                 let func = json_str(params.get("func"), "func")?;
-                commands::skill::info(&ctx, &func)
+                commands::skill::info(ctx, &func)
             }
             "sync" => {
-                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                let ctx = &self.ctx;
                 let host = params.get("host").and_then(|v| v.as_str());
-                commands::skill::sync_cache(&ctx, None, host, false)
+                commands::skill::sync_cache(ctx, None, host, false)
             }
             "cache" => {
-                let ctx = CommandContext::new(crate::config::Config::from_env()?, None)?;
+                let ctx = &self.ctx;
                 let host = params.get("host").and_then(|v| v.as_str());
                 let clear = params
                     .get("clear")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                commands::skill::show_cache(&ctx, host, clear)
+                commands::skill::show_cache(ctx, host, clear)
             }
             _ => Err(VirtuosoError::Execution(format!(
                 "unknown skill method '{}'",
@@ -884,7 +890,7 @@ impl RpcDispatcher {
         }
     }
 
-    fn dispatch_sim(_client: &VirtuosoClient, op: &str, _params: Value) -> Result<Value> {
+    fn dispatch_sim(&self, _client: &VirtuosoClient, op: &str, _params: Value) -> Result<Value> {
         match op {
             "check_license" => {
                 let _ = _client;

--- a/src/rpc/dispatcher.rs
+++ b/src/rpc/dispatcher.rs
@@ -134,7 +134,12 @@ impl RpcDispatcher {
         result
     }
 
-    fn dispatch_inner(&self, client: &VirtuosoClient, method: &str, params: Value) -> Result<Value> {
+    fn dispatch_inner(
+        &self,
+        client: &VirtuosoClient,
+        method: &str,
+        params: Value,
+    ) -> Result<Value> {
         let parts: Vec<&str> = method.splitn(2, '.').collect();
         if parts.len() != 2 {
             return Err(VirtuosoError::Execution(format!(
@@ -202,7 +207,12 @@ impl RpcDispatcher {
         }
     }
 
-    fn dispatch_schematic(&self, client: &VirtuosoClient, op: &str, params: Value) -> Result<Value> {
+    fn dispatch_schematic(
+        &self,
+        client: &VirtuosoClient,
+        op: &str,
+        params: Value,
+    ) -> Result<Value> {
         let ops = crate::client::schematic_ops::SchematicOps::new();
         match op {
             "open_cell_view" => {

--- a/src/rpc/dispatcher.rs
+++ b/src/rpc/dispatcher.rs
@@ -159,7 +159,7 @@ impl RpcDispatcher {
                         let cell = json_str(params.get("cell"), "cell")?;
                         let view = json_str_or(params.get("view"), "symbol")?;
                         let view_type = json_str_or(params.get("view_type"), "schematicSymbol")?;
-                        crate::commands::symbol::inspect(&ctx, &lib, &cell, &view, &view_type)
+                        crate::commands::symbol::inspect(ctx, &lib, &cell, &view, &view_type)
                     }
                     "generate" => {
                         let lib = json_str(params.get("lib"), "lib")?;
@@ -167,7 +167,7 @@ impl RpcDispatcher {
                         let src = json_str_or(params.get("schematic_view"), "schematic")?;
                         let dst = json_str_or(params.get("symbol_view"), "symbol")?;
                         let sort = params.get("sort_pins").and_then(Value::as_str);
-                        crate::commands::symbol::generate(&ctx, &lib, &cell, &src, &dst, sort)
+                        crate::commands::symbol::generate(ctx, &lib, &cell, &src, &dst, sort)
                     }
                     _ => Err(VirtuosoError::NotFound(format!(
                         "unknown symbol method '{op}'"
@@ -180,7 +180,7 @@ impl RpcDispatcher {
                         || params.as_object().map(|m| m.is_empty()).unwrap_or(false) =>
                 {
                     let ctx = &self.ctx;
-                    crate::commands::library::list(&ctx)
+                    crate::commands::library::list(ctx)
                 }
                 _ => Err(VirtuosoError::NotFound(format!(
                     "unknown library method '{op}'"

--- a/src/spectre/runner.rs
+++ b/src/spectre/runner.rs
@@ -684,8 +684,14 @@ impl SpectreOutcomeClassifier {
 }
 
 impl SpectreSimulator {
-    pub fn from_env() -> Result<Self> {
-        let cfg = crate::config::Config::from_env()?;
+    /// Construct a simulator from an already-resolved [`Config`].
+    ///
+    /// P0-A identity closure: migrated command families resolve the Config once
+    /// in `main()` and hand it down via `CommandContext`; this constructor lets
+    /// `sim run-async` / `sim run-parallel` use that pre-resolved config instead
+    /// of re-reading the environment (which could drift if env vars change
+    /// between the selection step and the command dispatch).
+    pub fn from_config(cfg: &crate::config::Config) -> Result<Self> {
         let remote = cfg.is_remote();
 
         // Built the same way it always was, then wrapped: this deliberately
@@ -695,7 +701,7 @@ impl SpectreSimulator {
         let transport = if remote {
             // OpenSSH-only lifecycle: reject an explicit `native` request so it
             // is never silently downgraded to OpenSSH.
-            crate::transport::backend::require_openssh(&cfg)?;
+            crate::transport::backend::require_openssh(cfg)?;
             let mut runner =
                 crate::transport::ssh::SSHRunner::new(cfg.remote_host.as_deref().unwrap_or(""));
             if let Some(ref user) = cfg.remote_user {
@@ -723,8 +729,8 @@ impl SpectreSimulator {
         };
 
         Ok(Self {
-            spectre_cmd: cfg.spectre_cmd,
-            spectre_args: cfg.spectre_args,
+            spectre_cmd: cfg.spectre_cmd.clone(),
+            spectre_args: cfg.spectre_args.clone(),
             timeout: cfg.timeout,
             work_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             output_format: "psfascii".into(),
@@ -734,13 +740,18 @@ impl SpectreSimulator {
             remote_work_dir: None,
             keep_remote_files: cfg.keep_remote_files,
             max_workers: cfg.spectre_max_workers,
-            cadence_cshrc: cfg.cadence_cshrc,
-            spectre_bin: cfg.spectre_bin,
+            cadence_cshrc: cfg.cadence_cshrc.clone(),
+            spectre_bin: cfg.spectre_bin.clone(),
             strict_psf: std::env::var("VB_STRICT_PSF")
                 .map(|v| v == "1" || v.to_lowercase() == "true")
                 .unwrap_or(false),
             sink: Arc::new(crate::streaming::NullSink),
         })
+    }
+
+    pub fn from_env() -> Result<Self> {
+        let cfg = crate::config::Config::from_env()?;
+        Self::from_config(&cfg)
     }
 
     pub fn with_sink(mut self, sink: Arc<dyn JobEventSink>) -> Self {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1832,6 +1832,46 @@ mod history_tests {
 
 #[cfg(test)]
 mod skill_command_tests {
+    /// Build a minimal CommandContext for tests that exercise validation
+    /// (which runs before ctx is actually used). Mirrors config_tests::make_config.
+    use crate::config::Config;
+    fn test_ctx() -> crate::context::CommandContext {
+        let cfg = Config {
+            profile: None,
+            remote_host: None,
+            remote_user: None,
+            port: 65432,
+            port_explicit: false,
+            jump_host: None,
+            jump_user: None,
+            ssh_port: None,
+            ssh_key: None,
+            ssh_config: None,
+            ssh_backend: None,
+            disable_control_master: false,
+            timeout: 30,
+            read_timeout: 120,
+            keep_remote_files: false,
+            spectre_cmd: "spectre".into(),
+            spectre_args: vec![],
+            spectre_max_workers: 8,
+            ssh_max_sessions: 10,
+            ssh_max_bulk_sessions: 2,
+            ssh_reconnect_max_attempts: 8,
+            ssh_reconnect_max_delay: 30,
+            ssh_keepalive_interval: 30,
+            ssh_keepalive_failures: 3,
+            transport_shutdown_grace: 10,
+            cadence_cshrc: None,
+            spectre_bin: None,
+            roles: crate::config::RemoteRoles::default(),
+            transport_daemon_socket: None,
+            transport_daemon_token: None,
+            allow_cross_user_daemon: false,
+        };
+        crate::context::CommandContext::new(cfg, None).expect("failed to build test CommandContext")
+    }
+
     /// Test that eval's progn wrapping is correct for various inputs.
     #[test]
     fn eval_progn_wrapping_single_expression() {
@@ -1865,7 +1905,8 @@ mod skill_command_tests {
         use crate::commands::skill;
         use crate::error::VirtuosoError;
 
-        let result = skill::eval(Some("   ".to_string()), false);
+        let ctx = test_ctx();
+        let result = skill::eval(&ctx, Some("   ".to_string()), false);
         assert!(matches!(result, Err(VirtuosoError::Config(_))));
     }
 
@@ -1874,7 +1915,8 @@ mod skill_command_tests {
         use crate::commands::skill;
         use crate::error::VirtuosoError;
 
-        let result = skill::eval(None, false);
+        let ctx = test_ctx();
+        let result = skill::eval(&ctx, None, false);
         assert!(matches!(result, Err(VirtuosoError::Config(_))));
     }
 
@@ -1883,7 +1925,8 @@ mod skill_command_tests {
         use crate::commands::skill;
         use crate::error::VirtuosoError;
 
-        let result = skill::eval(Some("code".to_string()), true);
+        let ctx = test_ctx();
+        let result = skill::eval(&ctx, Some("code".to_string()), true);
         assert!(matches!(result, Err(VirtuosoError::Config(_))));
     }
 
@@ -1926,7 +1969,8 @@ mod skill_command_tests {
         use crate::commands::skill;
         use crate::error::VirtuosoError;
 
-        let result = skill::eval(Some(String::new()), true);
+        let ctx = test_ctx();
+        let result = skill::eval(&ctx, Some(String::new()), true);
         assert!(matches!(result, Err(VirtuosoError::Config(_))));
     }
 }


### PR DESCRIPTION
## Summary

Migrates the remaining binary-side commands that were still calling `Config::from_env()` to instead accept `&CommandContext` and resolve through `ctx.config()`.

Command families on `fix/spectre-runner-ctx`:

- `spectre/process` (from_env → ctx)
- `skill`: exec, load, eval, find, info, sync_cache, show_cache
- `cell`: open, save, close, info
- `symbol`: inspect, generate
- `transaction`: begin, commit, rollback, diff, status
- `library`: list
- `window`: list, dismiss_dialog, x11 family, screenshot, action_x11, action_x11_batch

Also threads ctx through `rpc/dispatcher.rs` (which constructs a CommandContext from env for the RPC path) and input-validation tests (`src/tests.rs`).

## Why

All SKILL/config-producing paths should resolve through the same selection logic (`target::resolve`) so that `--target prod config check` would diagnose the prod target, and so `VB_TARGET` is kept consistent. Per-field code (`from_env()`) was reading env directly, bypassing the selection bridge and producing inconsistent snapshots.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test --lib config` + `cargo test --lib session`
- [x] `cargo test --bin vcli config` + `cargo test --bin vcli eval_input_validation`
- [ ] CI green on this branch
- [ ] Manual test: `vcli -v ...` with/without `--target` reflects the selected target