### PR TITLE
fix(context): skip host ownership check for loopback targets

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -103,7 +103,10 @@ impl CommandContext {
             return Ok(());
         }
         let target_host = self.config.remote_host.as_deref().unwrap_or("");
-        if !target_host.is_empty() && host != target_host {
+        // Loopback targets run on the same machine; session.host is the
+        // machine HOSTNAME (e.g. "dean") which never equals a loopback IP.
+        let is_loopback = matches!(target_host, "127.0.0.1" | "localhost" | "::1");
+        if !is_loopback && !target_host.is_empty() && host != target_host {
             return Err(VirtuosoError::Config(format!(
                 "{kind} '{id}' belongs to host '{host}' but target '{}' resolves to '{target_host}'; \
                  refusing to reuse the wrong {kind} (run `vcli session list`)",
@@ -195,6 +198,17 @@ mod tests {
         assert!(err
             .to_string()
             .contains("refusing to reuse the wrong session"));
+    }
+
+    #[serial]
+    #[test]
+    fn ownership_check_skips_host_for_loopback_target() {
+        // Loopback target: session.host is the machine HOSTNAME (e.g. "dean")
+        // which never equals "127.0.0.1". Host check must be skipped.
+        let ctx = CommandContext::new(cfg_with("127.0.0.1", 30001), Some("local".into())).unwrap();
+        assert!(ctx
+            .validate_session_ownership(&session_with("dean", 30001))
+            .is_ok());
     }
 
     #[serial]


### PR DESCRIPTION
## Problem

After #94/#95 introduced `validate_endpoint_ownership`, all local session connections were rejected:

```
config error: session 'dean-user1-37363' belongs to host 'dean' but target 'dean' resolves to '127.0.0.1'; refusing to reuse the wrong session
```

## Root cause

`session.host` records the machine `HOSTNAME` (e.g. `dean`) from `getShellEnvVar("HOSTNAME")` in `ramic_bridge.il`. For loopback targets (`127.0.0.1`/`localhost`/`::1`), `target.remote_host` is an IP while `session.host` is a hostname — they can never match, even though the session is on the same machine.

## Fix

Skip the host comparison when `target.remote_host` is a loopback address. Port check still applies when `port_explicit`.

## Test

Adds `ownership_check_skips_host_for_loopback_target` — loopback target with hostname-style session.host must pass validation.

- [x] cargo fmt --check
- [x] cargo test --lib context:: (14 passed)
- [x] cargo clippy --all-targets -- -D warnings
