### PR TITLE
docs(gui-debug): add layout automation via SKILL operations

### DIFF
--- a/.claude/skills/virtuoso-gui-debug/SKILL.md
+++ b/.claude/skills/virtuoso-gui-debug/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: virtuoso-gui-debug
 description: Replayable Virtuoso GUI debugging via strict JSON DSL with fake, live (vcli), and local (xdotool) executors — unified skill covering remote vcli-driven and direct local X11 GUI automation
 allowed-tools: Bash(python3 *) Read
@@ -813,6 +813,57 @@ Double-clicking inside a Layout Suite or Schematic Editor window triggers an int
 ### Concurrent execution note
 
 Virtuoso SKILL interpreter is single-threaded. Concurrent `vcli skill exec` calls arrive in parallel (5 connections within 56ms), but Virtuoso serializes SKILL evaluation. SSH pooling provides transport reuse, not SKILL parallelism.
+
+### Layout Automation via SKILL (verified 2026-09-12)
+
+Layout/schematic windows support a rich set of **safe, programmatic operations via `vcli skill exec`** that avoid the interactive-command trap. These are preferred over X11 clicks for layout debugging.
+
+**Safe SKILL queries (read-only, ~10ms each)**:
+
+```skill
+cv = geGetEditCellView()
+cv~>libName       ; library name
+cv~>cellName      ; cell name
+cv~>viewName      ; view name (layout/schematic)
+length(cv~>shapes) ; shape count
+length(cv~>insts)  ; instance count
+length(cv~>nets)   ; net count
+cv~>bBox           ; bounding box: ((LLx LLy) (URx URy))
+foreach(s cv~>shapes collect s~>layerName)  ; list all layers used
+foreach(i cv~>insts collect i~>instName)     ; list all instances
+length(setof(s cv~>shapes s~>layerName=="NW"))  ; shapes on NW layer
+```
+
+**Safe SKILL actions (programmatic selection)**:
+
+```skill
+hiSetCurrentCellView(cv)
+hiSelectObject(obj)      ; select a specific shape/inst by dbid
+hiClearSelected()        ; clear all selection
+hiSetDrawMode("Select")  ; set draw mode
+```
+
+**Safe X11 keyboard shortcuts on layout window** (verified, no interactive trap):
+
+| Key | Action | Notes |
+|-----|--------|-------|
+| `f` | Zoom fit (fill window) | Safe, immediate |
+| `shift+f` | Zoom all (entire cell) | Safe |
+| `z` | Zoom-in mode | Must press `Escape` immediately after to cancel; do not click |
+| scroll wheel | Pan/zoom | Safe |
+
+**Forbidden on layout/schematic windows**:
+- **Double-click** — triggers modal command, blocks CIW (see CRITICAL note above)
+- **Click-rel** — may trigger select/edit commands; prefer SKILL `hiSelectObject()`
+- Any drag operation without a known command context
+
+**Recommended layout debugging workflow**:
+1. Query structure via SKILL (`geGetEditCellView()~>shapes`, etc.)
+2. Screenshot via `import -window <wid>` for visual evidence
+3. Navigate via `f` / `shift+f` / scroll (keyboard only)
+4. Select objects via SKILL `hiSelectObject()` (not X11 click)
+5. Measure via SKILL bBox / coordinates
+6. Use SKILL for all modifications; use X11 only for screenshot and safe navigation
 
 ## Testing
 

--- a/.claude/skills/virtuoso-gui-debug/SKILL.md
+++ b/.claude/skills/virtuoso-gui-debug/SKILL.md
@@ -865,6 +865,25 @@ hiSetDrawMode("Select")  ; set draw mode
 5. Measure via SKILL bBox / coordinates
 6. Use SKILL for all modifications; use X11 only for screenshot and safe navigation
 
+
+## Future Directions
+
+### Zero-screenshot perception (aspirational)
+
+Current GUI debugging relies heavily on screenshots to verify window state. This is slow (network round-trip + image analysis) and fragile (resolution/theme changes).
+
+**Goal**: Eliminate screenshots by reading UI state through structured queries:
+- Window state via X11 properties (WM_NAME, WM_CLASS, geometry, visibility)
+- Form state via SKILL (`formName->fieldName->value`) — already works for verified forms
+- Widget introspection via `hiGetCurrentForm()` and field traversal
+- Screenshot as fallback only, not default verification
+
+**Why**: Structured JSON query returns in ~10ms; screenshot requires render + capture + download + visual analysis (100x slower).
+
+**Steps**:
+1. Build `vcli window introspect` returning window tree + form fields as JSON
+2. Use form field values as verification predicates in scenario DSL
+3. Reserve screenshots for visual regression only
 ## Testing
 
 ```bash


### PR DESCRIPTION
## Summary

Documents safe, programmatic layout debugging operations using SKILL commands, discovered during v1.3.5 testing on FT0001A_SH CMOP layout.

## Verified operations

**SKILL queries** (~10ms each, read-only):
- Cellview metadata (libName, cellName, viewName)
- Shape/instance/net counts
- Bounding box coordinates
- Layer-based shape search
- Instance enumeration

**Programmatic actions**:
- hiSelectObject / hiClearSelected (no X11 click needed)
- hiSetDrawMode

**Safe X11 keyboard**:
- f = zoom fit, shift+f = zoom all, scroll = pan
- z = zoom mode (always follow with Escape to cancel)

## Forbidden (re-discovered)

- Double-click on layout/schematic triggers modal commands that block CIW
- click-rel on layout may trigger interactive commands
- Use SKILL instead of X11 click for all selection operations