### PR TITLE
fix(whitelist): avoid blocking VDD with the dd command pattern

### DIFF
--- a/src/client/whitelist.rs
+++ b/src/client/whitelist.rs
@@ -16,6 +16,11 @@ pub enum WhitelistEntry {
     /// Case-insensitive word-boundary match on a function name (e.g. `\bsystem\(`).
     /// Prevents `hiSystem` matching as `system(`.
     FunctionName(&'static str),
+    /// Case-insensitive match anchored at a word boundary (e.g. `\bdd `).
+    /// For shell-command names that are also substrings of ordinary identifiers:
+    /// plain `Substring("dd ")` blocks `error("terminal VDD has no pin")`, and
+    /// `VDD` is the most common net name in analog design.
+    WordBoundary(&'static str),
 }
 
 impl WhitelistEntry {
@@ -42,6 +47,12 @@ impl WhitelistEntry {
             }
             Self::FunctionName(name) => {
                 let pattern = format!(r"(?i)\b{name}\(");
+                regex::Regex::new(&pattern)
+                    .map(|r| r.is_match(code))
+                    .unwrap_or(false)
+            }
+            Self::WordBoundary(needle) => {
+                let pattern = format!(r"(?i)\b{}", regex::escape(needle));
                 regex::Regex::new(&pattern)
                     .map(|r| r.is_match(code))
                     .unwrap_or(false)
@@ -78,8 +89,9 @@ fn default_dangerous() -> Vec<WhitelistEntry> {
         WhitelistEntry::Substring("|sh"),
         WhitelistEntry::Substring("; sh"),
         WhitelistEntry::Substring(";sh"),
-        // Raw disk I/O
-        WhitelistEntry::Substring("dd "),
+        // Raw disk I/O. `dd` needs a word boundary: it is a substring of `VDD`,
+        // and the raw-disk form `dd if=/dev/...` is caught by `/dev/` anyway.
+        WhitelistEntry::WordBoundary("dd "),
         WhitelistEntry::Substring("/dev/"),
         WhitelistEntry::Substring("/proc/"),
         // Process / IPC injection
@@ -137,6 +149,7 @@ impl EvalstringWhitelist {
                         WhitelistEntry::Substring(s) => *s,
                         WhitelistEntry::SubstringWithAllowlist { pattern, .. } => *pattern,
                         WhitelistEntry::FunctionName(n) => *n,
+                        WhitelistEntry::WordBoundary(s) => *s,
                     }
                 ));
             }
@@ -240,5 +253,19 @@ mod tests {
     fn block_dev_proc() {
         assert!(wl().check("dd if=/dev/zero of=/tmp/x").is_some());
         assert!(wl().check("/proc/self/cmdline").is_some());
+    }
+
+    #[test]
+    fn dd_needs_a_word_boundary() {
+        // `dd` as a bare command is still blocked...
+        assert!(wl().check("system(\"dd if=/x of=/y\")").is_some());
+        // ...but `VDD` is the most common net name in analog design, and it
+        // used to trip the raw-disk pattern from inside a quoted message.
+        assert!(wl()
+            .check("error(\"label_term: terminal VDD has no pin\")")
+            .is_none());
+        assert!(wl()
+            .check("sprintf(nil \"%s stub net=%s\" \"M1\" \"VDD \")")
+            .is_none());
     }
 }


### PR DESCRIPTION
## What

`WhitelistEntry::Substring("dd ")` — the entry guarding against raw-disk `dd`
writes — is a case-insensitive `contains` test, and **`VDD ` contains `dd `**.
So the dangerous-pattern scanner rejects any SKILL whose text mentions the most
common net name in analog design, even inside a quoted string.

```
$ vcli skill exec 'printf("VDD ok\n")'
error: SKILL rejected: matches dangerous pattern "dd " (raw disk write)
```

This is a false positive in a security control, on the tool's own primary
domain. It was hit for real: `schematic.label_term` generates SKILL containing
the diagnostic string `error("... terminal VDD has no pin ...")`, and the whole
RPC was refused as an attempted raw disk write. Any generated SKILL naming a
supply net is affected.

## How

Add a `WhitelistEntry::WordBoundary(&'static str)` variant that anchors the
needle at a regex word boundary, and move `dd ` onto it:

```rust
/// Case-insensitive match anchored at a word boundary (e.g. `\bdd `).
/// For shell-command names that are also substrings of ordinary identifiers:
/// plain `Substring("dd ")` blocks `error("terminal VDD has no pin")`, and
/// `VDD` is the most common net name in analog design.
WordBoundary(&'static str),
```

matching via `format!(r"(?i)\b{}", regex::escape(needle))`. `\b` does not match
between `V` and `d`, so `VDD ` no longer fires while `dd if=...` still does.

## Security is not weakened

Two independent reasons:

1. **`dd` as an actual command still matches.** `system("dd if=/x of=/y")` is
   blocked — there is a test asserting exactly this, alongside the new one
   asserting `VDD ` passes.
2. **The raw-disk form is caught twice over.** The existing
   `Substring("/dev/")` entry independently catches `dd if=/dev/zero of=...`,
   so even a total miss on this entry is still covered.

The change is additive: no existing entry changes semantics, and `Substring`
remains available for needles that genuinely want substring matching.

## Tests

New test `dd_needs_a_word_boundary` covers both directions — the command form
stays blocked, the `VDD` form is allowed. Existing whitelist tests unchanged.

| Gate | Result |
|---|---|
| `cargo test --no-fail-fast` | **3307 passed**, 6 ignored, 1 failed — see note<br>(`main @ 7d7e343` baseline is 3304; +3 = the new test × 3 targets) |
| `cargo clippy --all-targets` | clean, no new warnings |
| `cargo build --release` | ok |
| Conflicts with `main` | none — cherry-picks onto `7d7e343` cleanly |
| Files touched | `src/client/whitelist.rs` only (+29 −2) |

> **Note on the 1 failure — it is not from this branch.**
> `daemon_user_guard::ramic_bridge_version_stamp_matches_cargo_toml` fails on
> **pristine `main @ 7d7e343`** as well; reproduced on a clean detached checkout
> before building this branch. `resources/ramic_bridge.il` line 1 still reads
> `; RB_VERSION: 1.3.4` while `Cargo.toml` is at `1.3.5` — `0743fb1 chore: bump
> version to 1.3.5` bumped the crate but not the stamp (the v1.3.4 release commit
> `3461706` did both, per its own message "bump version, sync ramic_bridge
> stamp"). This branch touches neither file. A separate local issue report is prepared but has not been published; it is a
> one-line fix and yours to make, since version numbers are maintainer territory.

## Provenance

Developed against IC23.1 while driving Virtuoso headlessly for analog schematic
capture. Branched from `main @ 7d7e343` (fetched 2026-09-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Publication validation scope

The branch-specific gate counts above are from the preparation runs. A fresh run on the combined series tip `3dd8e74`, which includes an equivalent patch for this fix, reports **4020 passed, 1 version-stamp failure**; `cargo clippy --offline -- -D warnings` passes. **`cargo fmt --check` fails on that combined series**. This fresh run is not a separate rerun of this individual branch, and formatting status for this branch was not independently rechecked.
