### PR TITLE
fix(capability): route symbol and sim methods through their capability gates

### DIFF
--- a/src/capability/mod.rs
+++ b/src/capability/mod.rs
@@ -106,6 +106,17 @@ impl CapabilitySet {
         let domain = method.split('.').next().unwrap_or("");
         match domain {
             "schematic" => self.permits(Capability::Schematic),
+            // Symbol generation/inspection is a schematic-editing operation:
+            // it reads a schematic and writes the cell's symbol view. Without
+            // this arm `symbol.*` fell through to `_ => false` and was denied
+            // to *every* caller — including Admin, because the fallthrough
+            // never reaches `permits()`, which is where the Admin bypass lives.
+            // That made hierarchical design impossible over typed RPC.
+            "symbol" => self.permits(Capability::Schematic),
+            // Same fallthrough bug for `sim.*`. `Capability::Simulation` was
+            // declared and parseable from a token but no method domain ever
+            // mapped to it, so it granted nothing.
+            "sim" => self.permits(Capability::Simulation),
             "maestro" => self.permits(Capability::Maestro),
             "window" => self.permits(Capability::Window),
             "cell" => self.permits(Capability::Cell),
@@ -250,6 +261,36 @@ mod tests {
         assert!(caps.permits_method("maestro.open_session"));
         assert!(!caps.permits_method("window.list"));
         assert!(!caps.permits_method("cell.open"));
+    }
+
+    #[test]
+    fn permits_symbol_methods_with_schematic_capability() {
+        // Regression: `symbol.*` had no match arm and fell through to
+        // `_ => false`, which denied it to everyone — Admin included, since
+        // the Admin bypass lives in `permits()` and the fallthrough skipped it.
+        let caps = CapabilitySet(HashSet::from([Capability::Schematic]));
+        assert!(caps.permits_method("symbol.generate"));
+        assert!(caps.permits_method("symbol.inspect"));
+
+        let admin = CapabilitySet(HashSet::from([Capability::Admin]));
+        assert!(admin.permits_method("symbol.generate"));
+
+        let no_sch = CapabilitySet(HashSet::from([Capability::Cell]));
+        assert!(!no_sch.permits_method("symbol.generate"));
+    }
+
+    #[test]
+    fn permits_sim_methods_with_simulation_capability() {
+        // Regression: `Capability::Simulation` was declared and parseable but
+        // no method domain mapped to it, so holding it granted nothing.
+        let caps = CapabilitySet(HashSet::from([Capability::Simulation]));
+        assert!(caps.permits_method("sim.check_license"));
+
+        let admin = CapabilitySet(HashSet::from([Capability::Admin]));
+        assert!(admin.permits_method("sim.check_license"));
+
+        let other = CapabilitySet(HashSet::from([Capability::Schematic]));
+        assert!(!other.permits_method("sim.check_license"));
     }
 
     #[test]


### PR DESCRIPTION
## What

`CapabilitySet::permits_method` dispatches on the method's domain prefix.
`schematic`, `maestro`, `window`, `cell` and `tx` all have match arms;
**`symbol` and `sim` have none**, so both fall through to `_ => false`.

That is not "denied unless you hold the capability" — the Admin bypass lives
*inside* `permits()`, and the fallthrough returns before ever calling it. So
`symbol.*` and `sim.*` are denied to **every** caller, Admin included. And
`Capability::Simulation` is declared, documented and parseable from a token while
mapping to no method domain at all, so holding it grants nothing.

## Why it matters

The `symbol` half is a hard blocker rather than a papercut. `symbol.generate` is
the only way to turn a schematic into a symbol, and a symbol is the prerequisite
for instantiating one cell inside another — so with this arm missing,
**hierarchical design is not achievable over typed RPC at all.** You can build a
DUT schematic, and you can build a testbench, but you cannot put the first inside
the second.

## How

Two match arms, onto capabilities that already exist — no new capability is
introduced:

```rust
"schematic" => self.permits(Capability::Schematic),
"symbol"    => self.permits(Capability::Schematic),
"sim"       => self.permits(Capability::Simulation),
```

`symbol.*` reads a schematic view and writes the symbol view of the same cell,
so it is a schematic-editing operation by nature and `Capability::Schematic` is
its natural owner. `sim.*` maps onto the `Simulation` capability that was already
there waiting for it.

## Tests

Two new regression tests, each covering three directions:

- `permits_symbol_methods_with_schematic_capability` — granted with `Schematic`,
  granted with `Admin`, **still denied** with an unrelated capability (`Cell`).
- `permits_sim_methods_with_simulation_capability` — same shape for `Simulation`.

The "still denied" assertions are the point: this makes the two domains
capability-gated, not ungated.

## Live validation

On IC23.1, under the **default non-Admin** capability set, `symbol.generate`
produced `DESIGN_LIB/amp/symbol`, which a testbench in a different library
then instantiated successfully — the hierarchy that was previously impossible.

| Gate | Result |
|---|---|
| `cargo test --no-fail-fast` | **3310 passed**, 6 ignored, 1 failed — see note<br>(`main @ 7d7e343` baseline is 3304; +6 = the 2 new tests × 3 targets) |
| `cargo clippy --all-targets` | clean, no new warnings |
| `cargo build --release` | ok |
| Conflicts with `main` | none — cherry-picks onto `7d7e343` cleanly |
| Files touched | `src/capability/mod.rs` only (+41, no deletions) |

> **Note on the 1 failure — it is not from this branch.**
> `daemon_user_guard::ramic_bridge_version_stamp_matches_cargo_toml` fails on
> **pristine `main @ 7d7e343`** as well; reproduced on a clean detached checkout.
> `resources/ramic_bridge.il` line 1 still reads `; RB_VERSION: 1.3.4` while
> `Cargo.toml` is at `1.3.5` — `0743fb1` bumped the crate but not the stamp.
> This branch touches neither file. A separate local issue report is prepared but has not been published.

## Provenance

Found while driving IC23.1 headlessly for analog schematic capture, at the point
where a DUT needed to become a symbol. Branched from `main @ 7d7e343`
(fetched 2026-09-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Publication validation scope

The branch-specific gate counts above are from the preparation runs. A fresh run on the combined series tip `3dd8e74`, which includes an equivalent patch for this fix, reports **4020 passed, 1 version-stamp failure**; `cargo clippy --offline -- -D warnings` passes. **`cargo fmt --check` fails on that combined series**. This fresh run is not a separate rerun of this individual branch, and formatting status for this branch was not independently rechecked.
