### PR TITLE
fix(cell): use the IC23 open API and guard missing cellviews against modal freezes

### DIFF
--- a/src/client/bridge.rs
+++ b/src/client/bridge.rs
@@ -505,13 +505,7 @@ impl VirtuosoClient {
         view: &str,
         mode: &str,
     ) -> Result<VirtuosoResult> {
-        let lib = escape_skill_string(lib);
-        let cell = escape_skill_string(cell);
-        let view = escape_skill_string(view);
-        let mode = escape_skill_string(mode);
-        let skill = format!(
-            r#"geOpenCellView(?libName "{lib}" ?cellName "{cell}" ?viewName "{view}" ?mode "{mode}")"#
-        );
+        let skill = build_open_cell_view_skill(lib, cell, view, mode);
         // Use unchecked — capability check done at RPC dispatch level
         self.execute_skill_unchecked(&skill, None)
     }
@@ -987,6 +981,47 @@ fn build_fetch_skill(list_expr: &str, fields: &[&str]) -> String {
     format!("mapcar(lambda((o) list({fields_str})) {list_expr})")
 }
 
+/// Build the SKILL for `cell.open`.
+///
+/// IC23 opens a GUI editor window via `deOpenCellView`; `geOpenCellView` is
+/// undefined in IC23 (eval: undefined function). `deOpenCellView` takes viewType
+/// as a positional arg, so map the common view names to their DFII viewType
+/// (these names are Cadence-standard, version/PDK-independent). Unknown views
+/// fall back to the view name itself, matching the maestro convention
+/// (view "maestro" -> viewType "maestro").
+///
+/// Existence guard (CRITICAL): calling `deOpenCellView` on a cell that does NOT
+/// exist pops a modal "New File" dialog on Virtuoso's main thread, which blocks
+/// the SKILL bridge indefinitely — every subsequent call times out until a human
+/// dismisses the dialog, and the process that would dismiss it is the blocked
+/// one. So never let `deOpenCellView` hit a missing cell:
+///
+///   * probe existence with `ddGetObj` (pure metadata query, raises no GUI);
+///   * if missing and the mode is writable (anything but `"r"`), create the
+///     cellview headlessly with `dbOpenCellViewByType` + `dbSave` + `dbClose`
+///     (create-if-absent, matching mode `"a"` semantics) — no dialog;
+///   * if missing and read-only, error out cleanly instead of freezing.
+///
+/// By the time `deOpenCellView` runs the cell is guaranteed to exist, so the
+/// modal path is unreachable by construction rather than merely unlikely.
+fn build_open_cell_view_skill(lib: &str, cell: &str, view: &str, mode: &str) -> String {
+    let view_type = match view {
+        "layout" => "maskLayout",
+        "symbol" => "schematicSymbol",
+        other => other,
+    };
+    let lib = escape_skill_string(lib);
+    let cell = escape_skill_string(cell);
+    let view_type = escape_skill_string(view_type);
+    let view = escape_skill_string(view);
+    let mode = escape_skill_string(mode);
+    // deOpenCellView(libName cellName viewName viewType winSpec mode);
+    // winSpec = nil -> open in a new window.
+    format!(
+        r#"let((exists writable) writable = !(strcmp("{mode}" "r")==0) exists = ddGetObj("{lib}" "{cell}" "{view}") when(!exists if(writable then let((ncv) ncv = dbOpenCellViewByType("{lib}" "{cell}" "{view}" "{view_type}" "a") when(ncv dbSave(ncv) dbClose(ncv))) else error("cell.open: {lib}/{cell}/{view} not found and mode is read-only — create it first"))) deOpenCellView("{lib}" "{cell}" "{view}" "{view_type}" nil "{mode}"))"#
+    )
+}
+
 /// Read a file from the remote filesystem via SKILL's infile/gets channel.
 ///
 /// This is the CORRECT way to read file contents in Virtuoso SKILL — NOT via
@@ -1130,6 +1165,51 @@ mod tests {
     #[test]
     fn escape_backslash() {
         assert_eq!(escape_skill_string("a\\b"), "a\\\\b");
+    }
+
+    #[test]
+    fn open_cell_view_probes_before_opening() {
+        // The whole point of the guard: ddGetObj (metadata, no GUI) must be
+        // evaluated before deOpenCellView, which pops a modal dialog — and
+        // hangs the bridge — if the cell is missing.
+        let s = build_open_cell_view_skill("LIB", "CELL", "schematic", "a");
+        let probe = s.find("ddGetObj(").expect("guard must probe with ddGetObj");
+        let open = s.find("deOpenCellView(").expect("must open via deOpenCellView");
+        assert!(probe < open, "ddGetObj must precede deOpenCellView: {s}");
+        // geOpenCellView is undefined on IC23 — it must not reappear.
+        assert!(!s.contains("geOpenCellView"), "{s}");
+    }
+
+    #[test]
+    fn open_cell_view_read_only_errors_instead_of_creating() {
+        // Missing + read-only must take the error branch, never the create
+        // branch: creating a cell the caller asked to only read is a silent
+        // write to someone else's library.
+        let s = build_open_cell_view_skill("LIB", "CELL", "schematic", "r");
+        assert!(s.contains(r#"strcmp("r" "r")"#), "{s}");
+        assert!(s.contains("read-only"), "{s}");
+        assert!(s.contains("dbOpenCellViewByType"), "{s}");
+    }
+
+    #[test]
+    fn open_cell_view_maps_view_to_dfii_view_type() {
+        // deOpenCellView takes viewType positionally; these are the
+        // Cadence-standard names.
+        let layout = build_open_cell_view_skill("L", "C", "layout", "a");
+        assert!(layout.contains(r#""layout" "maskLayout""#), "{layout}");
+
+        let symbol = build_open_cell_view_skill("L", "C", "symbol", "a");
+        assert!(symbol.contains(r#""symbol" "schematicSymbol""#), "{symbol}");
+
+        // Unknown views fall back to the view name, per the maestro convention.
+        let maestro = build_open_cell_view_skill("L", "C", "maestro", "a");
+        assert!(maestro.contains(r#""maestro" "maestro""#), "{maestro}");
+    }
+
+    #[test]
+    fn open_cell_view_escapes_its_arguments() {
+        let s = build_open_cell_view_skill(r#"L"IB"#, "CELL", "schematic", "a");
+        assert!(s.contains(r#"L\"IB"#), "{s}");
     }
 
     #[test]


### PR DESCRIPTION
## What

Two defects on the same code path in `VirtuosoClient::open_cell_view`, fixed
together because the second is unreachable — and its fix unappliable — without
the first.

**1. `geOpenCellView` is undefined on IC23.1.** `cell.open` emits

```skill
geOpenCellView(?libName "..." ?cellName "..." ?viewName "..." ?mode "...")
```

which returns `eval: undefined function - geOpenCellView` on IC23. The IC23
entry point is `deOpenCellView`, which takes `viewType` **positionally** rather
than as keyword args:

```skill
deOpenCellView(libName cellName viewName viewType winSpec mode)
```

**2. Opening a cell that does not exist freezes the entire bridge.**
`deOpenCellView` on a non-existent cell pops a modal *New File* dialog on
Virtuoso's main thread — the same thread the SKILL bridge runs on. The call never
returns and **every subsequent RPC times out** until a human dismisses the dialog
by hand. It cannot be cleared programmatically: the process that would send the
dismissal is the blocked one. On a shared machine that means walking to the
console. A typo in a cell name is enough to trigger it.

## How

Probe for existence with a pure-metadata call that cannot raise a dialog, before
the name ever reaches the GUI layer:

- `ddGetObj(lib cell view)` — metadata only, no GUI;
- missing **and the mode is writable** → create it headlessly with
  `dbOpenCellViewByType(... "a")` + `dbSave` + `dbClose`. This is the same
  create-if-absent outcome the dialog was offering, and it matches mode `"a"`
  semantics — then open it;
- missing **and read-only** → return a clean error instead of freezing.

By the time `deOpenCellView` runs, the cell is guaranteed to exist, so the modal
path is unreachable **by construction** rather than merely unlikely.

The `viewType` positional argument needed by `deOpenCellView` is derived from the
view name using Cadence-standard mappings (`layout` → `maskLayout`,
`symbol` → `schematicSymbol`), falling back to the view name itself for anything
else — which is already the convention elsewhere in this codebase
(view `maestro` → viewType `maestro`). These names are version- and
PDK-independent.

## Why the two halves are one PR

The guard patches the `deOpenCellView` call site. A tree still calling
`geOpenCellView` has no such line, so the guard cannot be applied to it — this
was tried and confirmed to conflict. The change is only self-consistent as a
unit: move to the call that works on IC23, and guard it in the same commit.

## Live validation

On IC23.1: missing + writable creates and opens; missing + read-only errors
cleanly; the bridge stays responsive in both cases (verified by issuing further
RPCs immediately after each).

## Tests

The SKILL-building half is extracted into a free function
`build_open_cell_view_skill(lib, cell, view, mode) -> String`, following the
existing `build_fetch_skill` pattern in the same file, so the generated
expression can be asserted on directly. Four new tests:

- `open_cell_view_probes_before_opening` — asserts `ddGetObj` appears **before**
  `deOpenCellView` in the emitted SKILL, and that `geOpenCellView` does not
  reappear. This is the invariant the whole fix rests on, so it is worth pinning.
- `open_cell_view_read_only_errors_instead_of_creating` — missing + `"r"` must
  take the error branch. Creating a cell the caller asked only to *read* would be
  a silent write into someone else's library.
- `open_cell_view_maps_view_to_dfii_view_type` — `layout`→`maskLayout`,
  `symbol`→`schematicSymbol`, and the fall-through case (`maestro`→`maestro`).
- `open_cell_view_escapes_its_arguments` — arguments still pass through
  `escape_skill_string`.

| Gate | Result |
|---|---|
| `cargo test --no-fail-fast` | **3316 passed**, 6 ignored, 1 failed — see note<br>(`main @ 7d7e343` baseline is 3304; +12 = the 4 new tests × 3 targets) |
| `cargo clippy --all-targets` | clean, no new warnings |
| `cargo build --release` | ok |
| Conflicts with `main` | none — applies onto `7d7e343` cleanly |
| Files touched | `src/client/bridge.rs` only (+87 −7) |

> **Note on the 1 failure — it is not from this branch.**
> `daemon_user_guard::ramic_bridge_version_stamp_matches_cargo_toml` fails on
> **pristine `main @ 7d7e343`** as well; reproduced on a clean detached checkout.
> `resources/ramic_bridge.il` line 1 still reads `; RB_VERSION: 1.3.4` while
> `Cargo.toml` is at `1.3.5` — `0743fb1` bumped the crate but not the stamp.
> This branch touches neither file. A separate local issue report is prepared but has not been published.

## Provenance

Found while driving IC23.1 headlessly for analog schematic capture — the freeze
was hit for real and did require dismissing the dialog at the console. Branched
from `main @ 7d7e343` (fetched 2026-09-12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Publication validation scope

The branch-specific gate counts above are from the preparation runs. A fresh run on the combined series tip `3dd8e74`, which includes an equivalent patch for this fix, reports **4020 passed, 1 version-stamp failure**; `cargo clippy --offline -- -D warnings` passes. **`cargo fmt --check` fails on that combined series**. This fresh run is not a separate rerun of this individual branch, and formatting status for this branch was not independently rechecked.
